### PR TITLE
Apply cargo zng new template sorted by file name

### DIFF
--- a/crates/cargo-zng/src/new.rs
+++ b/crates/cargo-zng/src/new.rs
@@ -309,19 +309,20 @@ fn apply_template(cx: &Context, package_name: &str) -> io::Result<()> {
 }
 
 fn apply(cx: &Context, is_post: bool, from: &Path, to: &Path) -> io::Result<()> {
-    for entry in fs::read_dir(from)? {
-        let from = entry?.path();
-        if cx.ignore(&from, is_post) {
+    for entry in walkdir::WalkDir::new(from).min_depth(1).max_depth(1).sort_by_file_name() {
+        let entry = entry?;
+        let from = entry.path();
+        if cx.ignore(from, is_post) {
             continue;
         }
         if from.is_dir() {
-            let from = cx.rename(&from)?;
+            let from = cx.rename(from)?;
             let to = to.join(from.file_name().unwrap());
             println!("  {}", to.display());
             fs::create_dir(&to)?;
             apply(cx, is_post, &from, &to)?;
         } else if from.is_file() {
-            let from = cx.rename(&from)?;
+            let from = cx.rename(from)?;
             let to = to.join(from.file_name().unwrap());
             cx.rewrite(&from)?;
             println!("  {}", to.display());

--- a/tests/cargo-zng-new-tests/sanitize/test.stdout
+++ b/tests/cargo-zng-new-tests/sanitize/test.stdout
@@ -1,3 +1,3 @@
-  the-app/The App.md
   the-app/The App
   the-app/The App/ok
+  the-app/The App.md


### PR DESCRIPTION
Windows CI keeps failing due to different order.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->