### PR TITLE
Replace `breakpad-handler` with `minidumper` + `crash-handler`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -116,6 +116,7 @@
         "lnum",
         "machacek",
         "mexprp",
+        "minidumper",
         "minwindef",
         "mirr",
         "mixins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
+* Fix crash window summary tab when there are no localization resources.
 * Replace `breakpad-handler` with `minidumper` + `crash-handler`.
-    - This removes dep on native breakpad, a common cause of compilation issues.
+    - This removes dependency on native breakpad, a common cause of compilation issues.
 * Fix large rendered window icon resize.
 * Fix Emoji color palette panic (Windows 11 Emoji).
 * **Breaking** Remove `0.10.5` deprecated items.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Replace `breakpad-handler` with `minidumper` + `crash-handler`.
+    - This removes dep on native breakpad, a common cause of compilation issues.
 * Fix large rendered window icon resize.
 * Fix Emoji color palette panic (Windows 11 Emoji).
 * **Breaking** Remove `0.10.5` deprecated items.

--- a/crates/zng-app/Cargo.toml
+++ b/crates/zng-app/Cargo.toml
@@ -58,9 +58,11 @@ trace_wgt_item = []
 # Allow app-process crash handler.
 crash_handler = [
     "dep:serde_json",
-    "dep:breakpad-handler",
+    "dep:minidumper",
+    "dep:crash-handler",
     "dep:minidump",
     "dep:linkme",
+    "dep:uuid",
 ]
 
 # Enables IPC tasks and pre-build views and connecting to views running in another process.
@@ -106,9 +108,12 @@ unic-langid = { version = "0.9", features = ["serde"] }
 unicase = "2.7"
 
 serde_json = { version = "1.0", optional = true }
-breakpad-handler = { version = "0.2", optional = true }
+minidumper = { version = "0.8", optional = true }
+crash-handler = { version = "0.6", optional = true }
 minidump = { version = "0.22", optional = true }
 linkme = { version = "=0.3.27", optional = true }
+uuid = { version = "1.1", optional = true }
+
 hashbrown = { version = "0.14", features = ["rayon"] }
 rustc-hash = "2.0"
 

--- a/crates/zng-ext-l10n/src/service.rs
+++ b/crates/zng-ext-l10n/src/service.rs
@@ -303,7 +303,13 @@ impl fmt::Display for FluentErrors {
 fn format_fallback(file: &str, id: &str, attribute: &str, fallback: &Txt, args: Option<&fluent::FluentArgs>) -> Txt {
     let mut fallback_pattern = None;
 
-    let entry = format!("k={fallback}");
+    let mut entry = "k = ".to_owned();
+    let mut prefix = "";
+    for line in fallback.lines() {
+        entry.push_str(prefix);
+        entry.push_str(line);
+        prefix = "\n   ";
+    }
     match fluent_syntax::parser::parse_runtime(entry.as_str()) {
         Ok(mut f) => {
             if let Some(fluent_syntax::ast::Entry::Message(m)) = f.body.pop() {

--- a/crates/zng-wgt-inspector/Cargo.toml
+++ b/crates/zng-wgt-inspector/Cargo.toml
@@ -31,6 +31,7 @@ zng-ext-image = { path = "../zng-ext-image", version = "0.2.25" }
 zng-ext-config = { path = "../zng-ext-config", version = "0.3.5", default-features = false }
 zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.5.5" }
 zng-view-api = { path = "../zng-view-api", version = "0.6.4" }
+zng-wgt-dialog = { path = "../zng-wgt-dialog", version = "0.1.1" }
 zng-ext-window = { path = "../zng-ext-window", version = "0.3.15" }
 zng-wgt-window = { path = "../zng-wgt-window", version = "0.5.5" }
 zng-wgt-button = { path = "../zng-wgt-button", version = "0.4.5" }
@@ -58,7 +59,7 @@ zng-color = { path = "../zng-color", version = "0.3.4" }
 serde = { version = "1.0", features = ["derive"] }
 tracing = "0.1"
 parking_lot = "0.12"
-open = { version = "5.1", optional = true }
+open = { version = "5.1", features = ["shellexecute-on-windows"], optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/zng-wgt-markdown/Cargo.toml
+++ b/crates/zng-wgt-markdown/Cargo.toml
@@ -43,5 +43,5 @@ path-absolutize = "3.1"
 html-escape = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 tracing = "0.1"
-open = "5.1"
+open = { version = "5.1", features = ["shellexecute-on-windows"] }
 dunce = "1.0"


### PR DESCRIPTION
This removes dep on native breakpad, a common cause of compilation issues

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->