### PR TITLE
Warn when `.zr-copy` does not find the directory or file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Warn when `.zr-copy` does not find the directory or file.
 * Refactor `.zr-apk` to not require to be inside the staging dir.
 * Refactor `Impl Future` parameters into `impl IntoFuture`. 
 * Implement `IntoFuture for ResponseVar<T>`.

--- a/crates/cargo-zng/src/res/built_in.rs
+++ b/crates/cargo-zng/src/res/built_in.rs
@@ -133,6 +133,8 @@ fn copy() {
         fs::copy(source, &target).unwrap_or_else(|e| fatal!("{e}"));
     } else if source.is_symlink() {
         symlink_warn(&source);
+    } else {
+        warn!("cannot copy '{}', not found", source.display());
     }
 }
 
@@ -260,7 +262,7 @@ fn glob() {
     }
 
     if !any {
-        println!("no match")
+        warn!("no match")
     }
 }
 


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->