### PR TITLE
Refactor crash_handler to use on_process_start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@
 * **Breaking** Renamed `zng_view_prebuilt::ViewLib::init` to `view_process_main`.
 * **Breaking** Remove `is_single_instance`, `single_instance`, `single_instance_named`.
     - Single instance now enabled automatically just by setting `feature="single_instance"`.
-* **Braking** Add name requirement for `zng::task::ipc` workers.
+* **Breaking** Add name requirement for `zng::task::ipc` workers.
     - Workers are no longer limited to a single entry with an enum switch.
     - Use `zng::env::on_process_start!` to declare the worker entry anywhere.
+* **Breaking** Remove `zng::app::crash_handler::init` and `CrashConfig::new`.
+    - Use `zng::app::crash_handler::crash_handler_config` to config.
 
 # 0.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Implement `From<Txt>` for `std::ffi::OsString`.
 * **Breaking** Remove `zng_view::init`, `zng_view_prebuilt::init`, `zng::view_process::default::init`, `zng::view_process::prebuilt::init`.
     - Only `zng::env::init!()` needs to be called to setup the view-process.
+* **Breaking** Remove `zng_view::extensions::ViewExtensions::new`.
+    - Now use `zng_view::view_process_extension!` to declare.
 * **Breaking** `zng_view_api::Controller::start` now requires the exe path and supports optional env variables to set.
     - This only affects custom view-process implementers.
 * **Breaking** New default `zng::env::res`, was `./assets` now is `./res`.

--- a/crates/zng-app/Cargo.toml
+++ b/crates/zng-app/Cargo.toml
@@ -56,8 +56,6 @@ trace_widget = []
 trace_wgt_item = []
 
 # Allow app-process crash handler.
-#
-# Note that `crash_handler::init(_)` must be called to enable.
 crash_handler = ["dep:serde_json", "dep:breakpad-handler", "dep:minidump", "dep:linkme"]
 
 # Enables IPC tasks and pre-build views and connecting to views running in another process.

--- a/crates/zng-app/Cargo.toml
+++ b/crates/zng-app/Cargo.toml
@@ -58,7 +58,7 @@ trace_wgt_item = []
 # Allow app-process crash handler.
 #
 # Note that `crash_handler::init(_)` must be called to enable.
-crash_handler = ["dep:serde_json", "dep:breakpad-handler", "dep:minidump"]
+crash_handler = ["dep:serde_json", "dep:breakpad-handler", "dep:minidump", "dep:linkme"]
 
 # Enables IPC tasks and pre-build views and connecting to views running in another process.
 ipc = ["zng-view-api/ipc", "zng-task/ipc"]
@@ -105,6 +105,7 @@ unicase = "2.7"
 serde_json = { version = "1.0", optional = true }
 breakpad-handler = { version = "0.2", optional = true }
 minidump = { version = "0.21", optional = true }
+linkme = { version = "=0.3.26", optional = true }
 
 dunce = "1.0"
 

--- a/crates/zng-app/README.md
+++ b/crates/zng-app/README.md
@@ -52,8 +52,6 @@ Note that this can cause very large trace files and bad performance.
 #### `"crash_handler"`
 Allow app-process crash handler.
 
-Note that `crash_handler::init(_)` must be called to enable.
-
 *Enabled by default.*
 
 #### `"ipc"`

--- a/crates/zng-app/src/crash_handler.rs
+++ b/crates/zng-app/src/crash_handler.rs
@@ -15,7 +15,7 @@ use zng_layout::unit::TimeUnits as _;
 
 use zng_txt::{ToTxt as _, Txt};
 
