### PR TITLE
Fix context menus of child and parent opening at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix context menus of child and parent opening at the same time.
 * Add missing `zng::event::AppCommandArgs`, command app level event handling is part of the surface API.
 * Fix nested window render update flickering.
 * *Deprecated* Renamed `UiNodeVec` to `UiVec`, old name is now a deprecated type alias.

--- a/crates/zng-wgt-menu/src/context.rs
+++ b/crates/zng-wgt-menu/src/context.rs
@@ -75,6 +75,8 @@ fn context_menu_node(child: impl UiNode, menu: impl IntoVar<WidgetFn<ContextMenu
                         args.target.interactivity().is_enabled()
                     };
                     if apply {
+                        args.propagation().stop();
+
                         let menu = menu.get()(ContextMenuArgs {
                             anchor_id: WIDGET.id(),
                             disabled: disabled_only,


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->