### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,8 @@ jobs:
       CXX: 'clang-cl'
     steps:
     - name: fix clang version issue
-      run: $env:PATH = ($env:PATH -split ';' | Where-Object { $_ -ne 'C:\Program Files\LLVM\bin' }) -join ';'
-    # see: https://github.com/actions/runner-images/issues/10001#issuecomment-2150541007
+      run: choco upgrade llvm
+    # see: https://github.com/actions/runner-images/issues/10001#issuecomment-2150768562
     - uses: dtolnay/rust-toolchain@stable
     - name: install cargo-about
       uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
       CC: 'clang-cl'
       CXX: 'clang-cl'
     steps:
+    - name: fix clang version issue
+      run: $env:PATH = ($env:PATH -split ';' | Where-Object { $_ -ne 'C:\Program Files\LLVM\bin' }) -join ';'
+    # see: https://github.com/actions/runner-images/issues/10001#issuecomment-2150541007
     - uses: dtolnay/rust-toolchain@stable
     - name: install cargo-about
       uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -39,6 +39,9 @@ jobs:
       CC: 'clang-cl'
       CXX: 'clang-cl'
     steps:
+      - name: fix clang version issue
+        run: choco upgrade llvm
+        # see: https://github.com/actions/runner-images/issues/10001#issuecomment-2150768562
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
       - name: install cargo-about

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,6 +358,9 @@ jobs:
       CXX: 'clang-cl'
       NEXTEST_RETRIES: 3
     steps:
+      - name: fix clang version issue
+        run: choco upgrade llvm
+        # see: https://github.com/actions/runner-images/issues/10001#issuecomment-2150768562
       - name: install cargo-nextest
         if: ${{ github.event.inputs.skip_tests != 'true' }}
         uses: taiki-e/install-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,9 @@ jobs:
       CC: 'clang-cl'
       CXX: 'clang-cl'
     steps:
+      - name: fix clang version issue
+        run: choco upgrade llvm
+        # see: https://github.com/actions/runner-images/issues/10001#issuecomment-2150768562
       - uses: actions/checkout@v4
         if: ${{ github.event.inputs.skip_checks != 'true' }}
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,9 @@ jobs:
     env:
       ZNG_TP_LICENSES: true
     steps:
+      - name: fix clang version issue
+        run: choco upgrade llvm
+        # see: https://github.com/actions/runner-images/issues/10001#issuecomment-2150768562
       - name: install cargo-about
         if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
         uses: baptiste0928/cargo-install@v3


### PR DESCRIPTION
Fixes "Unexpected compiler version, expected Clang 17.0.0 or newer."

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->