### PR TITLE
Use `diagnostic::on_unimplemented` in multiple traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unpublished
 
+* Add `diagnostic::on_unimplemented` notes for multiple traits.
 
 # 0.5.0
 

--- a/crates/zng-app/src/handler.rs
+++ b/crates/zng-app/src/handler.rs
@@ -18,6 +18,10 @@ use crate::INSTANT;
 ///
 /// There are different flavors of handlers, you can use macros to declare then.
 /// See [`hn!`], [`hn_once!`] or [`async_hn!`], [`async_hn_once!`] to start.
+#[diagnostic::on_unimplemented(
+    note = "use `hn!(|args: &{A}| {{ }})` to declare a widget handler from a `FnMut` closure",
+    note = "use `hn_once!`, `async_hn!` or `async_hn_once!` for other closure types"
+)]
 pub trait WidgetHandler<A: Clone + 'static>: Any + Send {
     /// Called every time the handler's event happens in the widget context.
     ///
@@ -611,6 +615,10 @@ pub struct AppHandlerArgs<'a> {
 ///
 /// There are different flavors of handlers, you can use macros to declare then.
 /// See [`app_hn!`], [`app_hn_once!`] or [`async_app_hn!`], [`async_app_hn_once!`] to start.
+#[diagnostic::on_unimplemented(
+    note = "use `app_hn!(|args: &{A}, _| {{ }})` to declare an app handler closure",
+    note = "use `app_hn_once!`, `async_app_hn!` or `async_app_hn_once!` for other closure types"
+)]
 pub trait AppHandler<A: Clone + 'static>: Any + Send {
     /// Called every time the event happens.
     ///

