### PR TITLE
Fix auto scroll scrolling to the same focused widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,10 @@ fn version_0_5() -> impl UiNode {
         - Removed `FocusChangedCause::is_prev_request`.
 * Add `FocusChangedCause::request_target` helper method.
 * Add `WidgetPath::parent_id` helper method.
-* Fix auto scroll-to-focused not working when the focused child does not subscribe to focus change events.
-* Fix auto scroll-to-focused scrolling when large widget is already visible.
+* Fix auto scroll to focused issues:
+    - When the focused child does not subscribe to focus change events.
+    - Scrolling when large widget is already visible.
+    - Scrolling again to same widget when focus change event did not represent a widget change.
 * Add `WidgetInfo::spatial_bounds`.
 * Fix directional navigation cycling only inside viewport now full spatial bounds of scopes.
 * Add better conversions for `CommandScope`. You can now scope on named widgets directly, `FOO_CMD.scoped("bar-wgt")`.

--- a/crates/zng-wgt-scroll/src/node.rs
+++ b/crates/zng-wgt-scroll/src/node.rs
@@ -649,7 +649,12 @@ pub fn scroll_to_node(child: impl UiNode) -> impl UiNode {
             let self_id = WIDGET.id();
             if let Some(args) = FOCUS_CHANGED_EVENT.on(update) {
                 if let Some(path) = &args.new_focus {
-                    if (scroll_to.is_none() || !scroll_to_from_cmd) && path.contains(self_id) && path.widget_id() != self_id {
+                    if (scroll_to.is_none() || !scroll_to_from_cmd)
+                        && path.contains(self_id)
+                        && path.widget_id() != self_id
+                        && !args.is_enabled_change()
+                        && !args.is_highlight_changed()
+                    {
                         // focus move inside.
                         if let Some(mode) = SCROLL_TO_FOCUSED_MODE_VAR.get() {
                             // scroll_to_focused enabled


### PR DESCRIPTION
Fixes  #170.

Issue was that the focus change event can represent other changes, not just widget change, so the button was the same, but the interactivity path changes because it disables, because the command disables as it can't scroll up when the scroll reaches the top.
