### PR TITLE
Optimize prebuild

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ debug = 1
 
 [profile.release-lto]
 inherits = "release"
-lto = "thin"
+lto = "fat"
+codegen-units = 1
 
 [profile.prebuild]
 inherits = "release-lto"


### PR DESCRIPTION
Ubuntu prebuilt 13.9MiB -> 11.9MiB

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->