### PR TITLE
Refactor zng::env::init

### DIFF
--- a/crates/zng-app/src/lib.rs
+++ b/crates/zng-app/src/lib.rs
@@ -1165,18 +1165,8 @@ impl APP {
         APP_PROCESS_SV.read().device_events
     }
 
-    /// App display info.
-    ///
-    /// This info can be used by auto-generated views.
-    ///
-    /// # Examples
-    ///
-    /// You can set some of the info using crate metadata:
-    ///
-    /// ```no_run
-    /// # use zng_app::*;
-    /// APP.about().set(about_app_from_crate!());
-    /// ```
+    /// Deprecated.
+    #[deprecated = "use zng::env::about"]
     pub fn about(&self) -> ArcVar<AboutApp> {
         APP_PROCESS_SV.read().about.clone()
     }
@@ -1480,9 +1470,7 @@ zng_app_context::app_local! {
     static TEST_LOG: bool = false;
 }
 
-/// Display info about the current app.
-///
-/// You can use the [`about_app_from_crate!`] macro to generate info from the app crate metadata.
+/// Deprecated.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct AboutApp {
     /// App name.
@@ -1512,7 +1500,8 @@ impl AboutApp {
     }
 }
 
-/// Generate an [`AboutApp`] value from the crate's metadata.
+/// Deprecated.
+#[deprecated = "use zng::env::init"]
 #[macro_export]
 macro_rules! about_app_from_crate {
     () => {

--- a/crates/zng-env/Cargo.toml
+++ b/crates/zng-env/Cargo.toml
@@ -10,11 +10,16 @@ documentation = "https://zng-ui.github.io/doc/zng_unique_id"
 repository = "https://github.com/zng-ui/zng"
 categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
+[package.metadata.zng.about]
+app = "Zng Env" # test
 
 [dependencies]
 directories = "5.0"
 parking_lot = "0.12"
 tracing = "0.1"
+toml = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+semver = { version = "1.0", features = ["serde"] }
 
 zng-unique-id = { path = "../zng-unique-id", version = "0.4.1" }
 zng-txt = { path = "../zng-txt", version = "0.2.6" }

--- a/crates/zng-ext-window/Cargo.toml
+++ b/crates/zng-ext-window/Cargo.toml
@@ -30,6 +30,7 @@ zng-view-api = { path = "../zng-view-api", version = "0.4.3" }
 zng-task = { path = "../zng-task", version = "0.2.10" }
 zng-ext-image = { path = "../zng-ext-image", version = "0.2.13" }
 zng-color = { path = "../zng-color", version = "0.2.13" }
+zng-env ={ path = "../zng-env", version = "0.1.0" }
 
 serde = { version = "1.0", features = ["derive"] }
 bitflags = { version = "2.5", features = ["serde", "bytemuck"] }

--- a/crates/zng-ext-window/src/vars.rs
+++ b/crates/zng-ext-window/src/vars.rs
@@ -7,7 +7,7 @@ use zng_app::{
 use zng_ext_image::Img;
 use zng_layout::unit::{Dip, DipPoint, DipRect, DipSize, DipToPx, Factor, FactorUnits, Length, LengthUnits, Point, PxPoint, PxSize, Size};
 use zng_state_map::{static_id, StateId};
-use zng_txt::{ToTxt, Txt};
+use zng_txt::Txt;
 use zng_unique_id::IdSet;
 use zng_var::{merge_var, var, var_from, ArcVar, BoxedVar, ReadOnlyArcVar, Var};
 use zng_view_api::{
@@ -95,7 +95,7 @@ impl WindowVars {
             actual_icon: var(None),
             cursor: var_from(CursorIcon::Default),
             actual_cursor_img: var(None),
-            title: var("".to_txt()),
+            title: var(zng_env::about().app.clone()),
 
             state: var(WindowState::Normal),
             focus_indicator: var(None),
@@ -152,7 +152,6 @@ impl WindowVars {
             access_enabled: var(AccessEnabled::empty()),
             system_shutdown_warn: var(Txt::from("")),
         });
-        zng_app::APP.about().map_ref(|i| &i.name).set_bind(&vars.title).perm();
         Self(vars)
     }
 

--- a/crates/zng-wgt-inspector/Cargo.toml
+++ b/crates/zng-wgt-inspector/Cargo.toml
@@ -23,6 +23,7 @@ crash_handler = ["zng-app/crash_handler", "dep:open"]
 [dependencies]
 zng-wgt = { path = "../zng-wgt", version = "0.3.3" }
 zng-app = { path = "../zng-app", version = "0.5.1" }
+zng-env = { path = "../zng-env", version = "0.1.0" }
 zng-ext-input = { path = "../zng-ext-input", version = "0.5.1" }
 zng-ext-font = { path = "../zng-ext-font", version = "0.3.9" }
 zng-ext-clipboard = { path = "../zng-ext-clipboard", version = "0.2.13" }

--- a/crates/zng-wgt-inspector/src/crash_handler.rs
+++ b/crates/zng-wgt-inspector/src/crash_handler.rs
@@ -3,7 +3,7 @@
 //! Debug crash handler.
 
 use std::path::PathBuf;
-use zng_app::{crash_handler::*, APP};
+use zng_app::crash_handler::*;
 use zng_ext_config::CONFIG;
 use zng_ext_window::{StartPosition, WindowRoot, WINDOWS};
 use zng_wgt::prelude::*;
@@ -30,7 +30,7 @@ use zng_wgt_wrap::Wrap;
 pub fn debug_dialog(args: CrashArgs) -> WindowRoot {
     let error = args.latest();
     Window! {
-        title = APP.about().map(|a| formatx!("{}App Crashed", a.title_prefix()));
+        title = formatx!("{} - App Crashed", zng_env::about().app);
         start_position = StartPosition::CenterMonitor;
         color_scheme = ColorScheme::Dark;
 

--- a/crates/zng/src/app.rs
+++ b/crates/zng/src/app.rs
@@ -396,9 +396,12 @@
 //! This module provides most of the app API needed to make and extend apps, some more advanced or experimental API
 //! may be available at the [`zng_app`], [`zng_app_context`] and [`zng_ext_single_instance`] base crates.
 
+#[deprecated = "use zng::env::init"]
+#[allow(deprecated)]
+pub use zng_app::about_app_from_crate;
 pub use zng_app::{
-    about_app_from_crate, print_tracing, AboutApp, AppControlFlow, AppEventObserver, AppExtended, AppExtension, AppExtensionBoxed,
-    AppExtensionInfo, DInstant, Deadline, ExitRequestedArgs, HeadlessApp, InstantMode, EXIT_CMD, EXIT_REQUESTED_EVENT, INSTANT,
+    print_tracing, AboutApp, AppControlFlow, AppEventObserver, AppExtended, AppExtension, AppExtensionBoxed, AppExtensionInfo, DInstant,
+    Deadline, ExitRequestedArgs, HeadlessApp, InstantMode, EXIT_CMD, EXIT_REQUESTED_EVENT, INSTANT,
 };
 
 #[cfg(feature = "test_util")]

--- a/crates/zng/src/env.rs
+++ b/crates/zng/src/env.rs
@@ -6,7 +6,7 @@
 //! ```
 //! fn main() {
 //!    // optional, but recommended package metadata init.
-//!    zng::env::init("io.github.zng-ui", "Zng Developers", "Zng");
+//!    zng::env::init!();
 //!
 //!    // get a path in the app config dir, the config dir is created if needed.    
 //!    let my_config = zng::env::config("my-config.txt");
@@ -20,7 +20,7 @@
 //! }
 //! ```
 //!
-//! The example above uses [`init`] to initialize the metadata used to find a good place for each directory, it then
+//! The example above uses [`init!`] to initialize the metadata used to find a good place for each directory, it then
 //! uses [`config`] to write and read a file.
 
 pub use zng_env::{

--- a/crates/zng/src/env.rs
+++ b/crates/zng/src/env.rs
@@ -24,5 +24,5 @@
 //! uses [`config`] to write and read a file.
 
 pub use zng_env::{
-    app_unique_name, bin, cache, clear_cache, config, init, init_cache, init_config, init_res, migrate_cache, migrate_config, res,
+    about, bin, cache, clear_cache, config, init, init_cache, init_config, init_res, migrate_cache, migrate_config, res, About,
 };

--- a/crates/zng/src/third_party.rs
+++ b/crates/zng/src/third_party.rs
@@ -165,7 +165,7 @@ pub(crate) fn setup_default_view() {
                     }
 
                     Window! {
-                        title = APP.about().map(|i| formatx!("{}Third Party Licenses", i.title_prefix()));
+                        title = formatx!("{} - Third Party Licenses", zng::env::about().app);
                         child = default_view();
                         parent;
                     }


### PR DESCRIPTION
This change is part of an effort to unify the source of app metadata for 'cargo-zng res' to parse and make available for tools.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->