### PR TITLE
Support `RUSTFLAGS` "deny warnings" in cargo zng

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Support `RUSTFLAGS` "deny warnings" in cargo zng.
 * Warn when `.zr-copy` does not find the directory or file.
 * Refactor `.zr-apk` to not require to be inside the staging dir.
 * Refactor `Impl Future` parameters into `impl IntoFuture`. 

--- a/crates/cargo-zng/src/util.rs
+++ b/crates/cargo-zng/src/util.rs
@@ -13,10 +13,22 @@ use serde::Deserialize;
 /// Print warning message.
 macro_rules! warn {
     ($($format_args:tt)*) => {
-        {
+        if $crate::util::deny_warnings() {
+            error!($($format_args)*);
+        }else {
             eprintln!("{} {}", $crate::util::WARN_PREFIX, format_args!($($format_args)*));
         }
     };
+}
+
+pub fn deny_warnings() -> bool {
+    std::env::var("RUSTFLAGS")
+        .map(|f| {
+            ["--deny=warnings", "-Dwarnings", "-D warnings", "--deny warnings"]
+                .iter()
+                .any(|d| f.contains(d))
+        })
+        .unwrap_or(false)
 }
 
 /// Print error message and flags the current process as failed.

--- a/tests/cargo_zng.rs
+++ b/tests/cargo_zng.rs
@@ -227,9 +227,18 @@ fn assert_dir_eq(expected: &Path, actual: &Path) {
     }
 }
 
+fn rust_flags_allow_warnings() -> String {
+    let mut flags = std::env::var("RUSTFLAGS").unwrap_or_default();
+    for f in ["-Dwarnings", "--deny=warnings", "-D warnings", "--deny warnings"] {
+        flags = flags.replace(f, "");
+    }
+    flags
+}
+
 fn zng_res<S: AsRef<OsStr>>(args: &[S], tool_dir: &Path, metadata: &Path, pack: bool) -> Result<StdioStr, (io::Error, StdioStr)> {
     zng(
         |cmd| {
+            cmd.env("RUSTFLAGS", rust_flags_allow_warnings());
             cmd.arg("res");
             if pack {
                 cmd.arg("--pack");


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->