### PR TITLE
Fix text input moving caret on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix text input moving caret on focus.
 * Fix interactive caret touch causing loss of focus on the text input.
 * Implemented keyboard support for Android (no IME).
 * Add `--cfg=zng_view_image_has_avif` for `zng-view` to support building AVIF.

--- a/crates/zng-ext-input/src/focus.rs
+++ b/crates/zng-ext-input/src/focus.rs
@@ -438,9 +438,13 @@ impl AppExtension for FocusManager {
 
         if let Some(request) = request {
             let mut focus = FOCUS_SV.write();
-            focus.pending_highlight = false;
-            let args = focus.fulfill_request(request, false);
-            self.notify(&mut focus, args);
+            if !matches!(&focus.request, PendingFocusRequest::Update(_)) {
+                focus.request = PendingFocusRequest::None;
+                focus.pending_highlight = false;
+                focus.pending_window_focus = None;
+                let args = focus.fulfill_request(request, false);
+                self.notify(&mut focus, args);
+            }
         }
     }
 

--- a/crates/zng-wgt-text/src/node/resolve.rs
+++ b/crates/zng-wgt-text/src/node/resolve.rs
@@ -470,7 +470,7 @@ fn resolve_text_edit_events(update: &EventUpdate, edit: &mut ResolveTextEdit) {
         }
 
         let auto_select = AUTO_SELECTION_VAR.get();
-        if auto_select != AutoSelection::DISABLED && TEXT_SELECTABLE_VAR.get() {
+        if auto_select != AutoSelection::DISABLED && caret.selection_index.is_some() && TEXT_SELECTABLE_VAR.get() {
             if auto_select.contains(AutoSelection::CLEAR_ON_BLUR) && args.is_blur(widget.id()) {
                 // deselect if the widget is not the ALT return focus and is not the parent scope return focus.
 


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->