### PR TITLE
Fix context menu not opening in nested windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix context menu not opening in nested windows.
 * Fix context menus of child and parent opening at the same time.
 * Add missing `zng::event::AppCommandArgs`, command app level event handling is part of the surface API.
 * Fix nested window render update flickering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `MOUSE.position` not tracking nested windows.
 * Fix context menu not opening in nested windows.
 * Add `AnyEventArgs::backtrace` for tracking event args sources.
 * Fix focus not clearing from nested window when parent window loses focus on the system.

--- a/crates/zng-app/src/widget/info/path.rs
+++ b/crates/zng-app/src/widget/info/path.rs
@@ -181,7 +181,13 @@ impl fmt::Debug for InteractionPath {
 }
 impl fmt::Display for InteractionPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_path())
+        write!(f, "{}//", self.window_id)?;
+        let mut sep = "";
+        for (w, i) in self.zip() {
+            write!(f, "{sep}{w}{{{i:?}}}")?;
+            sep = "/";
+        }
+        Ok(())
     }
 }
 impl InteractionPath {

--- a/crates/zng-ext-input/src/focus.rs
+++ b/crates/zng-ext-input/src/focus.rs
@@ -398,7 +398,6 @@ impl AppExtension for FocusManager {
             if args.is_mouse_down() {
                 // click
                 request = Some(FocusRequest::direct_or_exit(args.target.widget_id(), true, false));
-                println!("!!: MOUSE INPUT FOCUS REQUEST FOR {:?}", args.target);
             }
         } else if let Some(args) = TOUCH_INPUT_EVENT.on(update) {
             if args.is_touch_start() {

--- a/crates/zng-ext-input/src/focus.rs
+++ b/crates/zng-ext-input/src/focus.rs
@@ -398,6 +398,7 @@ impl AppExtension for FocusManager {
             if args.is_mouse_down() {
                 // click
                 request = Some(FocusRequest::direct_or_exit(args.target.widget_id(), true, false));
+                println!("!!: MOUSE INPUT FOCUS REQUEST FOR {:?}", args.target);
             }
         } else if let Some(args) = TOUCH_INPUT_EVENT.on(update) {
             if args.is_touch_start() {

--- a/crates/zng-ext-input/src/mouse.rs
+++ b/crates/zng-ext-input/src/mouse.rs
@@ -919,12 +919,6 @@ impl MouseManager {
 
             self.pos = position;
 
-            MOUSE_SV.read().position.set(self.pos_window.map(|id| MousePosition {
-                window_id: id,
-                position,
-                timestamp: INSTANT.now(),
-            }));
-
             // mouse_move data
             let mut frame_info = match WINDOWS.widget_tree(window_id) {
                 Ok(f) => f,
@@ -976,6 +970,12 @@ impl MouseManager {
                 frame_info.root().interaction_path()
             }
             .unblocked();
+
+            MOUSE_SV.read().position.set(Some(MousePosition {
+                window_id: frame_info.window_id(),
+                position,
+                timestamp: INSTANT.now(),
+            }));
 
             self.hits = Some(pos_hits.clone());
 

--- a/crates/zng-wgt-layer/src/lib.rs
+++ b/crates/zng-wgt-layer/src/lib.rs
@@ -512,8 +512,8 @@ impl LAYERS {
                             }
 
                             *final_size = layer_size;
-                            return;
                         }
+                        return;
                     }
                 }
 


### PR DESCRIPTION
The right click causes a focus request for the window, in the host window this focus update happens before the context-menu opens by the full click event, in nested it only happens after.