### PR TITLE
Fix `WidgetInfo::new_interaction_path` always detecting change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unpublished
 
 * Add `diagnostic::on_unimplemented` notes for multiple traits.
+* Fix `WidgetInfo::new_interaction_path` always detecting change.
 
 # 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add `diagnostic::on_unimplemented` notes for multiple traits.
 * Fix `WidgetInfo::new_interaction_path` always detecting change.
+* Improve iterators in `InteractionPath`, `interaction_path` and `zip` are now double ended and exact sized.
 
 # 0.5.0
 

--- a/crates/zng-app/src/widget/info.rs
+++ b/crates/zng-app/src/widget/info.rs
@@ -1166,7 +1166,7 @@ impl WidgetInfo {
         if self.interactivity() != old_path.interactivity()
             || self
                 .ancestors()
-                .zip(old_path.zip())
+                .zip(old_path.zip().rev().skip(1))
                 .any(|(anc, (id, int))| anc.id() != id || anc.interactivity() != int)
         {
             Some(self.interaction_path())


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->