### PR TITLE
Add in memory "clipboard" for headless tests that use `CLIPBOARD`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Add in memory "clipboard" for headless tests that use `CLIPBOARD`.
 * Fix `tooltip` showing instead of `disabled_tooltip` in contexts that disable the widget after a slight delay.
 * Fix tooltip opened by `ACCESS.show_tooltip` closing immediately on mouse leave.
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -38,8 +38,8 @@ name = "config"
 path = "config.rs"
 
 [[test]]
-name = "text"
-path = "text.rs"
+name = "misc"
+path = "misc.rs"
 
 [[test]]
 name = "var"

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1,10 +1,6 @@
 use std::fmt::Write as _;
 
-use zng::{
-    font::SegmentedText,
-    layout::TextSegmentKind,
-    prelude_wgt::{LayoutDirection, Txt},
-};
+use zng::{font::SegmentedText, layout::TextSegmentKind, prelude::*, prelude_wgt::*};
 
 #[test]
 fn emoji_segs() {
@@ -46,4 +42,16 @@ fn emoji_segs() {
         }
         panic!("\n\n{errors}");
     }
+}
+
+#[test]
+fn headless_clipboard() {
+    let mut app = APP.defaults().run_headless(false);
+
+    let rsp = CLIPBOARD.set_text("test");
+    assert!(CLIPBOARD.text().unwrap().is_none()); // same app update
+
+    app.update(false).assert_wait();
+    assert_eq!(rsp.into_rsp().unwrap(), Ok(true));
+    assert_eq!("test", CLIPBOARD.text().unwrap().unwrap());
 }


### PR DESCRIPTION
Closes #5.