### PR TITLE
Remove `.zr-apk` requirement of extension on the folder name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Remove `.zr-apk` requirement of extension on the folder name.
 
 # 0.11.1
 

--- a/crates/cargo-zng/src/res/built_in.rs
+++ b/crates/cargo-zng/src/res/built_in.rs
@@ -755,9 +755,6 @@ fn apk() {
     }
 
     let apk_folder = path(ZR_TARGET_DD);
-    if apk_folder.extension().map(|s| s.to_ascii_lowercase() != "apk").unwrap_or(true) {
-        fatal!("not inside .apk folder")
-    }
 
     // find <sdk>/build-tools
     let android_home = match env::var("ANDROID_HOME") {


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->