### PR TITLE
Add `NO_ZNG_CRASH_HANDLER` env var

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -199,5 +199,8 @@
         "Zalgo",
         "zdenek",
         "zng"
-    ]
+    ],
+    "lldb.launch.env": {
+        "NO_ZNG_CRASH_HANDLER": ""
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unpublished
 
+* Add `NO_ZNG_CRASH_HANDLER` env var to easily disable crash handler for special runs like for a debugger.
 
 # 0.7.1
 

--- a/crates/zng-app/src/crash_handler.rs
+++ b/crates/zng-app/src/crash_handler.rs
@@ -15,7 +15,17 @@ use zng_layout::unit::TimeUnits as _;
 
 use zng_txt::{ToTxt as _, Txt};
 
+/// Environment variable that causes the crash handler to not start if set.
+///
+/// This is particularly useful to set in debugger launch configs. Crash handler spawns
+/// a different process for the app  so break points will not work.
+pub const NO_ZNG_CRASH_HANDLER: &str = "NO_ZNG_CRASH_HANDLER";
+
 zng_env::on_process_start!(|process_start_args| {
+    if std::env::var(NO_ZNG_CRASH_HANDLER).is_ok() {
+        return;
+    }
+
     let mut config = CrashConfig::new();
     for ext in CRASH_CONFIG {
         ext(&mut config);

--- a/crates/zng/src/app.rs
+++ b/crates/zng/src/app.rs
@@ -530,15 +530,15 @@ pub use zng_ext_single_instance::{AppInstanceArgs, APP_INSTANCE_EVENT};
 /// });
 ///
 /// ```
-/// 
+///
 /// # Debugger
-/// 
+///
 /// Note that because the crash handler spawns a different process for the app debuggers will not
 /// stop at break points in the app code. You can configure your debugger to set the `NO_ZNG_CRASH_HANDLER` environment
 /// variable to not use a crash handler in debug runs.
-/// 
+///
 /// On VS Code with the CodeLLDB extension you can add this workspace configuration:
-/// 
+///
 /// ```json
 /// "lldb.launch.env": {
 ///    "NO_ZNG_CRASH_HANDLER": ""

--- a/crates/zng/src/app.rs
+++ b/crates/zng/src/app.rs
@@ -530,6 +530,20 @@ pub use zng_ext_single_instance::{AppInstanceArgs, APP_INSTANCE_EVENT};
 /// });
 ///
 /// ```
+/// 
+/// # Debugger
+/// 
+/// Note that because the crash handler spawns a different process for the app debuggers will not
+/// stop at break points in the app code. You can configure your debugger to set the `NO_ZNG_CRASH_HANDLER` environment
+/// variable to not use a crash handler in debug runs.
+/// 
+/// On VS Code with the CodeLLDB extension you can add this workspace configuration:
+/// 
+/// ```json
+/// "lldb.launch.env": {
+///    "NO_ZNG_CRASH_HANDLER": ""
+/// }
+/// ```
 ///
 /// # Full API
 ///

--- a/crates/zng/src/lib.rs
+++ b/crates/zng/src/lib.rs
@@ -447,11 +447,13 @@
 //! some catastrophic video driver errors, like a forced disconnect caused by a driver update. The [`task::spawn`] and related
 //! fire-and-forget task runners will also just log the panic as an error.
 //!
-//! You can also use the [`zng::app::crash_handler`] to collect panic backtraces, crash minidumps, show a crash dialog to the user
+//! The [`zng::app::crash_handler`] is enabled by default, it collect panic backtraces, crash minidumps, show a crash dialog to the user
 //! and restart the app. During development a debug crash dialog is provided, it shows the stdout/stderr, panics stacktrace and
-//! minidumps collected if any non-panic fatal error happens.
+//! minidumps collected if any non-panic fatal error happens. Note that the crash handler **stops debuggers from working**, see the 
+//! [Debugger section] of the crash-handler docs on how to automatically disable the crash handler for debugger runs.
 //!
 //! [`tracing`]: https://docs.rs/tracing
+//! [Debugger section]: zng::app::crash_handler#debugger
 //!
 //! # In-Depth Documentation
 //!

--- a/crates/zng/src/lib.rs
+++ b/crates/zng/src/lib.rs
@@ -449,7 +449,7 @@
 //!
 //! The [`zng::app::crash_handler`] is enabled by default, it collect panic backtraces, crash minidumps, show a crash dialog to the user
 //! and restart the app. During development a debug crash dialog is provided, it shows the stdout/stderr, panics stacktrace and
-//! minidumps collected if any non-panic fatal error happens. Note that the crash handler **stops debuggers from working**, see the 
+//! minidumps collected if any non-panic fatal error happens. Note that the crash handler **stops debuggers from working**, see the
 //! [Debugger section] of the crash-handler docs on how to automatically disable the crash handler for debugger runs.
 //!
 //! [`tracing`]: https://docs.rs/tracing


### PR DESCRIPTION
To easily disable crash handler for special runs like for a debugger.

Closes #271