### PR TITLE
Add Android system config (#418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Implement initial `ColorScheme` for Android.
 * Support `RUSTFLAGS` "deny warnings" in cargo zng.
 * Warn when `.zr-copy` does not find the directory or file.
 * Refactor `.zr-apk` to not require to be inside the staging dir.

--- a/crates/zng-view/Cargo.toml
+++ b/crates/zng-view/Cargo.toml
@@ -157,6 +157,8 @@ features = ["NSString"]
 
 [target.'cfg(target_os = "android")'.dependencies]
 parking_lot = "0.12"
+# matches winit -> android-activity
+ndk = { version = "0.9.0", default-features = false }
 
 [build-dependencies]
 zng-tp-licenses = { path = "../zng-tp-licenses", version = "0.2.7", features = [

--- a/crates/zng-view/src/config.rs
+++ b/crates/zng-view/src/config.rs
@@ -12,6 +12,11 @@ mod macos;
 #[cfg(target_os = "macos")]
 use macos as platform;
 
+#[cfg(target_os = "android")]
+mod android;
+#[cfg(target_os = "android")]
+use android as platform;
+
 #[cfg(any(
     target_os = "linux",
     target_os = "dragonfly",
@@ -37,7 +42,8 @@ mod other;
     target_os = "dragonfly",
     target_os = "freebsd",
     target_os = "netbsd",
-    target_os = "openbsd"
+    target_os = "openbsd",
+    target_os = "android",
 )))]
 use other as platform;
 

--- a/crates/zng-view/src/config/android.rs
+++ b/crates/zng-view/src/config/android.rs
@@ -1,0 +1,44 @@
+use crate::platform::android;
+use zng_view_api::config::{AnimationsConfig, ColorScheme, ColorsConfig, FontAntiAliasing, KeyRepeatConfig, MultiClickConfig, TouchConfig};
+
+pub fn font_aa() -> FontAntiAliasing {
+    super::other::font_aa()
+}
+
+pub fn multi_click_config() -> MultiClickConfig {
+    super::other::multi_click_config()
+}
+
+pub fn animations_config() -> AnimationsConfig {
+    super::other::animations_config()
+}
+
+pub fn key_repeat_config() -> KeyRepeatConfig {
+    super::other::key_repeat_config()
+}
+
+pub fn touch_config() -> TouchConfig {
+    super::other::touch_config()
+}
+
+pub fn colors_config() -> ColorsConfig {
+    use ndk::configuration::UiModeNight;
+    ColorsConfig {
+        scheme: match android::android_app().config().ui_mode_night() {
+            UiModeNight::Yes => ColorScheme::Dark,
+            UiModeNight::No => ColorScheme::Light,
+            _ => ColorScheme::default(),
+        },
+        // accent:
+        ..ColorsConfig::default()
+    }
+}
+
+pub fn locale_config() -> zng_view_api::config::LocaleConfig {
+    // sys_locale
+    super::other::locale_config()
+}
+
+pub fn spawn_listener(l: crate::AppEventSender) -> Option<Box<dyn FnOnce()>> {
+    super::other::spawn_listener(l)
+}

--- a/crates/zng-view/src/config/macos.rs
+++ b/crates/zng-view/src/config/macos.rs
@@ -64,7 +64,6 @@ pub fn colors_config() -> ColorsConfig {
     ColorsConfig { scheme, accent }
 }
 
-#[cfg(not(windows))]
 pub fn locale_config() -> zng_view_api::config::LocaleConfig {
     super::other::locale_config()
 }


### PR DESCRIPTION
Just ColorScheme for now, I don't think Android supports any of the other configs.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->