### PR TITLE
Remove Windows docs workarounds

### DIFF
--- a/crates/zng/src/button.rs
+++ b/crates/zng/src/button.rs
@@ -119,8 +119,3 @@
 //! See [`zng_wgt_button`] for the full widget API.
 
 pub use zng_wgt_button::{base_colors, style_fn, Button, DefaultStyle, LinkStyle, BUTTON};
-
-/// Windows docs workaround, see ([#25879](https://github.com/rust-lang/rust/issues/25879)).
-///
-#[cfg(all(windows, doc))]
-pub use zng_wgt_button::BUTTON as BUTTON_;

--- a/crates/zng/src/popup.rs
+++ b/crates/zng/src/popup.rs
@@ -44,8 +44,3 @@ pub use zng_wgt_layer::popup::{
     on_pre_popup_close_requested, style_fn, ContextCapture, DefaultStyle, Popup, PopupCloseMode, PopupCloseRequestedArgs, PopupState,
     POPUP, POPUP_CLOSE_CMD, POPUP_CLOSE_REQUESTED_EVENT,
 };
-
-/// Windows docs workaround, see ([#25879](https://github.com/rust-lang/rust/issues/25879)).
-///
-#[cfg(all(windows, doc))]
-pub use zng_wgt_layer::popup::POPUP as POPUP_;

--- a/crates/zng/src/scroll.rs
+++ b/crates/zng/src/scroll.rs
@@ -66,11 +66,6 @@ pub use zng_wgt_scroll::{
     ScrollUnitsMix, Scrollbar, ScrollbarFnMix, SmoothScrolling, Thumb, WidgetInfoExt, SCROLL,
 };
 
-/// Windows docs workaround, see ([#25879](https://github.com/rust-lang/rust/issues/25879)).
-///
-#[cfg(all(windows, doc))]
-pub use zng_wgt_scroll::SCROLL as SCROLL_;
-
 /// Scrollbar thumb widget.
 pub mod thumb {
     pub use zng_wgt_scroll::thumb::{cross_length, offset, viewport_ratio, Thumb};
@@ -79,11 +74,6 @@ pub mod thumb {
 /// Scroll widget.
 pub mod scrollbar {
     pub use zng_wgt_scroll::scrollbar::{orientation, Orientation, Scrollbar, SCROLLBAR};
-
-    /// Windows docs workaround, see ([#25879](https://github.com/rust-lang/rust/issues/25879)).
-    ///
-    #[cfg(all(windows, doc))]
-    pub use zng_wgt_scroll::scrollbar::SCROLLBAR as SCROLLBAR_;
 }
 
 /// Scroll commands.

--- a/crates/zng/src/text.rs
+++ b/crates/zng/src/text.rs
@@ -81,8 +81,3 @@ pub use zng_wgt_text::{
     CaretStatus, ChangeStopArgs, ChangeStopCause, Em, InteractiveCaretMode, LangMix, LinesWrapCount, ParagraphMix, SelectionToolbarArgs,
     Strong, Text, TextOverflow, TxtParseValue, UnderlinePosition, UnderlineSkip, FONT_COLOR_VAR,
 };
-
-/// Windows docs workaround, see ([#25879](https://github.com/rust-lang/rust/issues/25879)).
-///
-#[cfg(all(windows, doc))]
-pub use zng_wgt_text::node::TEXT as TEXT_;

--- a/crates/zng/src/window.rs
+++ b/crates/zng/src/window.rs
@@ -99,11 +99,6 @@
 
 pub use zng_app::window::{MonitorId, StaticMonitorId, StaticWindowId, WindowId, WindowMode, WINDOW};
 
-/// Windows docs workaround, see ([#25879](https://github.com/rust-lang/rust/issues/25879)).
-///
-#[cfg(all(windows, doc))]
-pub use zng_app::window::WINDOW as WINDOW_;
-
 pub use zng_ext_window::{
     AppRunWindowExt, AutoSize, CloseWindowResult, FocusIndicator, FrameCaptureMode, FrameImageReadyArgs, HeadlessAppWindowExt,
     HeadlessMonitor, ImeArgs, MonitorInfo, MonitorQuery, MonitorsChangedArgs, ParallelWin, RenderMode, StartPosition, VideoMode,


### PR DESCRIPTION
Remove workarounds for #76.

If rustdoc fixes this issue it is fixed, on our side now that the docs are online (and generated in Ubuntu) we don't need to generate docs in Windows anymore.