### PR TITLE
Add `std::env::consts::OS` to crash error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     - Use `static_id!` to declare static IDs, the new way is compatible with hot reloading.
     - Removed `StaticWindowId`, `StaticMonitorId`, `StaticPropertyId`, `StaticAppId`, `StaticWidgetId`, `StaticDeviceId`, `StaticStateId`,  `StaticCommandMetaVarId`, `StaticSpatialFrameId`.
 * Implemented equality/hash for `zng::task::SignalOnce`.
+* Add `std::env::consts::OS` to crash error.
 
 [`zng.code-snippets`]: .vscode/zng.code-snippets
 

--- a/crates/zng-app/src/crash_handler.rs
+++ b/crates/zng-app/src/crash_handler.rs
@@ -183,6 +183,10 @@ pub struct CrashError {
     pub args: Box<[Txt]>,
     /// Minidump file.
     pub minidump: Option<PathBuf>,
+    /// Operating system.
+    ///
+    /// See [`std::env::consts::OS`] for details.
+    pub os: Txt,
 }
 /// Alternate mode `{:#}` prints plain stdout and stderr (no ANSI escape sequences).
 impl fmt::Display for CrashError {
@@ -228,6 +232,7 @@ impl CrashError {
             stderr,
             args,
             minidump,
+            os: std::env::consts::OS.into(),
         }
     }
 

--- a/crates/zng-wgt-inspector/src/crash_handler.rs
+++ b/crates/zng-wgt-inspector/src/crash_handler.rs
@@ -151,7 +151,7 @@ impl ErrorPanel {
 
 fn summary_panel(error: &CrashError) -> impl UiNode {
     let s = formatx!(
-        "Timestamp: {}\nExit Code: {}\nSignal: {}\nStderr: {} bytes\nStdout: {} bytes\nPanic: {}\nMinidump: {}\n\nArgs: {:?}\n",
+        "Timestamp: {}\nExit Code: {}\nSignal: {}\nStderr: {} bytes\nStdout: {} bytes\nPanic: {}\nMinidump: {}\n\nArgs: {:?}\nOS: {}",
         error.unix_time(),
         match error.code {
             Some(c) => format!("{c:#x}"),
@@ -173,6 +173,7 @@ fn summary_panel(error: &CrashError) -> impl UiNode {
             None => "<none>".to_owned(),
         },
         error.args,
+        error.os,
     );
     plain_panel(s, "summary")
 }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->