### PR TITLE
Explicitly select "Ubuntu Regular" as the system font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Now does not capture view-process stdout/err, inherits stdio from app-process.
 * Fix view-process getting killed before exit request can finish.
 * Fix windows not opening maximized in X11.
+* Fix bold default UI font on Ubuntu.
 
 # 0.7.0
 

--- a/crates/zng-ext-font/src/lib.rs
+++ b/crates/zng-ext-font/src/lib.rs
@@ -346,7 +346,7 @@ impl FontNames {
 
         if lang!("zh-Hans").matches(lang, true, false) {
             [
-                "Ubuntu",
+                "Ubuntu Regular",
                 "Droid Sans",
                 "Source Han Sans SC",
                 "Source Han Sans CN",
@@ -357,7 +357,7 @@ impl FontNames {
             .into()
         } else if lang!("zh-Hant").matches(lang, true, false) {
             [
-                "Ubuntu",
+                "Ubuntu Regular",
                 "Droid Sans",
                 "Source Han Sans TC",
                 "Source Han Sans TW",
@@ -369,7 +369,7 @@ impl FontNames {
         } else if lang!(ja).matches(lang, true, false) {
             [
                 "system-ui",
-                "Ubuntu",
+                "Ubuntu Regular",
                 "Droid Sans",
                 "Source Han Sans J",
                 "Source Han Sans JP",
@@ -381,7 +381,7 @@ impl FontNames {
         } else if lang!(ko).matches(lang, true, false) {
             [
                 "system-ui",
-                "Ubuntu",
+                "Ubuntu Regular",
                 "Droid Sans",
                 "Source Han Sans K",
                 "Source Han Sans JR",
@@ -393,7 +393,7 @@ impl FontNames {
             ]
             .into()
         } else {
-            ["system-ui", "Ubuntu", "Droid Sans", "Noto Color Emoji", "sans-serif"].into()
+            ["system-ui", "Ubuntu Regular", "Droid Sans", "Noto Color Emoji", "sans-serif"].into()
         }
     }
 


### PR DESCRIPTION
This is a workaround. There is still an underlying issue with font matching TTF fonts that use "named variations" to define different weights. Hopefully a font-kit update will fix the underlying issue.

Closes #269 