### PR TITLE
Fix `Key::all_named` build in non 64 bit targets

### DIFF
--- a/crates/zng-view-api/src/keyboard.rs
+++ b/crates/zng-view-api/src/keyboard.rs
@@ -2007,10 +2007,11 @@ impl Key {
     /// Iterate over all values from `Alt` to `F35`.
     pub fn all_named() -> impl ExactSizeIterator<Item = Key> + DoubleEndedIterator {
         unsafe {
-            // SAFETY: this is safe because all variants from `Alt` are without associated data.
-            let s: (u16, [u8; 38]) = mem::transmute(Key::Alt);
-            let e: (u16, [u8; 38]) = mem::transmute(Key::F35);
-            (s.0..=e.0).map(|n| mem::transmute((n, [0u8; 38])))
+            // SAFETY: this is safe because all variants from `Alt` are without associated data and Key is `repr(u16)`.
+            const KEY_DATA_SIZE: usize = mem::size_of::<Key>() - mem::size_of::<u16>();
+            let s: (u16, [u8; KEY_DATA_SIZE]) = mem::transmute(Key::Alt);
+            let e: (u16, [u8; KEY_DATA_SIZE]) = mem::transmute(Key::F35);
+            (s.0..=e.0).map(|n| mem::transmute((n, [0u8; KEY_DATA_SIZE])))
         }
     }
 }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->