### PR TITLE
`Lang` now parses empty strings as `und`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `zng-env` and `zng::env` as an API to get external directories and files associated with the installed process.
 * Add `zng::hot_reload::{lazy_static, lazy_static_init}`. Very useful for implementing "zng-env" like functions.
 * Implement `FromStr` for `zng::l10n::Langs`.
+* `Lang` now parses empty strings as `und`.
 
 # 0.6.1
 

--- a/crates/zng-ext-l10n/src/types.rs
+++ b/crates/zng-ext-l10n/src/types.rs
@@ -325,6 +325,10 @@ impl std::str::FromStr for Lang {
     type Err = unic_langid::LanguageIdentifierError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+        if s.is_empty() {
+            return Ok(lang!(und));
+        }
         unic_langid::LanguageIdentifier::from_str(s).map(Lang)
     }
 }
@@ -388,6 +392,9 @@ impl std::str::FromStr for Langs {
     type Err = unic_langid::LanguageIdentifierError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.trim().is_empty() {
+            return Ok(Langs(vec![]));
+        }
         let mut r = Self(vec![]);
         for lang in s.split(',') {
             r.0.push(lang.trim().parse()?)


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->