### PR TITLE
Improve `get_font_use`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unpublished
 
+* **Breaking** `get_font_use` now gets font references, not just names.
+
 * Fix integrated/dedicated render mode on Ubuntu.
 * Fix build of zng-view-* without `"ipc"` feature.
 * Prebuilt view-process now uses the same tracing context as the app-process.

--- a/crates/zng-wgt-text/src/text_properties.rs
+++ b/crates/zng-wgt-text/src/text_properties.rs
@@ -1884,11 +1884,11 @@ pub fn txt_highlight(child: impl UiNode, range: impl IntoVar<std::ops::Range<Car
     })
 }
 
-/// Gets a vector of font names and ranges.
+/// Gets a vector of font and ranges.
 ///
 /// This property must be set in the text widget.
 #[property(CHILD_LAYOUT+100, widget_impl(TextInspectMix<P>))]
-pub fn get_font_use(child: impl UiNode, font_use: impl IntoVar<Vec<(FontName, std::ops::Range<usize>)>>) -> impl UiNode {
+pub fn get_font_use(child: impl UiNode, font_use: impl IntoVar<Vec<(Font, std::ops::Range<usize>)>>) -> impl UiNode {
     let font_use = font_use.into_var();
     let mut shaped_text_version = u32::MAX;
     match_node(child, move |c, op| {
@@ -1907,7 +1907,6 @@ pub fn get_font_use(child: impl UiNode, font_use: impl IntoVar<Vec<(FontName, st
                     let seg_range = seg.text_range();
 
                     for (font, glyphs) in seg.glyphs() {
-                        let font = font.face().family_name();
                         if r.is_empty() {
                             r.push((font.clone(), 0..seg_range.end));
                         } else {

--- a/crates/zng/src/text.rs
+++ b/crates/zng/src/text.rs
@@ -34,7 +34,7 @@
 //!                 let mut r = Txt::from("");
 //!                 for (font, range) in u {
 //!                     use std::fmt::Write as _;
-//!                     writeln!(&mut r, "{} = {:?}", font, &txt[range.clone()]).unwrap();
+//!                     writeln!(&mut r, "{} = {:?}", font.face().family_name(), &txt[range.clone()]).unwrap();
 //!                 }
 //!                 r.end_mut();
 //!                 r


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->