### PR TITLE
Fix `"view_prebuilt"` linking on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix prebuilt multi-process on macOS.
 * Fix panic on old macOS (<11). Color scheme and accent is only supported >=11.
 * Fix `cargo zng fmt` of widgets with multi value property assigns.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Fix prebuilt multi-process on macOS.
+* Fix `"view_prebuilt"` linking on macOS.
 * Fix panic on old macOS (<11). Color scheme and accent is only supported >=11.
 * Fix `cargo zng fmt` of widgets with multi value property assigns.
 

--- a/crates/zng-env/src/process.rs
+++ b/crates/zng-env/src/process.rs
@@ -56,14 +56,14 @@ use parking_lot::Mutex;
 /// ```
 ///
 /// Try to match the version used by `zng-env`.
-/// 
+///
 /// # Linker Optimizer Issues
-/// 
+///
 /// The macOS system linker can "optimize" away crates that are only referenced via this macro, that is, a crate dependency
 /// that is not otherwise directly addressed by code. To workaround this issue you can add a bogus reference to the crate code, something
 /// that is not trivial to optimize away. Unfortunately this code must be added on the dependent crate, or on an intermediary dependency,
 /// if your crate is at risk of being used this way please document this issue.
-/// 
+///
 /// See [`zng#437`] for an example of how to fix this issue.
 ///
 /// [`wasm_bindgen`]: https://crates.io/crates/wasm-bindgen

--- a/crates/zng-env/src/process.rs
+++ b/crates/zng-env/src/process.rs
@@ -56,8 +56,18 @@ use parking_lot::Mutex;
 /// ```
 ///
 /// Try to match the version used by `zng-env`.
+/// 
+/// # Linker Optimizer Issues
+/// 
+/// The macOS system linker can "optimize" away crates that are only referenced via this macro, that is, a crate dependency
+/// that is not otherwise directly addressed by code. To workaround this issue you can add a bogus reference to the crate code, something
+/// that is not trivial to optimize away. Unfortunately this code must be added on the dependent crate, or on an intermediary dependency,
+/// if your crate is at risk of being used this way please document this issue.
+/// 
+/// See [`zng#437`] for an example of how to fix this issue.
 ///
 /// [`wasm_bindgen`]: https://crates.io/crates/wasm-bindgen
+/// [`zng#437`]: https://github.com/zng-ui/zng/pull/437
 #[macro_export]
 macro_rules! on_process_start {
     ($closure:expr) => {

--- a/crates/zng/src/lib.rs
+++ b/crates/zng/src/lib.rs
@@ -883,11 +883,6 @@ mod defaults {
             #[cfg(all(view, view_prebuilt))]
             tracing::debug!(r#"both "view" and "view_prebuilt" enabled, will use only one, indeterminate witch"#);
 
-            // ensure zng_view_prebuilt is linked, macOS system linker can "optimize" the entire
-            // crate away because it is only referenced by `linkme` in `on_process_start!`
-            #[cfg(view_prebuilt)]
-            std::hint::black_box(std::marker::PhantomData::<zng_view_prebuilt::ViewLib>);
-
             #[cfg(single_instance)]
             let r = r.extend(zng_ext_single_instance::SingleInstanceManager::default());
 
@@ -952,6 +947,15 @@ mod defaults {
                     }))
                     .perm();
                 tracing::debug!("defaults init, single_instance set");
+            }
+        }
+
+        fn deinit(&mut self) {
+            // ensure zng_view_prebuilt is linked, macOS system linker can "optimize" the entire
+            // crate away because it is only referenced by `linkme` in `on_process_start!`
+            #[cfg(all(view_prebuilt, any(target_os = "macos", target_os = "ios")))]
+            if std::env::var("=").is_ok() {
+                crate::view_process::prebuilt::run_same_process(|| unreachable!());
             }
         }
     }

--- a/crates/zng/src/lib.rs
+++ b/crates/zng/src/lib.rs
@@ -883,6 +883,11 @@ mod defaults {
             #[cfg(all(view, view_prebuilt))]
             tracing::debug!(r#"both "view" and "view_prebuilt" enabled, will use only one, indeterminate witch"#);
 
+            // ensure zng_view_prebuilt is linked, macOS system linker can "optimize" the entire
+            // crate away because it is only referenced by `linkme` in `on_process_start!`
+            #[cfg(view_prebuilt)]
+            std::hint::black_box(std::marker::PhantomData::<zng_view_prebuilt::ViewLib>);
+
             #[cfg(single_instance)]
             let r = r.extend(zng_ext_single_instance::SingleInstanceManager::default());
 


### PR DESCRIPTION
Fixes #435

Issue is macOS system linker "optimizing" away the `zng-view-prebuilt` crate because it is only used via a `linkme` reference. See upstream issue dtolnay/linkme#61.

To workaround I added a bogus reference to view-prebuilt that never actually runs and cannot be optimized away.