### PR TITLE
Fix unintended breaking change.

### DIFF
--- a/crates/zng-view/src/extensions.rs
+++ b/crates/zng-view/src/extensions.rs
@@ -344,7 +344,7 @@ pub trait AsyncBlobRasterizer: Send + Any {
 /// Arguments for [`BlobExtension::prepare_resources`].
 pub struct BlobPrepareArgs<'a> {
     #[allow(missing_docs)]
-    pub resources: &'a dyn webrender::api::BlobImageResources,
+    pub services: &'a dyn webrender::api::BlobImageResources,
     /// Requests targeting any of the blob extensions. Each extension must
     /// inspect the requests to find the ones targeting it.
     pub requests: &'a [BlobImageParams],
@@ -993,7 +993,7 @@ impl BlobImageHandler for BlobExtensionsImgHandler {
     fn prepare_resources(&mut self, services: &dyn webrender::api::BlobImageResources, requests: &[BlobImageParams]) {
         for ext in self.0.iter_mut() {
             ext.prepare_resources(&mut BlobPrepareArgs {
-                resources: services,
+                services,
                 requests,
             })
         }

--- a/crates/zng-view/src/extensions.rs
+++ b/crates/zng-view/src/extensions.rs
@@ -992,10 +992,7 @@ impl BlobImageHandler for BlobExtensionsImgHandler {
 
     fn prepare_resources(&mut self, services: &dyn webrender::api::BlobImageResources, requests: &[BlobImageParams]) {
         for ext in self.0.iter_mut() {
-            ext.prepare_resources(&mut BlobPrepareArgs {
-                services,
-                requests,
-            })
+            ext.prepare_resources(&mut BlobPrepareArgs { services, requests })
         }
     }
 


### PR DESCRIPTION
The name `services` comes from the `BlockImageHandler::prepare_resources` signature.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->