-zng_env::on_process_start!(|_| {
+zng_env::on_process_start!(|process_start_args| {
     let mut config = CrashConfig::new();
     for ext in CRASH_CONFIG {
         ext(&mut config);
@@ -38,6 +38,11 @@ zng_env::on_process_start!(|_| {
             std::env::VarError::NotPresent => {}
             e => panic!("invalid dialog env args, {e:?}"),
         },
+    }
+
+    if process_start_args.next_handlers_count > 0 && process_start_args.yield_count < zng_env::ProcessStartArgs::MAX_YIELD_COUNT - 10 {
+        // extra sure that this is the app-process
+        return process_start_args.yield_once();
     }
 
     crash_handler_monitor_process(

--- a/crates/zng-app/src/crash_handler.rs
+++ b/crates/zng-app/src/crash_handler.rs
@@ -15,26 +15,37 @@ use zng_layout::unit::TimeUnits as _;
 
 use zng_txt::{ToTxt as _, Txt};
 
-/// Starts the current app-process in a monitored instance.
-///
-/// This function takes over the first process turning it into the monitor-process, it spawns another process that
-/// is the monitored app-process. If the app-process crashes it spawns a dialog-process that calls the dialog handler
-/// to show an error message, upload crash reports, etc.
-pub fn init(config: CrashConfig) {
+zng_env::on_process_start!(|_| {
+    let mut config = CrashConfig::new();
+    for ext in CRASH_CONFIG {
+        ext(&mut config);
+    }
+
     if std::env::var(APP_PROCESS) != Err(std::env::VarError::NotPresent) {
         return crash_handler_app_process(config.dump_dir.as_deref());
     }
 
     match std::env::var(DIALOG_PROCESS) {
-        Ok(args_file) => crash_handler_dialog_process(config.dump_dir.as_deref(), config.dialog, args_file),
+        Ok(args_file) => crash_handler_dialog_process(
+            config.dump_dir.as_deref(),
+            config
+                .dialog
+                .or(config.default_dialog)
+                .expect("dialog-process spawned without dialog handler"),
+            args_file,
+        ),
         Err(e) => match e {
             std::env::VarError::NotPresent => {}
             e => panic!("invalid dialog env args, {e:?}"),
         },
     }
 
-    crash_handler_monitor_process(config.cfg_app, config.cfg_dialog);
-}
+    crash_handler_monitor_process(
+        config.app_process,
+        config.dialog_process,
+        config.default_dialog.is_some() || config.dialog.is_some(),
+    );
+});
 
 /// Gets the number of crash restarts in the app-process.
 ///
@@ -50,61 +61,119 @@ const APP_PROCESS: &str = "ZNG_CRASH_HANDLER_APP";
 const DIALOG_PROCESS: &str = "ZNG_CRASH_HANDLER_DIALOG";
 const RESPONSE_PREFIX: &str = "zng_crash_response: ";
 
+#[linkme::distributed_slice]
+static CRASH_CONFIG: [fn(&mut CrashConfig)];
+
+/// <span data-del-macro-root></span> Register a `FnOnce(&mut CrashConfig)` closure to be
+/// called on process init to configure the crash handler.
+///
+/// See [`CrashConfig`] for more details.
+#[macro_export]
+macro_rules! crash_handler_config {
+    ($closure:expr) => {
+        #[used]
+        #[cfg_attr(
+            any(
+                target_os = "none",
+                target_os = "linux",
+                target_os = "android",
+                target_os = "fuchsia",
+                target_os = "psp"
+            ),
+            link_section = "linkme_CRASH_CONFIG"
+        )]
+        #[cfg_attr(
+            any(target_os = "macos", target_os = "ios", target_os = "tvos"),
+            link_section = "__DATA,__linkmeK3uV0Fq0,regular,no_dead_strip"
+        )]
+        #[cfg_attr(target_os = "windows", link_section = ".linkme_CRASH_CONFIG$b")]
+        #[cfg_attr(target_os = "illumos", link_section = "set_linkme_CRASH_CONFIG")]
+        #[cfg_attr(target_os = "freebsd", link_section = "linkme_CRASH_CONFIG")]
+        #[doc(hidden)]
+        static _CRASH_CONFIG: fn(&mut $crate::crash_handler::CrashConfig) = _crash_config;
+        #[doc(hidden)]
+        fn _crash_config(cfg: &mut $crate::crash_handler::CrashConfig) {
+            fn crash_config(cfg: &mut $crate::crash_handler::CrashConfig, handler: impl FnOnce(&mut $crate::crash_handler::CrashConfig)) {
+                handler(cfg)
+            }
+            crash_config(cfg, $closure)
+        }
+    };
+}
+pub use crate::crash_handler_config;
+
 type ConfigProcess = Vec<Box<dyn for<'a, 'b> FnMut(&'a mut std::process::Command, &'b CrashArgs) -> &'a mut std::process::Command>>;
+type CrashDialogHandler = Box<dyn FnOnce(CrashArgs)>;
 
 /// Crash handler config.
+///
+/// Use [`crash_handler_config!`] to set config.
+///
+/// [`crash_handler_config!`]: crate::crash_handler_config!
 pub struct CrashConfig {
-    dialog: fn(CrashArgs) -> !,
-    cfg_app: ConfigProcess,
-    cfg_dialog: ConfigProcess,
+    default_dialog: Option<CrashDialogHandler>,
+    dialog: Option<CrashDialogHandler>,
+    app_process: ConfigProcess,
+    dialog_process: ConfigProcess,
     dump_dir: Option<PathBuf>,
 }
 impl CrashConfig {
-    /// New with function called in the dialog-process.
-    pub fn new(dialog: fn(CrashArgs) -> !) -> Self {
+    fn new() -> Self {
         Self {
-            dialog,
-            cfg_app: vec![],
-            cfg_dialog: vec![],
-            dump_dir: Some(std::env::temp_dir().join("zng_minidump")),
+            default_dialog: None,
+            dialog: None,
+            app_process: vec![],
+            dialog_process: vec![],
+            dump_dir: Some(zng_env::cache("zng_minidump")),
         }
     }
 
+    /// Set the crash dialog process handler.
+    ///
+    /// The dialog `handler` can run an app or show a native dialog, it must use the [`CrashArgs`] process
+    /// terminating methods to respond, if it returns [`CrashArgs::exit`] will run.
+    ///
+    /// Note that the handler does not need to actually show any dialog, it can just save crash info and
+    /// restart the app for example.
+    pub fn dialog(&mut self, handler: impl FnOnce(CrashArgs) + 'static) {
+        if self.dialog.is_none() {
+            self.dialog = Some(Box::new(handler));
+        }
+    }
+
+    /// Set the crash dialog-handler used if `crash_dialog` is not set.
+    ///
+    /// This is used by app libraries or themes to provide a default dialog.
+    pub fn default_dialog(&mut self, handler: impl FnOnce(CrashArgs) + 'static) {
+        self.default_dialog = Some(Box::new(handler));
+    }
+
     /// Add a closure that is called just before the app-process is spawned.
-    pub fn cfg_app(
-        mut self,
+    pub fn app_process(
+        &mut self,
         cfg: impl for<'a, 'b> FnMut(&'a mut std::process::Command, &'b CrashArgs) -> &'a mut std::process::Command + 'static,
-    ) -> Self {
-        self.cfg_app.push(Box::new(cfg));
-        self
+    ) {
+        self.app_process.push(Box::new(cfg));
     }
 
     /// Add a closure that is called just before the dialog-process is spawned.
-    pub fn cfg_dialog(
-        mut self,
+    pub fn dialog_process(
+        &mut self,
         cfg: impl for<'a, 'b> FnMut(&'a mut std::process::Command, &'b CrashArgs) -> &'a mut std::process::Command + 'static,
-    ) -> Self {
-        self.cfg_dialog.push(Box::new(cfg));
-        self
+    ) {
+        self.dialog_process.push(Box::new(cfg));
     }
 
     /// Change the minidump directory.
     ///
-    /// Is the temp dir by default.
-    pub fn minidump_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+    /// Is `zng::env::cache("zng_minidump")` by default.
+    pub fn minidump_dir(&mut self, dir: impl Into<PathBuf>) {
         self.dump_dir = Some(dir.into());
-        self
     }
 
     /// Do not collect a minidump.
-    pub fn no_minidump(mut self) -> Self {
+    pub fn no_minidump(&mut self) {
         self.dump_dir = None;
-        self
-    }
-}
-impl From<fn(CrashArgs) -> !> for CrashConfig {
-    fn from(dialog: fn(CrashArgs) -> !) -> Self {
-        Self::new(dialog)
     }
 }
 
@@ -683,7 +752,7 @@ impl BacktraceFrame {
     }
 }
 
-fn crash_handler_monitor_process(mut cfg_app: ConfigProcess, mut cfg_dialog: ConfigProcess) -> ! {
+fn crash_handler_monitor_process(mut cfg_app: ConfigProcess, mut cfg_dialog: ConfigProcess, has_dialog_handler: bool) -> ! {
     // monitor-process:
     tracing::info!("crash monitor-process is running");
 
@@ -797,11 +866,15 @@ fn crash_handler_monitor_process(mut cfg_app: ConfigProcess, mut cfg_dialog: Con
                             retries += 1;
                         };
 
-                        let mut dialog_process = std::process::Command::new(&exe);
-                        for cfg in &mut cfg_dialog {
-                            cfg(&mut dialog_process, &dialog_args);
-                        }
-                        let dialog_result = run_process(dialog_process.env(DIALOG_PROCESS, &crash_file));
+                        let dialog_result = if has_dialog_handler {
+                            let mut dialog_process = std::process::Command::new(&exe);
+                            for cfg in &mut cfg_dialog {
+                                cfg(&mut dialog_process, &dialog_args);
+                            }
+                            run_process(dialog_process.env(DIALOG_PROCESS, &crash_file))
+                        } else {
+                            Ok((std::process::ExitStatus::default(), [String::new(), String::new()]))
+                        };
 
                         for _ in 0..5 {
                             if !crash_file.exists() || std::fs::remove_file(&crash_file).is_ok() {
@@ -817,7 +890,7 @@ fn crash_handler_monitor_process(mut cfg_app: ConfigProcess, mut cfg_dialog: Con
                                         .lines()
                                         .filter_map(|l| l.trim().strip_prefix(RESPONSE_PREFIX))
                                         .last()
-                                        .expect("crash dialog-process did not respond correctly")
+                                        .unwrap_or("exit 0")
                                         .to_owned()
                                 } else {
                                     let code = dlg_status.code();
@@ -955,7 +1028,7 @@ fn crash_handler_app_process(dump_dir: Option<&Path>) {
     // app-process execution happens after the `crash_handler` function returns.
 }
 
-fn crash_handler_dialog_process(dump_dir: Option<&Path>, dialog: fn(CrashArgs) -> !, args_file: String) -> ! {
+fn crash_handler_dialog_process(dump_dir: Option<&Path>, dialog: CrashDialogHandler, args_file: String) -> ! {
     tracing::info!("crash dialog-process is running");
 
     std::panic::set_hook(Box::new(panic_handler));
@@ -977,7 +1050,12 @@ fn crash_handler_dialog_process(dump_dir: Option<&Path>, dialog: fn(CrashArgs) -
         }
     };
 
-    dialog(serde_json::from_str(&args).expect("error deserializing args"))
+    dialog(serde_json::from_str(&args).expect("error deserializing args"));
+    CrashArgs {
+        app_crashes: vec![],
+        dialog_crash: None,
+    }
+    .exit(0)
 }
 
 fn panic_handler(info: &std::panic::PanicInfo) {

--- a/crates/zng-ext-single-instance/src/lib.rs
+++ b/crates/zng-ext-single-instance/src/lib.rs
@@ -36,10 +36,7 @@ impl AppExtension for SingleInstanceManager {
 
         let name = match SINGLE_INSTANCE.lock().as_ref().map(|l| l.name.clone()) {
             Some(n) => n,
-            None => {
-                tracing::error!("single instance did not setup correctly on_process_start! app is not running in single instance mode");
-                return;
-            }
+            None => return, // app is running in a special process, like a crash dialog
         };
 
         let args_file = std::env::temp_dir().join(name);

--- a/crates/zng-view/src/extensions.rs
+++ b/crates/zng-view/src/extensions.rs
@@ -660,14 +660,13 @@ pub struct RendererCommandArgs<'a> {
 }
 
 /// View extensions register.
-#[derive(Default)]
 pub struct ViewExtensions {
     exts: Vec<Box<dyn ViewExtension>>,
 }
 impl ViewExtensions {
     /// New empty.
-    pub fn new() -> Self {
-        Self::default()
+    pub(crate) fn new() -> Self {
+        Self { exts: vec![] }
     }
 
     /// Register an extension with the ID that will be assigned to it.
@@ -1083,15 +1082,15 @@ impl AsyncBlobImageRasterizer for BlockExtensionsImgRasterizer {
     }
 }
 
-/// Register a `fn() -> ViewExtensions` to be called on view-process init to inject custom API extensions.
+/// Register a `FnOnce(&mut ViewExtensions)` closure to be called on view-process init to inject custom API extensions.
 ///
 /// See [`ViewExtensions`] for more details.
 #[macro_export]
 macro_rules! view_process_extension {
-    ($extension_fn:path) => {
+    ($closure:expr) => {
         // expanded from:
         // #[linkme::distributed_slice(ZNG_ENV_RUN_PROCESS)]
-        // static _VIEW_EXTENSIONS = fn() -> $crate::extensions::ViewExtensions = $extension_fn;
+        // static _VIEW_EXTENSIONS = fn...;
         // so that users don't need to depend on linkme just to call this macro.
         #[used]
         #[cfg_attr(
@@ -1112,10 +1111,19 @@ macro_rules! view_process_extension {
         #[cfg_attr(target_os = "illumos", link_section = "set_linkme_VIEW_EXTENSIONS")]
         #[cfg_attr(target_os = "freebsd", link_section = "linkme_VIEW_EXTENSIONS")]
         #[doc(hidden)]
-        static _VIEW_EXTENSIONS: fn() -> $crate::extensions::ViewExtensions = $extension_fn;
+        static _VIEW_EXTENSIONS: fn(&mut $crate::extensions::ViewExtensions) = _view_extensions;
+        fn _view_extensions(ext: &mut $crate::extensions::ViewExtensions) {
+            fn view_extensions(
+                ext: &mut $crate::extensions::ViewExtensions,
+                handler: impl FnOnce(&mut $crate::extensions::ViewExtensions),
+            ) {
+                handler(ext)
+            }
+            view_extensions(ext, $closure)
+        }
     };
 }
 
 #[doc(hidden)]
 #[linkme::distributed_slice]
-pub static VIEW_EXTENSIONS: [fn() -> ViewExtensions];
+pub static VIEW_EXTENSIONS: [fn(&mut ViewExtensions)];

--- a/crates/zng-view/src/extensions.rs
+++ b/crates/zng-view/src/extensions.rs
@@ -1112,6 +1112,7 @@ macro_rules! view_process_extension {
         #[cfg_attr(target_os = "freebsd", link_section = "linkme_VIEW_EXTENSIONS")]
         #[doc(hidden)]
         static _VIEW_EXTENSIONS: fn(&mut $crate::extensions::ViewExtensions) = _view_extensions;
+        #[doc(hidden)]
         fn _view_extensions(ext: &mut $crate::extensions::ViewExtensions) {
             fn view_extensions(
                 ext: &mut $crate::extensions::ViewExtensions,

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -171,7 +171,7 @@ pub fn view_process_main() {
 
     let mut ext = ViewExtensions::new();
     for e in extensions::VIEW_EXTENSIONS {
-        ext.append(e());
+        e(&mut ext);
     }
 
     if config.headless {

--- a/crates/zng/Cargo.toml
+++ b/crates/zng/Cargo.toml
@@ -82,7 +82,7 @@ single_instance = ["dep:zng-ext-single-instance"]
 
 # Allow app-process crash handler.
 #
-# Note that `zng::app::crash_handler::init(_)` must be called to enable.
+# Builds with this feature spawn a crash monitor-process for each app-process.
 crash_handler = ["zng-app/crash_handler", "zng-wgt-inspector/crash_handler"]
 
 # Instrument every widget outer-most node to trace UI methods.

--- a/crates/zng/README.md
+++ b/crates/zng/README.md
@@ -106,7 +106,7 @@ the running app-process.
 #### `"crash_handler"`
 Allow app-process crash handler.
 
-Note that `zng::app::crash_handler::init(_)` must be called to enable.
+Builds with this feature spawn a crash monitor-process for each app-process.
 
 *Enabled by default.*
 

--- a/crates/zng/src/app.rs
+++ b/crates/zng/src/app.rs
@@ -441,7 +441,7 @@ pub use zng_ext_single_instance::{AppInstanceArgs, APP_INSTANCE_EVENT};
 ///
 /// The dialog handler can be set using [`crash_handler_config!`].
 ///
-/// [`crash_handler_config`]: crate::app::crash_handler::crash_handler_config!
+/// [`crash_handler_config!`]: crate::app::crash_handler::crash_handler_config
 ///
 /// # Examples
 ///

--- a/crates/zng/src/app.rs
+++ b/crates/zng/src/app.rs
@@ -435,13 +435,17 @@ pub use zng_ext_single_instance::{AppInstanceArgs, APP_INSTANCE_EVENT};
 
 /// App-process crash handler.
 ///
-/// The [`zng::app::crash_handler::init`] function takes over the first process turning it into the monitor-process,
-/// it spawns another process that is the monitored app-process. If the app-process crashes the monitor-process spawns a
-/// dialog-process that calls the dialog handler to show an error message, upload crash reports, etc.
+/// In builds with `"crash_handler"` feature the crash handler takes over the first "app-process" turning it into
+/// the monitor-process, it spawns another process that is the monitored app-process. If the app-process crashes
+/// the monitor-process spawns a dialog-process that calls the dialog handler to show an error message, upload crash reports, etc.
+///
+/// The dialog handler can be set using [`crash_handler_config!`].
+///
+/// [`crash_handler_config`]: crate::app::crash_handler::crash_handler_config!
 ///
 /// # Examples
 ///
-/// The example below demonstrates an app setup to handle crashes in the app-process.
+/// The example below demonstrates an app setup to show a custom crash dialog.
 ///
 /// ```no_run
 /// use zng::prelude::*;
@@ -449,21 +453,11 @@ pub use zng_ext_single_instance::{AppInstanceArgs, APP_INSTANCE_EVENT};
 /// fn main() {
 ///     // tracing applied to all processes.
 ///     zng::app::print_tracing(tracing::Level::INFO);
+///
+///     // monitor-process spawns app-process and if needed dialog-process here.
 ///     zng::env::init!();
-///     
-///     // monitor-process or dialog-process init.
-///     //
-///     // Note that the dialog-process will use the same view-process init. Alternatively you
-///     // can call this before the view-process init and then init a custom view_process just
-///     // for the dialog or don't use Zng for the dialog.
-///     #[cfg(debug_assertions)]
-///     zng::app::crash_handler::init_debug();
-///     #[cfg(not(debug_assertions))]
-///     zng::app::crash_handler::init(zng::app::crash_handler::CrashConfig::new(dialog_main));
 ///
-///     // normal app-process
-///
-///     // zng::app::single_instance();
+///     // app-process:
 ///     app_main();
 /// }
 ///
@@ -497,40 +491,44 @@ pub use zng_ext_single_instance::{AppInstanceArgs, APP_INSTANCE_EVENT};
 ///     });
 /// }
 ///
-/// #[cfg(not(debug_assertions))]
-/// fn dialog_main(args: zng::app::crash_handler::CrashArgs) -> ! {
-///     APP.defaults().run_window(async move {
-///         Window! {
-///             title = "App Crashed!";
-///             auto_size = true;
-///             min_size = (300, 100);
-///             start_position = window::StartPosition::CenterMonitor;
-///             on_load = hn_once!(|_| WINDOW.bring_to_top());
-///             padding = 10;
-///             child = Text!(args.latest().message());
-///             child_bottom = Stack! {
-///                 direction = StackDirection::start_to_end();
-///                 layout::align = Align::BOTTOM_END;
-///                 spacing = 5;
-///                 children = ui_vec![
-///                     Button! {
-///                         child = Text!("Restart App");
-///                         on_click = hn_once!(args, |_| {
-///                             args.restart();
-///                         });
-///                     },
-///                     Button! {
-///                         child = Text!("Exit App");
-///                         on_click = hn_once!(|_| {
-///                             args.exit(0);
-///                         });
-///                     },
-///                 ]
-///             }, 10;
-///         }
+/// zng::app::crash_handler::crash_handler_config!(|cfg| {
+///     // monitor-process and dialog-process
+///
+///     cfg.dialog(|args| {
+///         // dialog-process
+///         APP.defaults().run_window(async move {
+///             Window! {
+///                 title = "App Crashed!";
+///                 auto_size = true;
+///                 min_size = (300, 100);
+///                 start_position = window::StartPosition::CenterMonitor;
+///                 on_load = hn_once!(|_| WINDOW.bring_to_top());
+///                 padding = 10;
+///                 child = Text!(args.latest().message());
+///                 child_bottom = Stack! {
+///                     direction = StackDirection::start_to_end();
+///                     layout::align = Align::BOTTOM_END;
+///                     spacing = 5;
+///                     children = ui_vec![
+///                         Button! {
+///                             child = Text!("Restart App");
+///                             on_click = hn_once!(args, |_| {
+///                                 args.restart();
+///                             });
+///                         },
+///                         Button! {
+///                             child = Text!("Exit App");
+///                             on_click = hn_once!(|_| {
+///                                 args.exit(0);
+///                             });
+///                         },
+///                     ]
+///                 }, 10;
+///             }
+///         });
 ///     });
-///     zng::env::exit(0)
-/// }
+/// });
+///
 /// ```
 ///
 /// # Full API
@@ -538,28 +536,25 @@ pub use zng_ext_single_instance::{AppInstanceArgs, APP_INSTANCE_EVENT};
 /// See [`zng_app::crash_handler`] and [`zng_wgt_inspector::crash_handler`] for the full API.
 #[cfg(feature = "crash_handler")]
 pub mod crash_handler {
-    use crate::prelude::*;
-    pub use zng_app::crash_handler::{init, BacktraceFrame, CrashArgs, CrashConfig, CrashError, CrashPanic};
+    pub use zng_app::crash_handler::{crash_handler_config, BacktraceFrame, CrashArgs, CrashConfig, CrashError, CrashPanic};
 
     pub use zng_wgt_inspector::crash_handler::debug_dialog;
 
-    /// Init a crash-handler with dialog that shows detailed debug info.
-    pub fn init_debug() {
-        init(CrashConfig::new(debug_app))
-    }
+    crash_handler_config!(|cfg| {
+        use crate::prelude::*;
+        cfg.default_dialog(|args| {
+            if let Some(c) = &args.dialog_crash {
+                eprintln!("DEBUG CRASH DIALOG ALSO CRASHED");
+                eprintln!("   {}", c.message());
+                eprintln!("ORIGINAL APP CRASH");
+                eprintln!("   {}", args.latest().message());
+                args.exit(0xBADC0DE)
+            }
 
-    fn debug_app(args: CrashArgs) -> ! {
-        if let Some(c) = &args.dialog_crash {
-            eprintln!("DEBUG CRASH DIALOG ALSO CRASHED");
-            eprintln!("   {}", c.message());
-            eprintln!("ORIGINAL APP CRASH");
-            eprintln!("   {}", args.latest().message());
-            args.exit(0xBADC0DE)
-        }
+            APP.defaults()
+                .run_window(async_clmv!(args, { zng_wgt_inspector::crash_handler::debug_dialog(args) }));
 
-        APP.defaults()
-            .run_window(async_clmv!(args, { zng_wgt_inspector::crash_handler::debug_dialog(args) }));
-
-        args.exit(0)
-    }
+            args.exit(0)
+        });
+    });
 }

--- a/crates/zng/src/lib.rs
+++ b/crates/zng/src/lib.rs
@@ -448,8 +448,8 @@
 //! fire-and-forget task runners will also just log the panic as an error.
 //!
 //! You can also use the [`zng::app::crash_handler`] to collect panic backtraces, crash minidumps, show a crash dialog to the user
-//! and restart the app. During development you can use [`zng::app::crash_handler::init_debug`] to quickly setup a crash dialog that
-//! helps you debug the app.
+//! and restart the app. During development a debug crash dialog is provided, it shows the stdout/stderr, panics stacktrace and
+//! minidumps collected if any non-panic fatal error happens.
 //!
 //! [`tracing`]: https://docs.rs/tracing
 //!

--- a/examples/README.md
+++ b/examples/README.md
@@ -302,13 +302,8 @@ zng = { path = "../../crates/zng", features = ["view_prebuilt"] }
 use zng::prelude::*;
 
 fn main() {
-    examples_util::print_info();
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
 
-fn app_main() {
     APP.defaults().run_window(async {
         Window! {
             title = "Foo Example";

--- a/examples/animation/src/main.rs
+++ b/examples/animation/src/main.rs
@@ -15,11 +15,7 @@ use widgets::{ease_btn, ruler};
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
 
-fn app_main() {
     APP.defaults().run_window(async {
         Window! {
             title = "Animation Example";

--- a/examples/border/src/main.rs
+++ b/examples/border/src/main.rs
@@ -9,11 +9,7 @@ mod widgets;
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
 
-fn app_main() {
     APP.defaults().run_window(async {
         Window! {
             title = "Border Example";

--- a/examples/button/src/main.rs
+++ b/examples/button/src/main.rs
@@ -13,11 +13,7 @@ use zng::{
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
 
-fn app_main() {
     APP.defaults().run_window(async {
         Window! {
             title = "Button Example";

--- a/examples/calculator/src/main.rs
+++ b/examples/calculator/src/main.rs
@@ -8,11 +8,7 @@ use zng::{
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
 
-fn app_main() {
     APP.defaults().run_window(async {
         set_fallback_font().await;
 

--- a/examples/config/src/main.rs
+++ b/examples/config/src/main.rs
@@ -12,9 +12,8 @@ use zng::{
 use zng::config::*;
 
 fn main() {
-    zng::env::init!();
     zng::env::init_res(concat!(env!("CARGO_MANIFEST_DIR"), "/res"));
-    zng::app::crash_handler::init_debug();
+    zng::env::init!();
     app_main();
 }
 

--- a/examples/countdown/src/main.rs
+++ b/examples/countdown/src/main.rs
@@ -5,7 +5,6 @@ use zng::{image, prelude::*, widget::background_color};
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
 
     // record profiler, use chrome://tracing or <ui.perfetto.dev>.
     let (chrome_layer, _guard) = tracing_chrome::ChromeLayerBuilder::new().build();

--- a/examples/cursor/src/main.rs
+++ b/examples/cursor/src/main.rs
@@ -12,11 +12,7 @@ mod widgets;
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
 
-fn app_main() {
     APP.defaults().run_window(async {
         let mut demos = ui_vec![];
         for icon in CURSORS {

--- a/examples/extend-view/src/get_window_handle.rs
+++ b/examples/extend-view/src/get_window_handle.rs
@@ -36,12 +36,12 @@ pub mod app_side {
 /// View-process stuff, the actual extension.
 pub mod view_side {
     use zng::text::formatx;
-    use zng_view::extensions::{ViewExtensions, WindowExtension};
+    use zng_view::extensions::WindowExtension;
     use zng_view_api::api_extension::{ApiExtensionId, ApiExtensionPayload};
 
-    pub fn extend(exts: &mut ViewExtensions) {
+    zng_view::view_process_extension!(|exts| {
         exts.window(super::api::extension_name(), CustomExtension::new);
-    }
+    });
 
     struct CustomExtension {
         id: ApiExtensionId,

--- a/examples/extend-view/src/main.rs
+++ b/examples/extend-view/src/main.rs
@@ -1,7 +1,6 @@
 //! Demonstrates the `zng-view` extension API and render extensions API.
 
 use zng::{color::filter::hue_rotate, layout::size, prelude::*};
-use zng_view::extensions::ViewExtensions;
 // use zng_wgt_webrender_debug as wr;
 
 // Examples of how to extend the view-process with custom renderers.
@@ -13,19 +12,6 @@ fn main() {
     zng::env::init!();
     zng::app::crash_handler::init_debug();
     app_main();
-}
-
-zng_view::view_process_extension!(view_extensions);
-
-/// Called in the view-process to init extensions.
-fn view_extensions() -> ViewExtensions {
-    let mut exts = ViewExtensions::new();
-    get_window_handle::view_side::extend(&mut exts);
-    using_display_items::view_side::extend(&mut exts);
-    using_blob::view_side::extend(&mut exts);
-    using_gl_overlay::view_side::extend(&mut exts);
-    using_gl_texture::view_side::extend(&mut exts);
-    exts
 }
 
 mod get_window_handle;

--- a/examples/extend-view/src/main.rs
+++ b/examples/extend-view/src/main.rs
@@ -10,7 +10,6 @@ use zng::{color::filter::hue_rotate, layout::size, prelude::*};
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
     app_main();
 }
 

--- a/examples/extend-view/src/using_blob.rs
+++ b/examples/extend-view/src/using_blob.rs
@@ -28,7 +28,7 @@ pub mod view_side {
     use zng::prelude::task::parking_lot::Mutex;
     use zng_view::extensions::PxToWr as _;
     use zng_view::{
-        extensions::{AsyncBlobRasterizer, BlobExtension, RenderItemArgs, RenderUpdateArgs, RendererExtension, ViewExtensions},
+        extensions::{AsyncBlobRasterizer, BlobExtension, RenderItemArgs, RenderUpdateArgs, RendererExtension},
         webrender::{
             api::{
                 units::{BlobDirtyRect, DeviceIntRect, DeviceIntSize, LayoutRect},
@@ -40,9 +40,9 @@ pub mod view_side {
     };
     use zng_view_api::api_extension::ApiExtensionId;
 
-    pub fn extend(exts: &mut ViewExtensions) {
+    zng_view::view_process_extension!(|exts| {
         exts.renderer(super::api::extension_name(), CustomExtension::new);
-    }
+    });
 
     struct CustomExtension {
         // id of this extension, for tracing.

--- a/examples/extend-view/src/using_display_items.rs
+++ b/examples/extend-view/src/using_display_items.rs
@@ -125,7 +125,7 @@ pub mod view_side {
 
     use zng::prelude_wgt::PxPoint;
     use zng_view::{
-        extensions::{PxToWr as _, RenderItemArgs, RenderUpdateArgs, RendererExtension, ViewExtensions},
+        extensions::{PxToWr as _, RenderItemArgs, RenderUpdateArgs, RendererExtension},
         webrender::{
             api::{
                 units::{LayoutPoint, LayoutRect},
@@ -136,9 +136,9 @@ pub mod view_side {
     };
     use zng_view_api::api_extension::ApiExtensionId;
 
-    pub fn extend(exts: &mut ViewExtensions) {
+    zng_view::view_process_extension!(|exts| {
         exts.renderer(super::api::extension_name(), CustomExtension::new);
-    }
+    });
 
     struct CustomExtension {
         // id of this extension, for tracing.

--- a/examples/extend-view/src/using_gl_overlay.rs
+++ b/examples/extend-view/src/using_gl_overlay.rs
@@ -24,16 +24,16 @@ pub mod app_side {
 pub mod view_side {
     use zng::layout::{Px, PxPoint, PxRect, PxSize};
     use zng_view::{
-        extensions::{RenderItemArgs, RenderUpdateArgs, RendererExtension, ViewExtensions},
+        extensions::{RenderItemArgs, RenderUpdateArgs, RendererExtension},
         gleam::gl,
     };
     use zng_view_api::api_extension::ApiExtensionId;
 
     use super::api::BindingId;
 
-    pub fn extend(exts: &mut ViewExtensions) {
+    zng_view::view_process_extension!(|exts| {
         exts.renderer(super::api::extension_name(), CustomExtension::new);
-    }
+    });
 
     struct CustomExtension {
         // id of this extension, for tracing.

--- a/examples/extend-view/src/using_gl_texture.rs
+++ b/examples/extend-view/src/using_gl_texture.rs
@@ -24,7 +24,7 @@ pub mod app_side {
 pub mod view_side {
     use zng::layout::PxRect;
     use zng_view::{
-        extensions::{PxToWr as _, RenderItemArgs, RendererExtension, ViewExtensions},
+        extensions::{PxToWr as _, RenderItemArgs, RendererExtension},
         gleam::gl,
         webrender::api::{
             units::{DeviceIntSize, TexelRect},
@@ -34,9 +34,9 @@ pub mod view_side {
     };
     use zng_view_api::api_extension::ApiExtensionId;
 
-    pub fn extend(exts: &mut ViewExtensions) {
+    zng_view::view_process_extension!(|exts| {
         exts.renderer(super::api::extension_name(), CustomExtension::new);
-    }
+    });
 
     struct TextureInfo {
         // texture in OpenGL.

--- a/examples/focus/src/main.rs
+++ b/examples/focus/src/main.rs
@@ -20,11 +20,7 @@ use zng::{
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
 
-fn app_main() {
     APP.defaults().run_window(async {
         WINDOW.id().set_name("main").unwrap();
 

--- a/examples/gradient/src/main.rs
+++ b/examples/gradient/src/main.rs
@@ -13,11 +13,7 @@ use zng::{
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
 
-fn app_main() {
     APP.defaults().run_window(async {
         Window! {
             title = "Gradient Example";

--- a/examples/hot-reload/src/main.rs
+++ b/examples/hot-reload/src/main.rs
@@ -6,11 +6,7 @@ use zng::prelude::*;
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
 
-fn app_main() {
     // examples/Cargo.toml enables the `"hot_reload"` feature for `zng`,
     // so the hot reload extension is available in `APP.defaults()`.
     APP.defaults().run_window(async {

--- a/examples/icon/src/main.rs
+++ b/examples/icon/src/main.rs
@@ -24,11 +24,7 @@ use zng::{
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
 
-fn app_main() {
     APP.defaults().run_window(async {
         Window! {
             title = "Icon Example";

--- a/examples/image/src/main.rs
+++ b/examples/image/src/main.rs
@@ -22,13 +22,9 @@ use zng::{
 use zng_wgt_webrender_debug as wr;
 
 fn main() {
-    zng::env::init!();
     zng::env::init_res(concat!(env!("CARGO_MANIFEST_DIR"), "/res"));
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
+    zng::env::init!();
 
-fn app_main() {
     APP.defaults().run_window(async {
         // by default all "ImageSource::Download" requests are blocked and "ImageSource::Read"
         // is limited to only the exe dir. The limits can be set globally in here and overridden 

--- a/examples/layer/src/main.rs
+++ b/examples/layer/src/main.rs
@@ -12,11 +12,7 @@ use zng::{
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
 
-fn app_main() {
     APP.defaults().run_window(async {
         // layer will init with the window, when it opens.
         LAYERS.insert(

--- a/examples/localize/src/main.rs
+++ b/examples/localize/src/main.rs
@@ -24,13 +24,9 @@ use zng::{
 // cargo run -p cargo-zng -- zng l10n "examples/localize/src" "examples/localize/res"
 
 fn main() {
-    zng::env::init!();
     zng::env::init_res(concat!(env!("CARGO_MANIFEST_DIR"), "/res"));
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
+    zng::env::init!();
 
-fn app_main() {
     APP.defaults().run_window(async {
         // load `available_langs`
         L10N.load_dir(zng::env::res(""));

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -8,13 +8,9 @@ use zng::{
 };
 
 fn main() {
-    zng::env::init!();
     zng::env::init_res(concat!(env!("CARGO_MANIFEST_DIR"), "/res"));
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
+    zng::env::init!();
 
-fn app_main() {
     APP.defaults().run_window(async {
         Window! {
             title = "Markdown Example";

--- a/examples/respawn/src/main.rs
+++ b/examples/respawn/src/main.rs
@@ -7,7 +7,6 @@ use zng::{
     prelude::*,
 };
 use zng_app::view_process::VIEW_PROCESS;
-use zng_view::extensions::ViewExtensions;
 
 fn main() {
     // log other processes too.
@@ -22,9 +21,6 @@ fn main() {
     // this is the normal app-process:
     app_main();
 }
-
-// init view with extensions used to cause a crash in the view-process.
-zng_view::view_process_extension!(test_extensions);
 
 fn app_main() {
     APP.defaults().run_window(async {
@@ -253,8 +249,7 @@ fn icon() -> impl UiNode {
     }
 }
 
-fn test_extensions() -> ViewExtensions {
-    let mut ext = ViewExtensions::new();
+// init view with extensions used to cause a crash in the view-process.
+zng_view::view_process_extension!(|ext| {
     ext.command::<(), ()>("zng.examples.respawn.crash", |_, _| panic!("Test view-process crash!"));
-    ext
-}
+});

--- a/examples/respawn/src/main.rs
+++ b/examples/respawn/src/main.rs
@@ -14,15 +14,7 @@ fn main() {
     // init metadata, view-process, crash-dialog-process.
     zng::env::init!();
 
-    // init crash-handler before view to use different view for the crash dialog app.
-    zng::app::crash_handler::init_debug();
-    // zng::app::crash_handler::init(zng::app::crash_handler::CrashConfig::new(app_crash_dialog));
-
     // this is the normal app-process:
-    app_main();
-}
-
-fn app_main() {
     APP.defaults().run_window(async {
         Window! {
             title = "Respawn Example";
@@ -83,8 +75,9 @@ fn app_main() {
 }
 
 // Crash dialog app, runs in the dialog-process.
+// zng::app::crash_handler::crash_handler_config!(|cfg| cfg.dialog(app_crash_handler));
 #[allow(unused)]
-fn app_crash_dialog(args: zng::app::crash_handler::CrashArgs) -> ! {
+fn app_crash_dialog(args: zng::app::crash_handler::CrashArgs) {
     APP.defaults().run_window(async move {
         Window! {
             title = "Respawn Example - App Crashed";
@@ -133,7 +126,6 @@ fn app_crash_dialog(args: zng::app::crash_handler::CrashArgs) -> ! {
             }, 5;
         }
     });
-    zng::env::exit(0)
 }
 
 fn view_respawn() -> impl UiNode {

--- a/examples/scroll/src/main.rs
+++ b/examples/scroll/src/main.rs
@@ -10,11 +10,7 @@ use rand::SeedableRng;
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
 
-fn app_main() {
     APP.defaults().run_window(async {
         let mouse_pan = var(false);
         let smooth_scrolling = var(true);

--- a/examples/shortcut/src/main.rs
+++ b/examples/shortcut/src/main.rs
@@ -6,11 +6,7 @@ use zng::{font::FontName, layout::align, prelude::*};
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
 
-fn app_main() {
     APP.defaults().run_window(async {
         let shortcut_text = var(Txt::from_str(""));
         let keypress_text = var(Txt::from_str(""));

--- a/examples/text/src/main.rs
+++ b/examples/text/src/main.rs
@@ -17,11 +17,7 @@ mod form;
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
 
-fn app_main() {
     APP.defaults().run_window(async {
         let fs = var(Length::Pt(11.0));
 

--- a/examples/transform/src/main.rs
+++ b/examples/transform/src/main.rs
@@ -16,11 +16,7 @@ use zng::{
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
-    app_main();
-}
 
-fn app_main() {
     APP.defaults().run_window(async {
         Window! {
             title = "Transform Example";

--- a/examples/window/src/main.rs
+++ b/examples/window/src/main.rs
@@ -24,7 +24,6 @@ use zng::{
 
 fn main() {
     zng::env::init!();
-    zng::app::crash_handler::init_debug();
     zng::view_process::prebuilt::run_same_process(app_main);
 }
 


### PR DESCRIPTION
Closes #253

Also cleanup APIs replated to on_process_start
<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->