### PR TITLE
Fix zng-wgt-scroll release build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unpublished
 
+* Fix release build of `zng-wgt-scroll` running out of memory. (#203)
 
 # 0.5.1
 

--- a/crates/zng-wgt-scroll/src/lib.rs
+++ b/crates/zng-wgt-scroll/src/lib.rs
@@ -151,7 +151,7 @@ fn on_build(wgt: &mut WidgetBuilding) {
         let child = with_context_var(child, SCROLL_VERTICAL_CONTENT_OVERFLOWS_VAR, var(false));
         let child = with_context_var(child, SCROLL_HORIZONTAL_CONTENT_OVERFLOWS_VAR, var(false));
 
-        let child = SCROLL.config_node(child);
+        let child = SCROLL.config_node(child).boxed();
 
         let child = with_context_var(child, SCROLL_VERTICAL_OFFSET_VAR, var(0.fct()));
         let child = with_context_var(child, SCROLL_HORIZONTAL_OFFSET_VAR, var(0.fct()));


### PR DESCRIPTION
Without this a release build on Windows uses more then 32GB (out-of-memory on my machine).

Might be related to rust-lang/rust#82406, will try to make a MRE.