### PR TITLE
Fix panic on old macOS (<11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix panic on old macOS (<11). Color scheme and accent is only supported >=11.
 * Fix `cargo zng fmt` of widgets with multi value property assigns.
 
 # 0.11.3


### PR DESCRIPTION
Color scheme and accent is only supported >=11.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->