### PR TITLE
Don't fail publish-doc if there are no changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -568,6 +568,8 @@ jobs:
     needs: [tag]
     permissions:
       contents: write
+    env:
+      HAS_CHANGES: 0
     steps:
       - uses: actions/checkout@v4      
         if: ${{ github.event.inputs.skip_doc != 'true' }}
@@ -585,12 +587,16 @@ jobs:
           name: doc
           path: doc
       - run: |
+          set +e
+          git diff --cached --quiet
+          echo "HAS_CHANGES=$?" >> $GITHUB_ENV
+      - run: |
           git config user.name "$(git log -n 1 --pretty=format:%an)"
           git config user.email "$(git log -n 1 --pretty=format:%ae)"
           git add -A
           git commit -m ${{ needs.tag.outputs.tag_name }} --quiet
           git push
-        if: ${{ github.event.inputs.skip_doc != 'true' }}
+        if: ${{ env.HAS_CHANGES && github.event.inputs.skip_doc != 'true' }}
 
   publish-crates:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This can happen in a rerun after a later publish job fails.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->