### PR TITLE
Fix cargo zng l10n not generating a .gitignore file for deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `cargo zng l10n` not generating a .gitignore file for deps.
 * Implement serialization for l10n types.
 
 # 0.10.0

--- a/crates/cargo-zng/src/l10n.rs
+++ b/crates/cargo-zng/src/l10n.rs
@@ -171,10 +171,7 @@ pub fn run(mut args: L10nArgs) {
                 // get l10n_dir/{lang}/deps/dep.name/dep.version/
                 let mut l10n_dir = |lang: Option<&std::ffi::OsStr>| {
                     any = true;
-                    let dir = match lang {
-                        Some(l) => l10n_dir.join(l).join("deps"),
-                        None => l10n_dir.join("deps"),
-                    };
+                    let dir = l10n_dir.join(lang.unwrap()).join("deps");
                     let ignore_file = dir.join(".gitignore");
 
                     if !ignore_file.exists() {
@@ -214,6 +211,10 @@ pub fn run(mut args: L10nArgs) {
                             writeln!(&mut ignore).unwrap();
                             writeln!(&mut ignore, "*").unwrap();
                             writeln!(&mut ignore, "!.gitignore").unwrap();
+
+                            if let Err(e) = fs::write(&ignore_file, ignore.as_bytes()) {
+                                fatal!("cannot write `{}`, {e}", ignore_file.display())
+                            }
 
                             Ok(())
                         })()

--- a/examples/localize/res/template/deps/.gitignore
+++ b/examples/localize/res/template/deps/.gitignore
@@ -1,5 +1,5 @@
 # Dependency localization files
-# Call `cargo zng l10n --package zng-example-localize` to update
+# Call `cargo zng l10n --package zng-example-localize --output "examples/localize/res"` to update
 
 *
 !.gitignore


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->