### PR TITLE
Only allow one window in Android builds

### DIFF
--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -1675,6 +1675,12 @@ impl Api for App {
         } else {
             self.assert_resumed();
 
+            #[cfg(target_os = "android")]
+            if !self.windows.is_empty() {
+                tracing::error!("android can only have one window");
+                return;
+            }
+
             let id = config.id;
             let win = Window::open(
                 self.generation,


### PR DESCRIPTION
This a better error, as the second window is just ignored, instead of panicking trying create an gles context.

Closes #402

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->