--- a/crates/zng-app/src/widget/base.rs
+++ b/crates/zng-app/src/widget/base.rs
@@ -195,6 +195,7 @@ impl WidgetBase {
 ///
 /// This trait is used in widget mix-in implementations to constraint `P`, it is also used by the
 /// the generated widget code. You do not need to implement it directly.
+#[diagnostic::on_unimplemented(note = "`{Self}` is not an `#[widget]`")]
 pub trait WidgetImpl {
     /// The inherit function.
     fn inherit(widget: WidgetType) -> Self;

--- a/crates/zng-app/src/widget/easing.rs
+++ b/crates/zng-app/src/widget/easing.rs
@@ -25,6 +25,7 @@ pub trait easing_property: Send + Sync + Clone + Copy {
 
 #[doc(hidden)]
 #[allow(non_camel_case_types)]
+#[diagnostic::on_unimplemented(note = "property type must be `Transitionable` to support `#[easing]`")]
 pub trait easing_property_input_Transitionable: Any + Send {
     fn easing(self, duration: Duration, easing: EasingFn, when_conditions_data: &[Option<Arc<dyn Any + Send + Sync>>]) -> Self;
 }

--- a/crates/zng-app/src/widget/node.rs
+++ b/crates/zng-app/src/widget/node.rs
@@ -43,6 +43,10 @@ use super::{
 /// using the match helpers. For more advanced nodes you can use the [`ui_node`] proc-macro attribute.
 ///
 /// [`match_node`]:fn@match_node
+#[diagnostic::on_unimplemented(
+    note = "you can use `match_node` to declare a node from a closure",
+    note = "you can use `#[ui_node]` to implement `UiNode` for `{Self}`"
+)]
 pub trait UiNode: Any + Send {
     /// Initializes the node in a new UI context.
     ///

--- a/crates/zng-ext-config/src/lib.rs
+++ b/crates/zng-ext-config/src/lib.rs
@@ -152,6 +152,7 @@ pub type ConfigKey = Txt;
 /// Marker trait for types that can stored in a [`Config`].
 ///
 /// This trait is already implemented for types it applies.
+#[diagnostic::on_unimplemented(note = "`ConfigValue` is implemented for all `T: VarValue + Serialize + DeserializeOwned`")]
 pub trait ConfigValue: VarValue + serde::Serialize + serde::de::DeserializeOwned {}
 impl<T: VarValue + serde::Serialize + serde::de::DeserializeOwned> ConfigValue for T {}
 

--- a/crates/zng-ext-fs-watcher/src/lib.rs
+++ b/crates/zng-ext-fs-watcher/src/lib.rs
@@ -792,6 +792,7 @@ impl<E: std::error::Error + 'static> std::error::Error for WatchFileParseError<E
 /// Represents a [`FsChange`] note.
 ///
 /// This trait is already implemented for types it applies.
+#[diagnostic::on_unimplemented(note = "`FsChangeNote` is implemented for all `T: Debug + Any + Send + Sync`")]
 pub trait FsChangeNote: fmt::Debug + std::any::Any + Send + Sync {
     /// Access any.
     fn as_any(&self) -> &dyn std::any::Any;

--- a/crates/zng-state-map/src/lib.rs
+++ b/crates/zng-state-map/src/lib.rs
@@ -19,8 +19,9 @@ use zng_unique_id::unique_id_64;
 ///
 /// This trait is used like a type alias for traits and is
 /// already implemented for all types it applies to.
-pub trait StateValue: Any + Send + Sync + 'static {}
-impl<T: Any + Send + Sync + 'static> StateValue for T {}
+#[diagnostic::on_unimplemented(note = "`StateValue` is implemented for all `T: Any + Send + Sync`")]
+pub trait StateValue: Any + Send + Sync {}
+impl<T: Any + Send + Sync> StateValue for T {}
 
 unique_id_64! {
     /// Unique identifier of a value in a state map.

--- a/crates/zng-task/src/http.rs
+++ b/crates/zng-task/src/http.rs
@@ -50,6 +50,7 @@ use zng_unit::*;
 /// Marker trait for types that try-to-convert to [`Uri`].
 ///
 /// All types `T` that match `Uri: TryFrom<T>, <Uri as TryFrom<T>>::Error: Into<isahc::http::Error>` implement this trait.
+#[diagnostic::on_unimplemented(note = "`TryUri` is implemented for all `T` where `Uri: TryFrom<T, Error: Into<isahc::http::Error>>`")]
 pub trait TryUri {
     /// Tries to convert `self` into [`Uri`].
     fn try_uri(self) -> Result<Uri, Error>;
@@ -67,6 +68,7 @@ where
 /// Marker trait for types that try-to-convert to [`Method`].
 ///
 /// All types `T` that match `Method: TryFrom<T>, <Method as TryFrom<T>>::Error: Into<isahc::http::Error>` implement this trait.
+#[diagnostic::on_unimplemented(note = "`TryMethod` is implemented for all `T` where `Method: TryFrom<T, Error: Into<isahc::http::Error>>`")]
 pub trait TryMethod {
     /// Tries to convert `self` into [`Method`].
     fn try_method(self) -> Result<Method, Error>;
@@ -85,6 +87,7 @@ where
 ///
 /// All types `T` that match `isahc::AsyncBody: TryFrom<T>, <isahc::AsyncBody as TryFrom<T>>::Error: Into<isahc::http::Error>`
 /// implement this trait.
+#[diagnostic::on_unimplemented(note = "`TryBody` is implemented for all `T` where `Body: TryFrom<T, Error: Into<isahc::http::Error>>`")]
 pub trait TryBody {
     /// Tries to convert `self` into [`Body`].
     fn try_body(self) -> Result<Body, Error>;
@@ -106,6 +109,9 @@ where
 ///
 /// All types `T` that match `header::HeaderName: TryFrom<T>, <header::HeaderName as TryFrom<T>>::Error: Into<isahc::http::Error>`
 /// implement this trait.
+#[diagnostic::on_unimplemented(
+    note = "`TryHeaderName` is implemented for all `T` where `HeaderName: TryFrom<T, Error: Into<isahc::http::Error>>`"
+)]
 pub trait TryHeaderName {
     /// Tries to convert `self` into [`Body`].
     fn try_header_name(self) -> Result<header::HeaderName, Error>;
@@ -124,6 +130,9 @@ where
 ///
 /// All types `T` that match `header::HeaderValue: TryFrom<T>, <header::HeaderValue as TryFrom<T>>::Error: Into<isahc::http::Error>`
 /// implement this trait.
+#[diagnostic::on_unimplemented(
+    note = "`TryHeaderValue` is implemented for all `T` where `HeaderValue: TryFrom<T, Error: Into<isahc::http::Error>>`"
+)]
 pub trait TryHeaderValue {
     /// Tries to convert `self` into [`Body`].
     fn try_header_value(self) -> Result<header::HeaderValue, Error>;

--- a/crates/zng-task/src/ipc.rs
+++ b/crates/zng-task/src/ipc.rs
@@ -149,6 +149,7 @@ pub use ipc_channel::ipc::{bytes_channel, IpcBytesReceiver, IpcBytesSender, IpcR
 /// Types need to be `Debug + serde::Serialize + serde::de::Deserialize + Send + 'static` to auto-implement this trait,
 /// if you want to send an external type in that does not implement all the traits
 /// you may need to declare a *newtype* wrapper.
+#[diagnostic::on_unimplemented(note = "`IpcValue` is implemented for all `T: Debug + Serialize + Deserialize + Send + 'static`")]
 pub trait IpcValue: fmt::Debug + serde::Serialize + for<'d> serde::de::Deserialize<'d> + Send + 'static {}
 
 impl<T: fmt::Debug + serde::Serialize + for<'d> serde::de::Deserialize<'d> + Send + 'static> IpcValue for T {}

--- a/crates/zng-var/src/lib.rs
+++ b/crates/zng-var/src/lib.rs
@@ -156,8 +156,9 @@ mod private {
 /// you may need to declare a *newtype* wrapper, if the external type is `Debug + Send + Sync + Any` at
 /// least you can use the [`ArcEq<T>`] wrapper to quickly implement `Clone + PartialEq`, this is particularly
 /// useful for error types in [`ResponseVar<Result<_, E>>`].
+#[diagnostic::on_unimplemented(note = "`VarValue` is implemented for all `T: Debug + Clone + PartialEq + Any + Send + Sync`")]
 pub trait VarValue: fmt::Debug + Clone + PartialEq + Any + Send + Sync {}
-impl<T: fmt::Debug + Clone + Any + PartialEq + Send + Sync> VarValue for T {}
+impl<T: fmt::Debug + Clone + PartialEq + Any + Send + Sync> VarValue for T {}
 
 /// Trait implemented for all [`VarValue`] types.
 pub trait AnyVarValue: fmt::Debug + Any + Send + Sync {
@@ -209,6 +210,10 @@ impl<T: VarValue> AnyVarValue for T {
 /// [inspected]: crate::inspector
 /// [`Debug`]: std::fmt::Debug
 /// [`impl_from_and_into_var`]: impl_from_and_into_var
+#[diagnostic::on_unimplemented(
+    note = "`IntoValue<T>` is implemented for all `T: VarValue",
+    note = "you can use `impl_from_and_into_var!` to implement conversions"
+)]
 pub trait IntoValue<T: VarValue>: Into<T> {}
 impl<T: VarValue> IntoValue<T> for T {}
 
@@ -770,6 +775,10 @@ pub trait WeakVar<T: VarValue>: AnyWeakVar + Clone {
 /// this converts the *shorthand value* like a tuple into the actual value type and wraps it into a variable, usually [`LocalVar`]
 /// too. They can implement the trait multiple times to support different shorthand syntaxes or different types in the shorthand
 /// value.
+#[diagnostic::on_unimplemented(
+    note = "`IntoVar<T>` is implemented for all `T: VarValue",
+    note = "`IntoVar<T>` is implemented for all `V: Var<T>`"
+)]
 pub trait IntoVar<T: VarValue> {
     /// Variable type that will wrap the `T` value.
     ///

--- a/crates/zng-var/src/lib.rs
+++ b/crates/zng-var/src/lib.rs
@@ -211,7 +211,7 @@ impl<T: VarValue> AnyVarValue for T {
 /// [`Debug`]: std::fmt::Debug
 /// [`impl_from_and_into_var`]: impl_from_and_into_var
 #[diagnostic::on_unimplemented(
-    note = "`IntoValue<T>` is implemented for all `T: VarValue",
+    note = "`IntoValue<T>` is implemented for all `T: VarValue`",
     note = "you can use `impl_from_and_into_var!` to implement conversions"
 )]
 pub trait IntoValue<T: VarValue>: Into<T> {}
@@ -776,7 +776,7 @@ pub trait WeakVar<T: VarValue>: AnyWeakVar + Clone {
 /// too. They can implement the trait multiple times to support different shorthand syntaxes or different types in the shorthand
 /// value.
 #[diagnostic::on_unimplemented(
-    note = "`IntoVar<T>` is implemented for all `T: VarValue",
+    note = "`IntoVar<T>` is implemented for all `T: VarValue`",
     note = "`IntoVar<T>` is implemented for all `V: Var<T>`"
 )]
 pub trait IntoVar<T: VarValue> {

--- a/crates/zng-wgt-data/src/lib.rs
+++ b/crates/zng-wgt-data/src/lib.rs
@@ -591,6 +591,7 @@ impl DataNoteHandle {
 ///
 /// This trait is used like a type alias for traits and is
 /// already implemented for all types it applies to.
+#[diagnostic::on_unimplemented(note = "`DataNoteValue` is implemented for all `T: Debug + Display + Send + Sync + Any")]
 pub trait DataNoteValue: fmt::Debug + fmt::Display + Send + Sync + Any {
     /// /// Access to `dyn Any` methods.
     fn as_any(&self) -> &dyn Any;

--- a/crates/zng-wgt-text/src/lib.rs
+++ b/crates/zng-wgt-text/src/lib.rs
@@ -174,6 +174,7 @@ where
 /// `VarValue + FromStr + Display where FromStr::Err: Display`.
 ///
 /// [`txt_parse`]: fn@txt_parse
+#[diagnostic::on_unimplemented(note = "`TxtParseValue` is implemented for all `T: VarValue + Display + FromStr<Error: Display>")]
 pub trait TxtParseValue: VarValue {
     /// Try parse `Self` from `txt`, formats the error for display.
     ///

--- a/tests/macro-tests/cases/property/defaults.stderr
+++ b/tests/macro-tests/cases/property/defaults.stderr
@@ -88,6 +88,8 @@ error[E0277]: the trait bound `{integer}: IntoVar<bool>` is not satisfied
    |                     |
    |                     required by a bound introduced by this call
    |
+   = note: `IntoVar<T>` is implemented for all `T: VarValue`
+   = note: `IntoVar<T>` is implemented for all `V: Var<T>`
    = help: the following other types implement trait `IntoVar<T>`:
             <implementers-list>
 note: required by a bound in `invalid_default_args_types_u_2_::args`
@@ -106,6 +108,8 @@ error[E0277]: the trait bound `bool: IntoVar<u32>` is not satisfied
    |                     |
    |                     required by a bound introduced by this call
    |
+   = note: `IntoVar<T>` is implemented for all `T: VarValue`
+   = note: `IntoVar<T>` is implemented for all `V: Var<T>`
    = help: the following other types implement trait `IntoVar<T>`:
             <implementers-list>
 note: required by a bound in `invalid_default_args_types_u_2_::args`

--- a/tests/macro-tests/cases/property/prefix_get_default.stderr
+++ b/tests/macro-tests/cases/property/prefix_get_default.stderr
@@ -4,6 +4,7 @@ error[E0277]: the trait bound `NotDefault: VarValue` is not satisfied
 10 | pub fn get_state_invalid(child: impl UiNode, state: impl IntoVar<NotDefault>) -> impl UiNode {
    |                                                          ^^^^^^^^^^^^^^^^^^^ the trait `PartialEq` is not implemented for `NotDefault`, which is required by `NotDefault: VarValue`
    |
+   = note: `VarValue` is implemented for all `T: Debug + Clone + PartialEq + Any + Send + Sync`
    = note: required for `NotDefault` to implement `VarValue`
 note: required by a bound in `IntoVar`
   --> $WORKSPACE/crates/zng-var/src/lib.rs
@@ -22,6 +23,7 @@ error[E0277]: the trait bound `NotDefault: VarValue` is not satisfied
 10 | pub fn get_state_invalid(child: impl UiNode, state: impl IntoVar<NotDefault>) -> impl UiNode {
    |                                                                  ^^^^^^^^^^ the trait `PartialEq` is not implemented for `NotDefault`, which is required by `NotDefault: VarValue`
    |
+   = note: `VarValue` is implemented for all `T: Debug + Clone + PartialEq + Any + Send + Sync`
    = note: required for `NotDefault` to implement `VarValue`
 note: required by a bound in `WhenInputVar::new`
   --> $WORKSPACE/crates/zng-app/src/widget/builder.rs
@@ -101,6 +103,7 @@ error[E0277]: the trait bound `NotDefault: VarValue` is not satisfied
 9 | #[property(CONTEXT)]
   | ^^^^^^^^^^^^^^^^^^^^ the trait `PartialEq` is not implemented for `NotDefault`, which is required by `NotDefault: VarValue`
   |
+  = note: `VarValue` is implemented for all `T: Debug + Clone + PartialEq + Any + Send + Sync`
   = note: required for `NotDefault` to implement `VarValue`
 note: required by a bound in `new_dyn_var`
  --> $WORKSPACE/crates/zng-app/src/widget/builder.rs
@@ -182,6 +185,7 @@ error[E0277]: the trait bound `NotDefault: VarValue` is not satisfied
 9 | #[property(CONTEXT)]
   | ^^^^^^^^^^^^^^^^^^^^ the trait `PartialEq` is not implemented for `NotDefault`, which is required by `NotDefault: VarValue`
   |
+  = note: `VarValue` is implemented for all `T: Debug + Clone + PartialEq + Any + Send + Sync`
   = note: required for `NotDefault` to implement `VarValue`
 note: required by a bound in `var_to_args`
  --> $WORKSPACE/crates/zng-app/src/widget/builder.rs

--- a/tests/macro-tests/cases/property/prefix_has_default.stderr
+++ b/tests/macro-tests/cases/property/prefix_has_default.stderr
@@ -6,6 +6,8 @@ error[E0277]: the trait bound `ArcVar<bool>: IntoVar<u32>` is not satisfied
 10 | pub fn has_state_invalid(child: impl UiNode, state: impl IntoVar<u32>) -> impl UiNode {
    |                                                     ^^^^ the trait `IntoVar<u32>` is not implemented for `ArcVar<bool>`
    |
+   = note: `IntoVar<T>` is implemented for all `T: VarValue`
+   = note: `IntoVar<T>` is implemented for all `V: Var<T>`
    = help: the trait `IntoVar<bool>` is implemented for `ArcVar<bool>`
    = help: for that trait implementation, expected `bool`, found `u32`
 note: required by a bound in `has_state_invalid_::args`

--- a/tests/macro-tests/cases/property/prefix_is_default.stderr
+++ b/tests/macro-tests/cases/property/prefix_is_default.stderr
@@ -6,6 +6,8 @@ error[E0277]: the trait bound `ArcVar<bool>: IntoVar<u32>` is not satisfied
 10 | pub fn is_state_invalid(child: impl UiNode, state: impl IntoVar<u32>) -> impl UiNode {
    |                                                    ^^^^ the trait `IntoVar<u32>` is not implemented for `ArcVar<bool>`
    |
+   = note: `IntoVar<T>` is implemented for all `T: VarValue`
+   = note: `IntoVar<T>` is implemented for all `V: Var<T>`
    = help: the trait `IntoVar<bool>` is implemented for `ArcVar<bool>`
    = help: for that trait implementation, expected `bool`, found `u32`
 note: required by a bound in `is_state_invalid_::args`

--- a/tests/macro-tests/cases/property/return_type_is_not_ui_node.stderr
+++ b/tests/macro-tests/cases/property/return_type_is_not_ui_node.stderr
@@ -6,5 +6,7 @@ error[E0277]: the trait bound `NotUiNode: zng::prelude::UiNode` is not satisfied
 6 | pub fn invalid_output(_child: impl UiNode, _input: impl IntoVar<bool>) -> NotUiNode {
   |                                                                           ^^^^^^^^^ the trait `zng::prelude::UiNode` is not implemented for `NotUiNode`
   |
+  = note: you can use `match_node` to declare a node from a closure
+  = note: you can use `#[ui_node]` to implement `UiNode` for `NotUiNode`
   = help: the following other types implement trait `zng::prelude::UiNode`:
             <implementers-list>

--- a/tests/macro-tests/cases/ui_node/delegate_expr_error_incorrect_type.stderr
+++ b/tests/macro-tests/cases/ui_node/delegate_expr_error_incorrect_type.stderr
@@ -7,5 +7,7 @@ error[E0277]: the trait bound `NotANode: zng::prelude::UiNode` is not satisfied
   | |                    the trait `zng::prelude::UiNode` is not implemented for `NotANode`
   | required by a bound introduced by this call
   |
+  = note: you can use `match_node` to declare a node from a closure
+  = note: you can use `#[ui_node]` to implement `UiNode` for `NotANode`
   = help: the following other types implement trait `zng::prelude::UiNode`:
             <implementers-list>

--- a/tests/macro-tests/cases/ui_node/delegate_expr_error_incorrect_type_child.stderr
+++ b/tests/macro-tests/cases/ui_node/delegate_expr_error_incorrect_type_child.stderr
@@ -7,5 +7,7 @@ error[E0277]: the trait bound `NotANode: zng::prelude::UiNode` is not satisfied
   | |         the trait `zng::prelude::UiNode` is not implemented for `NotANode`
   | required by a bound introduced by this call
   |
+  = note: you can use `match_node` to declare a node from a closure
+  = note: you can use `#[ui_node]` to implement `UiNode` for `NotANode`
   = help: the following other types implement trait `zng::prelude::UiNode`:
             <implementers-list>

--- a/tests/macro-tests/cases/widget/parent_not_widget.stderr
+++ b/tests/macro-tests/cases/widget/parent_not_widget.stderr
@@ -4,6 +4,7 @@ error[E0277]: the trait bound `f32: WidgetImpl` is not satisfied
 4 | pub struct Foo(f32);
   |                ^^^ the trait `WidgetImpl` is not implemented for `f32`
   |
+  = note: `f32` is not an `#[widget]`
   = help: the following other types implement trait `WidgetImpl`:
             <implementers-list>
 
@@ -13,6 +14,7 @@ error[E0277]: the trait bound `f32: WidgetImpl` is not satisfied
 3 | #[widget($crate::Foo)]
   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `WidgetImpl` is not implemented for `f32`
   |
+  = note: `f32` is not an `#[widget]`
   = help: the following other types implement trait `WidgetImpl`:
             <implementers-list>
   = note: this error originates in the attribute macro `widget` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/macro-tests/cases/widget_new/incorrect_arg_type1.stderr
+++ b/tests/macro-tests/cases/widget_new/incorrect_arg_type1.stderr
@@ -6,6 +6,8 @@ error[E0277]: the trait bound `bool: IntoVar<SideOffsets>` is not satisfied
   |         |
   |         required by a bound introduced by this call
   |
+  = note: `IntoVar<T>` is implemented for all `T: VarValue`
+  = note: `IntoVar<T>` is implemented for all `V: Var<T>`
   = help: the following other types implement trait `IntoVar<T>`:
             <implementers-list>
 note: required by a bound in `zng::layout::margin::margin`

--- a/tests/macro-tests/cases/widget_new/incorrect_arg_type2.stderr
+++ b/tests/macro-tests/cases/widget_new/incorrect_arg_type2.stderr
@@ -6,6 +6,8 @@ error[E0277]: the trait bound `bool: IntoVar<u32>` is not satisfied
    |         |
    |         required by a bound introduced by this call
    |
+   = note: `IntoVar<T>` is implemented for all `T: VarValue`
+   = note: `IntoVar<T>` is implemented for all `V: Var<T>`
    = help: the following other types implement trait `IntoVar<T>`:
             <implementers-list>
 note: required by a bound in `simple_type::simple_type`

--- a/tests/macro-tests/cases/widget_new/incorrect_arg_type3.stderr
+++ b/tests/macro-tests/cases/widget_new/incorrect_arg_type3.stderr
@@ -6,6 +6,8 @@ error[E0277]: the trait bound `bool: IntoVar<GradientStops>` is not satisfied
    |         |
    |         required by a bound introduced by this call
    |
+   = note: `IntoVar<T>` is implemented for all `T: VarValue`
+   = note: `IntoVar<T>` is implemented for all `V: Var<T>`
    = help: the following other types implement trait `IntoVar<T>`:
             <implementers-list>
 note: required by a bound in `zng::widget::background_gradient::background_gradient`

--- a/tests/macro-tests/cases/widget_new/incorrect_arg_type4.stderr
+++ b/tests/macro-tests/cases/widget_new/incorrect_arg_type4.stderr
@@ -6,6 +6,8 @@ error[E0277]: the trait bound `bool: IntoVar<GradientStops>` is not satisfied
    |             |
    |             required by a bound introduced by this call
    |
+   = note: `IntoVar<T>` is implemented for all `T: VarValue`
+   = note: `IntoVar<T>` is implemented for all `V: Var<T>`
    = help: the following other types implement trait `IntoVar<T>`:
             <implementers-list>
 note: required by a bound in `zng_wgt_fill::background_gradient_inputs__::stops`

--- a/tests/macro-tests/cases/widget_new/incorrect_arg_type5.stderr
+++ b/tests/macro-tests/cases/widget_new/incorrect_arg_type5.stderr
@@ -6,6 +6,8 @@ error[E0277]: the trait bound `bool: IntoVar<u32>` is not satisfied
    |         |
    |         required by a bound introduced by this call
    |
+   = note: `IntoVar<T>` is implemented for all `T: VarValue`
+   = note: `IntoVar<T>` is implemented for all `V: Var<T>`
    = help: the following other types implement trait `IntoVar<T>`:
             <implementers-list>
 note: required by a bound in `simple_type::simple_type`

--- a/tests/macro-tests/cases/widget_new/incorrect_arg_type6.stderr
+++ b/tests/macro-tests/cases/widget_new/incorrect_arg_type6.stderr
@@ -6,6 +6,8 @@ error[E0277]: the trait bound `bool: IntoVar<u32>` is not satisfied
    |             |
    |             required by a bound introduced by this call
    |
+   = note: `IntoVar<T>` is implemented for all `T: VarValue`
+   = note: `IntoVar<T>` is implemented for all `V: Var<T>`
    = help: the following other types implement trait `IntoVar<T>`:
             <implementers-list>
 note: required by a bound in `simple_type_inputs__::simple_b`

--- a/tests/macro-tests/cases/widget_new/missing_field_all_multi.stderr
+++ b/tests/macro-tests/cases/widget_new/missing_field_all_multi.stderr
@@ -6,6 +6,8 @@ error[E0277]: the trait bound `(): IntoVar<LinearGradientAxis>` is not satisfied
    |         |
    |         required by a bound introduced by this call
    |
+   = note: `IntoVar<T>` is implemented for all `T: VarValue`
+   = note: `IntoVar<T>` is implemented for all `V: Var<T>`
    = help: the following other types implement trait `IntoVar<T>`:
             <implementers-list>
 note: required by a bound in `zng::widget::background_gradient::background_gradient`

--- a/tests/macro-tests/cases/widget_new/missing_field_all_single.stderr
+++ b/tests/macro-tests/cases/widget_new/missing_field_all_single.stderr
@@ -6,6 +6,8 @@ error[E0277]: the trait bound `(): IntoVar<SideOffsets>` is not satisfied
   |         |
   |         required by a bound introduced by this call
   |
+  = note: `IntoVar<T>` is implemented for all `T: VarValue`
+  = note: `IntoVar<T>` is implemented for all `V: Var<T>`
   = help: the following other types implement trait `IntoVar<T>`:
             <implementers-list>
 note: required by a bound in `zng::layout::margin::margin`

--- a/tests/macro-tests/cases/widget_new/property_generic2.stderr
+++ b/tests/macro-tests/cases/widget_new/property_generic2.stderr
@@ -6,6 +6,8 @@ error[E0277]: the trait bound `{integer}: IntoVar<bool>` is not satisfied
   |         |
   |         required by a bound introduced by this call
   |
+  = note: `IntoVar<T>` is implemented for all `T: VarValue`
+  = note: `IntoVar<T>` is implemented for all `V: Var<T>`
   = help: the following other types implement trait `IntoVar<T>`:
             <implementers-list>
 note: required by a bound in `Toggle::value`


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->