### PR TITLE
Fix view-process becoming a zombie if the app-process panics to early.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix release build of `zng-wgt-scroll` running out of memory. (#203)
 * Implemented VsCode snippets for common Zng macros, see [`zng.code-snippets`].
+* Fix view-process cleanup when app-process panics on init.
 
 [`zng.code-snippets`]: .vscode/zng.code-snippets
 


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->