### PR TITLE
Fix config errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix `WINDOWS.frame_image` capture with multiple windows capturing pixels from the wrong window.
 * Fix `WINDOWS.frame_image` var not updating on load or error.
 * Fix cursor not resetting on widget deinit.
+* Add missing `zng::app::test_log`.
 
 # 0.3.3
 

--- a/crates/zng-app/src/lib.rs
+++ b/crates/zng-app/src/lib.rs
@@ -743,6 +743,7 @@ impl HeadlessApp {
                 Err(t) => task = t,
             }
         }
+        task.cancel();
 
         None
     }

--- a/crates/zng/src/app.rs
+++ b/crates/zng/src/app.rs
@@ -400,6 +400,10 @@ pub use zng_app::{
     print_tracing, AppControlFlow, AppEventObserver, AppExtended, AppExtension, AppExtensionBoxed, AppExtensionInfo, DInstant, Deadline,
     ExitRequestedArgs, HeadlessApp, InstantMode, EXIT_CMD, EXIT_REQUESTED_EVENT, INSTANT,
 };
+
+#[cfg(feature = "test_util")]
+pub use zng_app::test_log;
+
 pub use zng_app_context::{
     app_local, context_local, AppId, AppLocal, AppScope, CaptureFilter, ContextLocal, ContextValueSet, FullLocalContext, LocalContext,
     MappedRwLockReadGuardOwned, MappedRwLockWriteGuardOwned, ReadOnlyRwLock, RunOnDrop, RwLockReadGuardOwned, RwLockWriteGuardOwned,

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -38,6 +38,7 @@ fn test_config<C: AnyConfig>(file: &str, source: impl Fn(&Path) -> C) {
 
     fn run<C: AnyConfig>(source: impl Fn() -> C, test_read: bool) {
         let mut app = APP.defaults().run_headless(false);
+        zng::app::test_log();
 
         CONFIG.load(source());
         app.run_task(async {
@@ -212,6 +213,7 @@ fn concurrent_read_write() {
         // setup
         rmv_file_assert(&file);
         let mut app = APP.defaults().run_headless(false);
+        zng::app::test_log();
         CONFIG.load(JsonConfig::sync(&file));
         CONFIG.get("key", || Txt::from_static("default/custom")).set("custom").unwrap();
 
@@ -231,6 +233,7 @@ fn concurrent_read_write() {
         .map(|_| {
             std::thread::spawn(clmv!(file, || {
                 let mut app = APP.defaults().run_headless(false);
+                zng::app::test_log();
                 CONFIG.load(JsonConfig::sync(file));
 
                 app.run_task(async {
@@ -267,6 +270,7 @@ fn fallback_swap() {
         rmv_file_assert(&fallback_cfg);
 
         let mut app = APP.defaults().run_headless(false);
+        zng::app::test_log();
         CONFIG.load(JsonConfig::sync(&fallback_cfg));
         CONFIG.get("key", || Txt::from_static("default/fallback")).set("fallback").unwrap();
 
@@ -295,6 +299,7 @@ fn fallback_swap() {
 
     // test
     let mut app = APP.defaults().run_headless(false);
+    zng::app::test_log();
 
     CONFIG.load(FallbackConfig::new(JsonConfig::sync(&main_cfg), JsonConfig::sync(fallback_cfg)));
     app.run_task(async {
@@ -337,6 +342,7 @@ fn fallback_reset() {
         rmv_file_assert(&fallback_cfg);
 
         let mut app = APP.defaults().run_headless(false);
+        zng::app::test_log();
         CONFIG.load(JsonConfig::sync(&fallback_cfg));
         CONFIG.get("key", || Txt::from_static("default/fallback")).set("fallback").unwrap();
 
@@ -365,6 +371,7 @@ fn fallback_reset() {
 
     // test
     let mut app = APP.defaults().run_headless(false);
+    zng::app::test_log();
 
     CONFIG.load(FallbackConfig::new(JsonConfig::sync(&main_cfg), JsonConfig::sync(&fallback_cfg)));
     app.run_task(async {
@@ -409,6 +416,7 @@ fn fallback_reset_entry() {
         rmv_file_assert(&fallback_cfg);
 
         let mut app = APP.defaults().run_headless(false);
+        zng::app::test_log();
         CONFIG.load(JsonConfig::sync(&fallback_cfg));
         CONFIG.get("key", || Txt::from_static("default/fallback")).set("fallback").unwrap();
 
@@ -437,6 +445,7 @@ fn fallback_reset_entry() {
 
     // test
     let mut app = APP.defaults().run_headless(false);
+    zng::app::test_log();
 
     let mut cfg = FallbackConfig::new(JsonConfig::sync(&main_cfg), JsonConfig::sync(&fallback_cfg));
     // wait_idle


### PR DESCRIPTION
Fixes #112.

First, the errors are only logged, enabled `test_log` so now config tests fail for log errors.

The issue was caused by conversions of number types between TomlValue and YamlValue. Serde JSON does not implicit cast
floats to integers, and we converted to float first. Changing the order of conversion fixed the issue.