### PR TITLE
Add Android panic backtrace help

### DIFF
--- a/docs/android-setup.md
+++ b/docs/android-setup.md
@@ -84,3 +84,15 @@ fn android() {
     println!("cargo:rerun-if-env-changed=CARGO_NDK_ANDROID_TARGET");
 }
 ```
+
+## Backtraces
+
+To log backtraces you must ensure:
+
+* `android:extractNativeLibs="true"` is set on the Android manifest XML (in the `application` element).
+* Symbols must not be stripped, use `--no-strip` with  `cargo do build-apk` or with `cargo ndk`.
+* Use the [`backtrace`] crate to collect the backtraces, there is a bug on Rust's `std` backtrace (see [rust#121033]).
+  If you are debugging a panic you have to add a `println!("{:?}", backtrace::Backtrace::new())` just before the panic code.
+
+[`backtrace`]: https://crates.io/crates/backtrace
+[rust#121033]: https://github.com/rust-lang/rust/issues/121033

--- a/tools/cargo-do/src/build-apk-manifest.xml
+++ b/tools/cargo-do/src/build-apk-manifest.xml
@@ -8,7 +8,8 @@
 
     <application android:label="${EXAMPLE}"
         android:hasCode="false"
-        android:debuggable="true">
+        android:debuggable="true"
+        android:extractNativeLibs="true">
         <activity android:name="android.app.NativeActivity"
             android:label="${EXAMPLE}"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|uiMode">

--- a/tools/cargo-do/src/main.rs
+++ b/tools/cargo-do/src/main.rs
@@ -872,7 +872,7 @@ fn build(mut args: Vec<&str>) {
 
 // do build-apk <EXAMPLE> [--release-lto] [--no-strip]
 //    Compile an example for Android using cargo-ndk and cargo zng res (.zr-apk)
-// 
+//
 // USAGE
 //    build-apk multi --no-strip
 //        Build 'multi' example with debug symbols to target/build-apk/multi.apk

--- a/tools/cargo-do/src/main.rs
+++ b/tools/cargo-do/src/main.rs
@@ -870,10 +870,15 @@ fn build(mut args: Vec<&str>) {
     cmd_env("cargo", &cargo_args, &args, rust_flags);
 }
 
-// do build-apk <EXAMPLE> [--release-lto]
+// do build-apk <EXAMPLE> [--release-lto] [--no-strip]
 //    Compile an example for Android using cargo-ndk and cargo zng res (.zr-apk)
+// 
+// USAGE
+//    build-apk multi --no-strip
+//        Build 'multi' example with debug symbols to target/build-apk/multi.apk
 fn build_apk(mut args: Vec<&str>) {
     let release_lto = take_flag(&mut args, &["--release-lto"]);
+    let no_strip = take_flag(&mut args, &["--no-strip"]);
     let e = match args.pop() {
         Some(e) => e,
         None => fatal("missing example"),
@@ -907,6 +912,9 @@ fn build_apk(mut args: Vec<&str>) {
     // cargo ndk with all installed Android targets
     let apk_lib_dir = apk_dir.join("lib").display().to_string();
     let mut ndk_args = vec!["ndk", "-o", apk_lib_dir.as_str()];
+    if no_strip {
+        ndk_args.push("--no-strip");
+    }
 
     let installed_targets = std::process::Command::new("rustup")
         .arg("target")


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->