### PR TITLE
Fix crash handler passing app name twice as command line arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     - The `CTRL+'0'` shortcut is now used for this command, not `ZOOM_RESET_CMD`.
 * Deprecate `NilAnimationObserver`, use `()` now.
 * Add `ForceAnimationController` to force important animations to run when animations are disabled on the system.
+* Fix crash handler passing app name twice as command line arguments.
 
 # 0.5.0
 

--- a/crates/zng-app/src/crash_handler.rs
+++ b/crates/zng-app/src/crash_handler.rs
@@ -686,7 +686,7 @@ fn crash_handler_monitor_process(mut cfg_app: ConfigProcess, mut cfg_dialog: Con
         .and_then(|p| p.canonicalize())
         .expect("failed to get the current executable");
 
-    let mut args: Box<[_]> = std::env::args().map(Txt::from).collect();
+    let mut args: Box<[_]> = std::env::args().skip(1).map(Txt::from).collect();
 
     let mut dialog_args = CrashArgs {
         app_crashes: vec![],


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->