### PR TITLE
Bump `zng-unique-id`

### DIFF
--- a/crates/zng-unique-id/Cargo.toml
+++ b/crates/zng-unique-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-unique-id"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["The Zng Project Developers"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
I forgot to include this in the release 0.6.1 after #223...

So now I release just this crate manually, and will have to bump it again with 0.6.2 to update all dependencies (this pull request is tagged for 0.6.2 as a reminder). 