### PR TITLE
Use `#[expect]` when possible

### DIFF
--- a/crates/zng-app-context/src/lib.rs
+++ b/crates/zng-app-context/src/lib.rs
@@ -1688,6 +1688,7 @@ impl<F: FnOnce()> Drop for RunOnDrop<F> {
     }
 }
 
+#[allow(clippy::manual_unwrap_or)] // false positive, already fixed for Rust 1.82
 fn panic_str<'s>(payload: &'s Box<dyn std::any::Any + Send + 'static>) -> &'s str {
     if let Some(s) = payload.downcast_ref::<&str>() {
         s

--- a/crates/zng-app-context/src/lib.rs
+++ b/crates/zng-app-context/src/lib.rs
@@ -1688,7 +1688,7 @@ impl<F: FnOnce()> Drop for RunOnDrop<F> {
     }
 }
 
-#[allow(clippy::manual_unwrap_or)] // false positive, already fixed for Rust 1.82
+#[expect(clippy::manual_unwrap_or)] // false positive, already fixed remove when Rust 1.82 is released
 fn panic_str<'s>(payload: &'s Box<dyn std::any::Any + Send + 'static>) -> &'s str {
     if let Some(s) = payload.downcast_ref::<&str>() {
         s

--- a/crates/zng-app-proc-macros/src/ui_node.rs
+++ b/crates/zng-app-proc-macros/src/ui_node.rs
@@ -472,7 +472,6 @@ fn delegate_list_absents(crate_: TokenStream, user_mtds: HashSet<Ident>, borrow:
 }
 
 /// Parsed macro arguments.
-#[allow(clippy::large_enum_variant)]
 enum Args {
     /// No arguments. Impl is for a leaf in the Ui tree.
     NoDelegate,

--- a/crates/zng-app-proc-macros/src/util.rs
+++ b/crates/zng-app-proc-macros/src/util.rs
@@ -34,7 +34,7 @@ pub fn parse_braces<'a>(input: &syn::parse::ParseBuffer<'a>) -> syn::Result<(syn
 }
 
 /// Returns `true` if the proc-macro is running in one of the rust-analyzer proc-macro servers.
-#[allow(unexpected_cfgs)] // rust_analyzer exists: https://github.com/rust-lang/rust-analyzer/pull/15528
+#[expect(unexpected_cfgs)] // rust_analyzer exists: https://github.com/rust-lang/rust-analyzer/pull/15528
 pub fn is_rust_analyzer() -> bool {
     cfg!(rust_analyzer)
 }
@@ -277,7 +277,7 @@ macro_rules! non_user_braced {
 }
 
 /// Does a `parenthesized!` parse but panics with [`non_user_error!()`](non_user_error) if the parsing fails.
-#[allow(unused)]
+#[allow(unused)] // depends on cfg
 macro_rules! non_user_parenthesized {
     ($input:expr) => {
         non_user_group! { parenthesized, $input }
@@ -358,7 +358,7 @@ impl Attributes {
                     inline = Some(attr);
                 } else if ident == "cfg" {
                     cfg = Some(attr);
-                } else if ident == "allow" || ident == "warn" || ident == "deny" || ident == "forbid" {
+                } else if ident == "allow" || ident == "expect" || ident == "warn" || ident == "deny" || ident == "forbid" {
                     lints.push(attr);
                 } else {
                     others.push(attr);
@@ -718,7 +718,7 @@ impl ErrorRecoverable for syn::Error {
 // This is useful for debugging say the widget macros but only for a widget.
 //
 // Use [`enable_trace!`] and [`trace!`].
-#[allow(unused)]
+#[allow(unused)] // depends on cfg
 #[cfg(debug_assertions)]
 pub mod debug_trace {
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -739,7 +739,7 @@ pub mod debug_trace {
     }
 }
 
-#[allow(unused)]
+#[allow(unused)] // depends on cfg
 #[cfg(debug_assertions)]
 macro_rules! enable_trace {
     () => {
@@ -749,7 +749,7 @@ macro_rules! enable_trace {
         $crate::util::debug_trace::enable($bool_expr);
     };
 }
-#[allow(unused)]
+#[allow(unused)] // depends on cfg
 #[cfg(debug_assertions)]
 macro_rules! trace {
     ($msg:tt) => {

--- a/crates/zng-app-proc-macros/src/widget_util.rs
+++ b/crates/zng-app-proc-macros/src/widget_util.rs
@@ -118,7 +118,7 @@ pub(crate) fn split_path_generics(mut path: Path) -> Result<(Path, TokenStream)>
 
 pub struct PropertyField {
     pub ident: Ident,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub colon: Token![:],
     pub expr: TokenStream,
 }
@@ -152,11 +152,11 @@ impl Parse for PropertyField {
 // Value assigned in a [`PropertyAssign`].
 pub enum PropertyValue {
     /// `unset!`.
-    Special(Ident, #[allow(dead_code)] Token![!]),
+    Special(Ident, #[expect(dead_code)] Token![!]),
     /// `arg0, arg1,`
     Unnamed(TokenStream),
     /// `{ field0: true, field1: false, }`
-    Named(#[allow(dead_code)] syn::token::Brace, Punctuated<PropertyField, Token![,]>),
+    Named(#[expect(dead_code)] syn::token::Brace, Punctuated<PropertyField, Token![,]>),
 }
 impl Parse for PropertyValue {
     fn parse(input: parse::ParseStream) -> syn::Result<Self> {
@@ -254,11 +254,11 @@ pub mod keyword {
 
 pub struct WgtWhen {
     pub attrs: Attributes,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub when: keyword::when,
     pub condition_expr: TokenStream,
     pub condition_expr_str: String,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub brace_token: syn::token::Brace,
     pub assigns: Vec<WgtProperty>,
 }

--- a/crates/zng-app/src/crash_handler.rs
+++ b/crates/zng-app/src/crash_handler.rs
@@ -1182,8 +1182,7 @@ fn crash_handler_dialog_process(dump_enabled: bool, dialog: CrashDialogHandler, 
     .exit(0)
 }
 
-#[allow(deprecated)] // std::panic::PanicInfo is deprecated on nightly (>=1.81)
-fn panic_handler(info: &std::panic::PanicInfo) {
+fn panic_handler(info: &std::panic::PanicHookInfo) {
     let backtrace = std::backtrace::Backtrace::capture();
     let path = crate::widget::WIDGET.trace_path();
     let panic = PanicInfo::from_hook(info);
@@ -1233,8 +1232,7 @@ struct PanicInfo {
     pub column: u32,
 }
 impl PanicInfo {
-    #[allow(deprecated)] // std::panic::PanicInfo is deprecated on nightly (>=1.81)
-    pub fn from_hook(info: &std::panic::PanicInfo) -> Self {
+    pub fn from_hook(info: &std::panic::PanicHookInfo) -> Self {
         let current_thread = std::thread::current();
         let thread = current_thread.name().unwrap_or("<unnamed>");
         let msg = Self::payload(info.payload());

--- a/crates/zng-app/src/crash_handler.rs
+++ b/crates/zng-app/src/crash_handler.rs
@@ -818,7 +818,7 @@ fn crash_handler_monitor_process(
                     zng_env::exit(code);
                 } else {
                     let code = status.code();
-                    #[allow(unused_mut)]
+                    #[allow(unused_mut)] // Windows has no signal
                     let mut signal = None::<i32>;
 
                     #[cfg(windows)]
@@ -932,7 +932,7 @@ fn crash_handler_monitor_process(
                                         .to_owned()
                                 } else {
                                     let code = dlg_status.code();
-                                    #[allow(unused_mut)]
+                                    #[allow(unused_mut)] // Windows has no signal
                                     let mut signal = None::<i32>;
 
                                     #[cfg(windows)]

--- a/crates/zng-app/src/event/args.rs
+++ b/crates/zng-app/src/event/args.rs
@@ -225,7 +225,6 @@ macro_rules! __event_args {
             /// # Panics
             ///
             /// Panics if the arguments are invalid.
-            #[track_caller]
             #[allow(clippy::too_many_arguments)]
             pub fn new(
                 timestamp: impl Into<$crate::DInstant>,
@@ -266,7 +265,6 @@ macro_rules! __event_args {
             /// # Panics
             ///
             /// Panics if the arguments are invalid.
-            #[track_caller]
             #[allow(clippy::too_many_arguments)]
             pub fn now($($arg : impl Into<$arg_ty>),*) -> Self {
                 Self::new($crate::INSTANT.now(), $crate::event::EventPropagationHandle::new(), $($arg),*)

--- a/crates/zng-app/src/event/command.rs
+++ b/crates/zng-app/src/event/command.rs
@@ -754,7 +754,6 @@ impl CommandArgs {
     /// lower priority handlers, but if the handler is disabled the command primary action is not run.
     ///
     /// Returns the `handler` result if it was called.
-    #[allow(unused)]
     pub fn handle_enabled<F, R>(&self, local_handle: &CommandHandle, handler: F) -> Option<R>
     where
         F: FnOnce(&Self) -> R,

--- a/crates/zng-app/src/event/events.rs
+++ b/crates/zng-app/src/event/events.rs
@@ -120,7 +120,7 @@ impl EVENTS {
 }
 
 /// EVENTS L10N integration.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub struct EVENTS_L10N;
 impl EVENTS_L10N {
     pub(crate) fn init_meta_l10n(&self, file: [&'static str; 3], cmd: Command, meta_name: &'static str, txt: CommandMetaVar<Txt>) {

--- a/crates/zng-app/src/lib.rs
+++ b/crates/zng-app/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
 #![recursion_limit = "256"]
 // suppress nag about very simple boxed closure signatures.
-#![allow(clippy::type_complexity)]
+#![expect(clippy::type_complexity)]
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 

--- a/crates/zng-app/src/render.rs
+++ b/crates/zng-app/src/render.rs
@@ -163,7 +163,7 @@ impl FrameBuilder {
     /// * `scale_factor` - Scale factor that will be used to render the frame, usually the scale factor of the screen the window is at.
     /// * `default_font_aa` - Fallback font anti-aliasing used when the default value is requested.
     ///   because WebRender does not let us change the initial clear color.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         render_widgets: Arc<RenderUpdates>,
         render_update_widgets: Arc<RenderUpdates>,
@@ -232,7 +232,7 @@ impl FrameBuilder {
     }
 
     /// [`new`](Self::new) with only the inputs required for renderless mode.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new_renderless(
         render_widgets: Arc<RenderUpdates>,
         render_update_widgets: Arc<RenderUpdates>,
@@ -1270,7 +1270,7 @@ impl FrameBuilder {
     }
 
     /// Push a nine-patch border with image source.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn push_border_image(
         &mut self,
         bounds: PxRect,
@@ -1298,7 +1298,7 @@ impl FrameBuilder {
     }
 
     /// Push a nine-patch border with linear gradient source.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn push_border_linear_gradient(
         &mut self,
         bounds: PxRect,
@@ -1337,7 +1337,7 @@ impl FrameBuilder {
     }
 
     /// Push a nine-patch border with radial gradient source.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn push_border_radial_gradient(
         &mut self,
         bounds: PxRect,
@@ -1380,7 +1380,7 @@ impl FrameBuilder {
     }
 
     /// Push a nine-patch border with conic gradient source.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn push_border_conic_gradient(
         &mut self,
         bounds: PxRect,
@@ -1517,7 +1517,7 @@ impl FrameBuilder {
     ///
     /// The gradient `stops` must be normalized, first stop at 0.0 and last stop at 1.0, this
     /// is asserted in debug builds.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn push_linear_gradient(
         &mut self,
         clip_rect: PxRect,
@@ -1566,7 +1566,7 @@ impl FrameBuilder {
     ///
     /// The gradient `stops` must be normalized, first stop at 0.0 and last stop at 1.0, this
     /// is asserted in debug builds.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn push_radial_gradient(
         &mut self,
         clip_rect: PxRect,
@@ -1615,7 +1615,7 @@ impl FrameBuilder {
     ///
     /// The gradient `stops` must be normalized, first stop at 0.0 and last stop at 1.0, this
     /// is asserted in debug builds.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn push_conic_gradient(
         &mut self,
         clip_rect: PxRect,
@@ -1848,7 +1848,7 @@ impl FrameBuilder {
     }
 
     /// Calls `render` to render a separate nested window on this frame.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn with_nested_window(
         &mut self,
         render_widgets: Arc<RenderUpdates>,

--- a/crates/zng-app/src/running.rs
+++ b/crates/zng-app/src/running.rs
@@ -517,7 +517,6 @@ impl<E: AppExtension> RunningApp<E> {
     }
 
     pub(crate) fn run_headed(mut self) {
-        #[allow(clippy::let_unit_value)]
         let mut observer = ();
         #[cfg(feature = "dyn_app_extension")]
         let mut observer = observer.as_dyn();
@@ -1197,7 +1196,6 @@ impl fmt::Display for ExitCancelled {
 }
 
 struct AppIntrinsic {
-    #[allow(dead_code)]
     exit_handle: CommandHandle,
     pending_exit: Option<PendingExit>,
 }
@@ -1388,7 +1386,7 @@ impl AppProcessService {
 
 /// App events.
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub(crate) enum AppEvent {
     /// Event from the View Process.
     ViewEvent(zng_view_api::Event),

--- a/crates/zng-app/src/shortcut.rs
+++ b/crates/zng-app/src/shortcut.rs
@@ -170,7 +170,7 @@ impl std::hash::Hash for KeyGesture {
     }
 }
 impl KeyGesture {
-    #[allow(missing_docs)]
+    /// New from modifiers and key.
     pub fn new(modifiers: ModifiersState, key: GestureKey) -> Self {
         KeyGesture { modifiers, key }
     }
@@ -508,7 +508,7 @@ pub struct ParseError {
     pub error: String,
 }
 impl ParseError {
-    #[allow(missing_docs)]
+    /// New from any error message.
     pub fn new(error: impl ToString) -> Self {
         ParseError { error: error.to_string() }
     }

--- a/crates/zng-app/src/tests/widget.rs
+++ b/crates/zng-app/src/tests/widget.rs
@@ -383,9 +383,9 @@ impl CfgPropertyWgt {
             never_trace = "never-trace";
 
             // suppress warning.
-            #[allow(non_snake_case)]
+            #[expect(non_snake_case)]
             always_trace = {
-                #[allow(clippy::needless_late_init)]
+                #[expect(clippy::needless_late_init)]
                 let weird___name;
                 weird___name = "always-trace";
                 weird___name
@@ -426,9 +426,9 @@ pub fn user_cfg_property() {
             never_trace = "never-trace";
 
             // suppress warning.
-            #[allow(non_snake_case)]
+            #[expect(non_snake_case)]
             always_trace = {
-                #[allow(clippy::needless_late_init)]
+                #[expect(clippy::needless_late_init)]
                 let weird___name;
                 weird___name = "always-trace";
                 weird___name
@@ -454,10 +454,10 @@ impl CfgWhenWgt {
             util::live_trace = "trace";
 
             // suppress warning in all assigns.
-            #[allow(non_snake_case)]
+            #[expect(non_snake_case)]
             when *#util::is_state {
                 util::live_trace = {
-                    #[allow(clippy::needless_late_init)]
+                    #[expect(clippy::needless_late_init)]
                     let weird___name;
                     weird___name = "is_state";
                     weird___name
@@ -507,8 +507,8 @@ pub fn user_cfg_when() {
 
             when *#util::is_state {
                 util::live_trace = {
-                    #[allow(non_snake_case)]
-                    #[allow(clippy::needless_late_init)]
+                    #[expect(non_snake_case)]
+                    #[expect(clippy::needless_late_init)]
                     let weird___name;
                     weird___name = "is_state";
                     weird___name
@@ -1081,7 +1081,7 @@ pub fn name_collision_wgt_when() {
 * macro_rules! generated widget
 */
 
-#[allow(dead_code)] // weird interaction with macro_rules!.
+#[allow(dead_code)]
 mod macro_rules_generated {
     use zng_app_proc_macros::{property, widget};
     use zng_layout::unit::SideOffsets;
@@ -1396,7 +1396,7 @@ pub mod util {
 
     /// A capture_only property.
     #[property(CONTEXT)]
-    #[allow(unreachable_code)]
+    #[expect(unreachable_code)]
     pub fn capture_only_trace(_child: impl UiNode, trace: impl IntoValue<&'static str>) -> impl UiNode {
         let _ = trace;
         panic!("capture-only property");

--- a/crates/zng-app/src/view_process.rs
+++ b/crates/zng-app/src/view_process.rs
@@ -49,7 +49,7 @@ use self::raw_device_events::DeviceId;
 use super::{AppId, APP};
 
 /// Connection to the running view-process for the context app.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub struct VIEW_PROCESS;
 struct ViewProcessService {
     process: zng_view_api::Controller,

--- a/crates/zng-app/src/widget/builder.rs
+++ b/crates/zng-app/src/widget/builder.rs
@@ -2563,7 +2563,7 @@ impl WidgetBuilding {
                         inspector_items.push(crate::widget::inspector::InstanceItem::Property { args, captured });
                     }
                 }
-                #[allow(unused_variables)]
+                #[allow(unused_variables)] // depends on cfg
                 WidgetItem::Intrinsic { new, name } => {
                     node = new(node);
                     #[cfg(feature = "trace_wgt_item")]

--- a/crates/zng-app/src/widget/easing.rs
+++ b/crates/zng-app/src/widget/easing.rs
@@ -16,7 +16,7 @@ pub use zng_app_proc_macros::easing;
 type EasingFn = Arc<dyn Fn(EasingTime) -> EasingStep + Send + Sync>;
 
 #[doc(hidden)]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub trait easing_property: Send + Sync + Clone + Copy {
     fn easing_property_unset(self);
     fn easing_property(self, duration: Duration, easing: EasingFn) -> Vec<Box<dyn AnyPropertyBuildAction>>;
@@ -24,7 +24,7 @@ pub trait easing_property: Send + Sync + Clone + Copy {
 }
 
 #[doc(hidden)]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 #[diagnostic::on_unimplemented(note = "property type must be `Transitionable` to support `#[easing]`")]
 pub trait easing_property_input_Transitionable: Any + Send {
     fn easing(self, duration: Duration, easing: EasingFn, when_conditions_data: &[Option<Arc<dyn Any + Send + Sync>>]) -> Self;

--- a/crates/zng-app/src/widget/info.rs
+++ b/crates/zng-app/src/widget/info.rs
@@ -241,7 +241,7 @@ impl WidgetInfoTree {
     /// Total number of widgets in the tree.
     ///
     /// Is never zero, every tree has at least the root widget.
-    #[allow(clippy::len_without_is_empty)]
+    #[expect(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.0.lookup.len()
     }

--- a/crates/zng-app/src/widget/info/builder.rs
+++ b/crates/zng-app/src/widget/info/builder.rs
@@ -1595,7 +1595,6 @@ impl WidgetLayout {
     /// Returns the child final size.
     ///
     /// [`InlineConstraintsLayout`]: zng_layout::context::InlineConstraintsLayout
-    #[allow(clippy::too_many_arguments)]
     pub fn layout_inline(
         &mut self,
         first: PxRect,

--- a/crates/zng-app/src/widget/node.rs
+++ b/crates/zng-app/src/widget/node.rs
@@ -376,7 +376,7 @@ pub trait UiNode: Any + Send {
 }
 
 /// See [`UiNode::into_widget`]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 #[widget($crate::widget::node::into_widget)]
 struct into_widget(crate::widget::base::WidgetBase);
 #[zng_app_proc_macros::property(CHILD, capture, widget_impl(into_widget))]

--- a/crates/zng-app/src/widget/node/list.rs
+++ b/crates/zng-app/src/widget/node/list.rs
@@ -572,7 +572,7 @@ impl UiNodeList for UiNodeListChainImpl {
 }
 
 /// Represents the contextual parent [`SortingList`] during an update.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub struct SORTING_LIST;
 impl SORTING_LIST {
     /// If the current call has a parent sorting list.
@@ -794,7 +794,7 @@ context_local! {
 }
 
 /// Access to widget z-index in a parent [`PanelList`].
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub struct Z_INDEX;
 impl Z_INDEX {
     fn with(&self, panel_id: WidgetId, action: impl FnOnce()) -> bool {

--- a/crates/zng-app/src/widget/node/match_node.rs
+++ b/crates/zng-app/src/widget/node/match_node.rs
@@ -56,7 +56,7 @@ pub enum UiNodeOp<'a> {
     /// [`WIDGET.update_info`]: crate::widget::WIDGET::update_info
     /// [`WIDGET.info`]: crate::widget::WIDGET::info
     Info {
-        #[allow(missing_docs)]
+        /// Info builder.
         info: &'a mut WidgetInfoBuilder,
     },
     /// The [`UiNode::event`].
@@ -76,7 +76,7 @@ pub enum UiNodeOp<'a> {
     /// [`Init`]: Self::Init
     /// [`Event::on`]: crate::event::Event::on
     Event {
-        #[allow(missing_docs)]
+        /// Event update args and targets.
         update: &'a EventUpdate,
     },
     /// The [`UiNode::update`].
@@ -94,7 +94,7 @@ pub enum UiNodeOp<'a> {
     /// [`Init`]: Self::Init
     /// [`Var::get_new`]: zng_var::Var::get_new
     Update {
-        #[allow(missing_docs)]
+        /// Update targets
         updates: &'a WidgetUpdates,
     },
     /// The [`UiNode::measure`].
@@ -114,9 +114,9 @@ pub enum UiNodeOp<'a> {
     /// [`LAYOUT`]: zng_layout::context::LAYOUT
     /// [`PxSize`]: zng_layout::unit::PxSize
     Measure {
-        #[allow(missing_docs)]
+        /// Measure pass state.
         wm: &'a mut WidgetMeasure,
-        #[allow(missing_docs)]
+        /// Return value, the widget's desired size after measure.
         desired_size: &'a mut PxSize,
     },
     /// The [`UiNode::layout`].
@@ -141,9 +141,9 @@ pub enum UiNodeOp<'a> {
     /// [`LAYOUT`]: zng_layout::context::LAYOUT
     /// [`PxSize`]: zng_layout::unit::PxSize
     Layout {
-        #[allow(missing_docs)]
+        /// Layout pass state.
         wl: &'a mut WidgetLayout,
-        #[allow(missing_docs)]
+        /// Return value, the widget's final size after layout.
         final_size: &'a mut PxSize,
     },
     /// The [`UiNode::render`].
@@ -156,7 +156,7 @@ pub enum UiNodeOp<'a> {
     /// Only widgets and ancestors that requested render receive this call, other widgets reuse the display items and transforms
     /// from the last frame.
     Render {
-        #[allow(missing_docs)]
+        /// Frame builder.
         frame: &'a mut FrameBuilder,
     },
     /// The [`UiNode::render_update`].
@@ -171,7 +171,7 @@ pub enum UiNodeOp<'a> {
     ///
     /// [`FrameValue<T>`]: crate::render::FrameValue
     RenderUpdate {
-        #[allow(missing_docs)]
+        /// Fame updater.
         update: &'a mut FrameUpdate,
     },
 }

--- a/crates/zng-color-proc-macros/src/hex_color.rs
+++ b/crates/zng-color-proc-macros/src/hex_color.rs
@@ -3,7 +3,7 @@ use syn::{parse::Parse, parse_macro_input, LitInt, Path, Token};
 
 struct Input {
     crate_: Path,
-    #[allow(unused)]
+    #[expect(unused)]
     comma: Token![,],
     hex: TokenStream,
 }

--- a/crates/zng-color/src/gradient.rs
+++ b/crates/zng-color/src/gradient.rs
@@ -629,7 +629,7 @@ impl fmt::Debug for GradientStops {
         }
     }
 }
-#[allow(clippy::len_without_is_empty)] // cannot be empty
+#[expect(clippy::len_without_is_empty)] // cannot be empty
 impl GradientStops {
     /// Gradients stops with two colors from `start` to `end`.
     pub fn new(start: impl Into<Rgba>, end: impl Into<Rgba>) -> Self {

--- a/crates/zng-color/src/mix.rs
+++ b/crates/zng-color/src/mix.rs
@@ -426,7 +426,7 @@ impl_mix! {
         Luminosity => |[fgh, _fgs, _fbl], [bgh, bgs, _bgl]| [bgh, bgs, fgh],
     }
 }
-#[allow(clippy::derivable_impls)] // macro generated enum
+#[expect(clippy::derivable_impls)] // macro generated enum
 impl Default for MixBlendMode {
     fn default() -> Self {
         MixBlendMode::Normal

--- a/crates/zng-env/src/lib.rs
+++ b/crates/zng-env/src/lib.rs
@@ -197,7 +197,7 @@ impl About {
     }
 
     #[doc(hidden)]
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn macro_new(
         pkg_name: &'static str,
         pkg_authors: &[&'static str],

--- a/crates/zng-ext-config/src/lib.rs
+++ b/crates/zng-ext-config/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
 // suppress nag about very simple boxed closure signatures.
-#![allow(clippy::type_complexity)]
+#![expect(clippy::type_complexity)]
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 

--- a/crates/zng-ext-font/src/lib.rs
+++ b/crates/zng-ext-font/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
 // suppress nag about very simple boxed closure signatures.
-#![allow(clippy::type_complexity)]
+#![expect(clippy::type_complexity)]
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 
@@ -1637,7 +1637,7 @@ pub struct FontList {
     requested_weight: FontWeight,
     requested_stretch: FontStretch,
 }
-#[allow(clippy::len_without_is_empty)] // cannot be empty.
+#[expect(clippy::len_without_is_empty)] // cannot be empty.
 impl FontList {
     /// The font that best matches the requested properties.
     pub fn best(&self) -> &Font {
@@ -2364,7 +2364,6 @@ impl GenericFonts {
 
 /// Reference to in memory font data.
 #[derive(Clone)]
-#[allow(clippy::rc_buffer)]
 pub struct FontDataRef(pub Arc<Vec<u8>>);
 impl FontDataRef {
     /// Copy bytes from embedded font.

--- a/crates/zng-ext-font/src/shaping.rs
+++ b/crates/zng-ext-font/src/shaping.rs
@@ -635,7 +635,7 @@ impl ShapedText {
     ///
     /// The general process of shaping text is to generate a shaped-text without align during *measure*, and then reuse
     /// this shaped text every layout that does not invalidate any property that affects the text wrap.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn reshape_lines(
         &mut self,
         constraints: PxConstraints2d,

--- a/crates/zng-ext-font/src/unicode_bidi_util.rs
+++ b/crates/zng-ext-font/src/unicode_bidi_util.rs
@@ -162,7 +162,7 @@ pub(super) fn explicit_compute(
                 } else {
                     last_level.new_explicit_next_ltr()
                 };
-                #[allow(clippy::unnecessary_unwrap)]
+
                 if new_level.is_ok() && overflow_isolate_count == 0 && overflow_embedding_count == 0 {
                     let new_level = new_level.unwrap();
                     stack.push(
@@ -387,7 +387,7 @@ struct Status {
 }
 
 #[derive(PartialEq)]
-#[allow(clippy::upper_case_acronyms)]
+#[expect(clippy::upper_case_acronyms)]
 enum OverrideStatus {
     Neutral,
     RTL,
@@ -994,7 +994,7 @@ fn identify_bracket_pairs(
 /// Neutral or Isolate formatting character (B, S, WS, ON, FSI, LRI, RLI, PDI)
 ///
 /// <http://www.unicode.org/reports/tr9/#NI>
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 fn is_NI(class: BidiClass) -> bool {
     use BidiClass::*;
     matches!(class, B | S | WS | ON | FSI | LRI | RLI | PDI)

--- a/crates/zng-ext-fs-watcher/src/lib.rs
+++ b/crates/zng-ext-fs-watcher/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
 // suppress nag about very simple boxed closure signatures.
-#![allow(clippy::type_complexity)]
+#![expect(clippy::type_complexity)]
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 
@@ -805,7 +805,7 @@ impl<T: fmt::Debug + std::any::Any + Send + Sync> FsChangeNote for T {
 /// [`WATCHER.annotate`]: WATCHER::annotate
 #[derive(Clone)]
 #[must_use = "the note is removed when the handle is dropped"]
-pub struct FsChangeNoteHandle(#[allow(dead_code)] Arc<Arc<dyn FsChangeNote>>);
+pub struct FsChangeNoteHandle(#[expect(dead_code)] Arc<Arc<dyn FsChangeNote>>);
 
 /// Annotation for file watcher events and var update tags.
 ///

--- a/crates/zng-ext-hot-reload/src/cargo.rs
+++ b/crates/zng-ext-hot-reload/src/cargo.rs
@@ -228,7 +228,7 @@ impl fmt::Display for BuildError {
             BuildError::Command { status, err } => {
                 write!(f, "build command failed")?;
                 let mut sep = "\n";
-                #[allow(unused_assignments)]
+                #[allow(unused_assignments)] // depends on cfg
                 if let Some(c) = status.code() {
                     write!(f, "{sep}exit code: {c:#x}")?;
                     sep = ", ";

--- a/crates/zng-ext-hot-reload/src/lib.rs
+++ b/crates/zng-ext-hot-reload/src/lib.rs
@@ -432,7 +432,7 @@ impl BuildArgs {
 }
 
 /// Hot reload service.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub struct HOT_RELOAD;
 impl HOT_RELOAD {
     /// Hot reload status, libs that are rebuilding, errors.
@@ -498,7 +498,7 @@ app_local! {
 struct HotReloadService {
     libs: Vec<HotLib>,
     // mutex for Sync only
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     rebuilders: Mutex<Vec<Box<dyn FnMut(BuildArgs) -> Option<RebuildVar> + Send + 'static>>>,
 
     status: ArcVar<Vec<HotStatus>>,

--- a/crates/zng-ext-hot-reload/src/util.rs
+++ b/crates/zng-ext-hot-reload/src/util.rs
@@ -3,8 +3,7 @@ use std::fmt;
 use zng_txt::{ToTxt, Txt};
 
 // format panic, code copied from `zng::crash_handler`
-#[allow(deprecated)] // std::panic::PanicInfo is deprecated on nightly (>=1.81)
-pub fn crash_handler(info: &std::panic::PanicInfo) {
+pub fn crash_handler(info: &std::panic::PanicHookInfo) {
     let backtrace = std::backtrace::Backtrace::capture();
     let panic = PanicInfo::from_hook(info);
     eprintln!("{panic}stack backtrace:\n{backtrace}");
@@ -19,8 +18,7 @@ struct PanicInfo {
     pub column: u32,
 }
 impl PanicInfo {
-    #[allow(deprecated)] // std::panic::PanicInfo is deprecated on nightly (>=1.81)
-    pub fn from_hook(info: &std::panic::PanicInfo) -> Self {
+    pub fn from_hook(info: &std::panic::PanicHookInfo) -> Self {
         let current_thread = std::thread::current();
         let thread = current_thread.name().unwrap_or("<unnamed>");
         let msg = Self::payload(info.payload());

--- a/crates/zng-ext-image/src/render.rs
+++ b/crates/zng-ext-image/src/render.rs
@@ -210,7 +210,7 @@ impl IMAGES {
 }
 
 /// Images render window hook.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub struct IMAGES_WINDOW;
 impl IMAGES_WINDOW {
     /// Sets the windows service used to manage the headless windows used to render images.
@@ -331,7 +331,7 @@ static_id! {
 /// Controls properties of the render window used by [`IMAGES.render`].
 ///
 /// [`IMAGES.render`]: IMAGES::render
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub struct IMAGE_RENDER;
 impl IMAGE_RENDER {
     /// If the current context is an [`IMAGES.render`] closure, window or widget.

--- a/crates/zng-ext-input/src/focus.rs
+++ b/crates/zng-ext-input/src/focus.rs
@@ -1177,7 +1177,6 @@ impl FocusService {
     }
 
     #[must_use]
-    #[allow(clippy::too_many_arguments)]
     fn focus_direct(
         &mut self,
         widget_id: WidgetId,

--- a/crates/zng-ext-input/src/focus/cmd.rs
+++ b/crates/zng-ext-input/src/focus/cmd.rs
@@ -105,7 +105,6 @@ pub(super) struct FocusCommands {
     exit_handle: CommandHandle,
     enter_handle: CommandHandle,
 
-    #[allow(dead_code)]
     focus_handle: CommandHandle,
 }
 impl FocusCommands {

--- a/crates/zng-ext-input/src/focus/focus_info.rs
+++ b/crates/zng-ext-input/src/focus/focus_info.rs
@@ -258,7 +258,7 @@ pub struct FocusRequest {
 }
 
 impl FocusRequest {
-    #[allow(missing_docs)]
+    /// New request from target and highlight.
     pub fn new(target: FocusTarget, highlight: bool) -> Self {
         Self {
             target,

--- a/crates/zng-ext-input/src/focus/iter.rs
+++ b/crates/zng-ext-input/src/focus/iter.rs
@@ -123,7 +123,6 @@ where
     where
         F: FnMut(&WidgetFocusInfo) -> w_iter::TreeFilter,
     {
-        #[allow(clippy::filter_next)]
         self.tree_filter(filter).next()
     }
 

--- a/crates/zng-ext-input/src/pointer_capture.rs
+++ b/crates/zng-ext-input/src/pointer_capture.rs
@@ -284,7 +284,7 @@ impl PointerCaptureManager {
 /// # Provider
 ///
 /// This service is provided by the [`PointerCaptureManager`] extension.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub struct POINTER_CAPTURE;
 impl POINTER_CAPTURE {
     /// Variable that gets the current capture target and mode.

--- a/crates/zng-ext-l10n/src/service.rs
+++ b/crates/zng-ext-l10n/src/service.rs
@@ -59,7 +59,6 @@ impl L10nService {
         self.app_lang.clone()
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn localized_message(
         &mut self,
         langs: Langs,

--- a/crates/zng-ext-l10n/src/types.rs
+++ b/crates/zng-ext-l10n/src/types.rs
@@ -629,7 +629,6 @@ impl<V> LangMap<V> {
     }
 
     /// Iterate over key-value pairs.
-    #[allow(clippy::map_identity)] // false positive, already fixed https://github.com/rust-lang/rust-clippy/pull/11792
     pub fn iter(&self) -> impl std::iter::ExactSizeIterator<Item = (&Lang, &V)> {
         self.inner.iter().map(|(k, v)| (k, v))
     }

--- a/crates/zng-ext-undo/src/lib.rs
+++ b/crates/zng-ext-undo/src/lib.rs
@@ -10,7 +10,7 @@
 #![warn(missing_docs)]
 #![recursion_limit = "256"]
 // suppress nag about very simple boxed closure signatures.
-#![allow(clippy::type_complexity)]
+#![expect(clippy::type_complexity)]
 
 use std::{
     any::Any,

--- a/crates/zng-ext-window/src/control.rs
+++ b/crates/zng-ext-window/src/control.rs
@@ -2086,7 +2086,7 @@ impl ContentCtrl {
     }
 
     /// Layout content if there was a pending request, returns `Some(final_size)`.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn layout(
         &mut self,
         layout_widgets: Arc<LayoutUpdates>,

--- a/crates/zng-ext-window/src/lib.rs
+++ b/crates/zng-ext-window/src/lib.rs
@@ -9,7 +9,7 @@
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 // suppress nag about very simple boxed closure signatures.
-#![allow(clippy::type_complexity)]
+#![expect(clippy::type_complexity)]
 
 #[macro_use]
 extern crate bitflags;

--- a/crates/zng-ext-window/src/monitor.rs
+++ b/crates/zng-ext-window/src/monitor.rs
@@ -351,7 +351,6 @@ pub enum MonitorQuery {
     /// If the closure returns `None` the `ParentOrPrimary` query is used, if there is any.
     ///
     /// You can use the [`MONITORS`] service in the query closure to select a monitor.
-    #[allow(clippy::type_complexity)]
     Query(Arc<dyn Fn() -> Option<MonitorInfo> + Send + Sync>),
 }
 impl MonitorQuery {

--- a/crates/zng-ext-window/src/service.rs
+++ b/crates/zng-ext-window/src/service.rs
@@ -1720,7 +1720,7 @@ impl WindowLoading {
 /// Extensions methods for [`WINDOW`] contexts of windows open by [`WINDOWS`].
 ///
 /// [`WINDOW`]: zng_app::window::WINDOW
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub trait WINDOW_Ext {
     /// Clone a reference to the variables that get and set window properties.
     fn vars(&self) -> super::WindowVars {
@@ -1880,7 +1880,7 @@ impl ImageRenderWindowsService for WINDOWS {
 }
 
 /// Window focused widget hook.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub struct WINDOW_FOCUS;
 impl WINDOW_FOCUS {
     /// Setup a var that is controlled by the focus service and tracks the focused widget.

--- a/crates/zng-ext-window/src/types.rs
+++ b/crates/zng-ext-window/src/types.rs
@@ -58,7 +58,7 @@ impl WindowRoot {
     /// * `headless_monitor` - "Monitor" configuration used in [headless mode](zng_app::window::WindowMode::is_headless).
     /// * `start_focused` - If the window is forced to be the foreground keyboard focus after opening.
     /// * `root` - The root widget's outermost `CONTEXT` node, the window uses this and the `root_id` to form the root widget.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         root_id: WidgetId,
         start_position: StartPosition,
@@ -90,7 +90,7 @@ impl WindowRoot {
     /// See [`new`] for other parameters.
     ///
     /// [`new`]: Self::new
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new_container(
         root_id: WidgetId,
         start_position: StartPosition,

--- a/crates/zng-layout/src/unit/transform.rs
+++ b/crates/zng-layout/src/unit/transform.rs
@@ -534,7 +534,7 @@ impl MatrixDecomposed3D {
             scale.1 *= -1.0;
             scale.2 *= -1.0;
 
-            #[allow(clippy::needless_range_loop)]
+            #[expect(clippy::needless_range_loop)]
             for i in 0..3 {
                 row[i][0] *= -1.0;
                 row[i][1] *= -1.0;

--- a/crates/zng-state-map/src/lib.rs
+++ b/crates/zng-state-map/src/lib.rs
@@ -480,7 +480,7 @@ pub mod state_map {
     {
         /// Ensures a value is in the entry by inserting the default value if empty,
         /// and returns a mutable reference to the value in the entry.
-        #[allow(clippy::unwrap_or_default)]
+        #[expect(clippy::unwrap_or_default)]
         pub fn or_default(self) -> &'a mut T {
             self.or_insert_with(Default::default)
         }

--- a/crates/zng-task/src/crate_util.rs
+++ b/crates/zng-task/src/crate_util.rs
@@ -1,4 +1,5 @@
 /// Converts a [`std::panic::catch_unwind`] payload to a str.
+#[allow(clippy::manual_unwrap_or)] // false positive, already fixed for Rust 1.82
 pub fn panic_str<'s>(payload: &'s Box<dyn std::any::Any + Send + 'static>) -> &'s str {
     if let Some(s) = payload.downcast_ref::<&str>() {
         s

--- a/crates/zng-task/src/crate_util.rs
+++ b/crates/zng-task/src/crate_util.rs
@@ -1,5 +1,5 @@
 /// Converts a [`std::panic::catch_unwind`] payload to a str.
-#[allow(clippy::manual_unwrap_or)] // false positive, already fixed for Rust 1.82
+#[expect(clippy::manual_unwrap_or)] // false positive, already fixed for Rust 1.82
 pub fn panic_str<'s>(payload: &'s Box<dyn std::any::Any + Send + 'static>) -> &'s str {
     if let Some(s) = payload.downcast_ref::<&str>() {
         s

--- a/crates/zng-task/src/http.rs
+++ b/crates/zng-task/src/http.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "http")]
 // suppress nag about very simple boxed closure signatures.
-#![allow(clippy::type_complexity)]
+#![expect(clippy::type_complexity)]
 
 //! HTTP client.
 //!

--- a/crates/zng-task/src/http/cache.rs
+++ b/crates/zng-task/src/http/cache.rs
@@ -98,7 +98,6 @@ impl From<hcs::CachePolicy> for CachePolicy {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[allow(clippy::large_enum_variant)]
 enum PolicyInner {
     Policy(hcs::CachePolicy),
     Permanent(PermanentHeader),

--- a/crates/zng-task/src/lib.rs
+++ b/crates/zng-task/src/lib.rs
@@ -882,7 +882,7 @@ fn default_deadline(deadline: Deadline) -> Pin<Box<dyn Future<Output = ()> + Sen
 }
 
 /// Deadline APP integration.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub struct DEADLINE_APP;
 
 impl DEADLINE_APP {

--- a/crates/zng-time/src/lib.rs
+++ b/crates/zng-time/src/lib.rs
@@ -69,7 +69,7 @@ impl INSTANT {
 }
 
 /// App control of the [`INSTANT`] service in an app context.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub struct INSTANT_APP;
 impl INSTANT_APP {
     /// Set how the app controls the time.

--- a/crates/zng-txt/src/lib.rs
+++ b/crates/zng-txt/src/lib.rs
@@ -138,7 +138,7 @@ impl Txt {
     /// consider using [`from_string`] instead.
     ///
     /// [`from_string`]: Self::from_string
-    #[allow(clippy::should_implement_trait)] // have implemented trait, this one is infallible.
+    #[expect(clippy::should_implement_trait)] // have implemented trait, this one is infallible.
     pub fn from_str(s: &str) -> Txt {
         if s.is_empty() {
             Self::from_static("")

--- a/crates/zng-unit/src/px_dip.rs
+++ b/crates/zng-unit/src/px_dip.rs
@@ -446,7 +446,7 @@ impl num_traits::ToPrimitive for Dip {
 }
 impl num_traits::NumCast for Dip {
     fn from<T: num_traits::ToPrimitive>(n: T) -> Option<Self> {
-        #[allow(clippy::manual_map)]
+        #[expect(clippy::manual_map)]
         if let Some(n) = n.to_f32() {
             Some(Dip::new_f32(n))
         } else if let Some(n) = n.to_i32() {

--- a/crates/zng-var/src/animation/easing.rs
+++ b/crates/zng-var/src/animation/easing.rs
@@ -180,7 +180,7 @@ impl fmt::Debug for EasingFn {
 }
 impl EasingFn {
     /// Create a closure that calls the easing function.
-    #[allow(clippy::redundant_closure)] // false positive
+    #[expect(clippy::redundant_closure)] // false positive
     pub fn ease_fn(&self) -> impl Fn(EasingTime) -> EasingStep + Send + Sync + 'static {
         let me = self.clone();
         move |t| me(t)

--- a/crates/zng-var/src/contextualized.rs
+++ b/crates/zng-var/src/contextualized.rs
@@ -76,7 +76,7 @@ pub struct ContextualizedVar<T> {
     actual: ActualLock![T],
 }
 
-#[allow(clippy::extra_unused_type_parameters)]
+#[expect(clippy::extra_unused_type_parameters)]
 fn borrow_init_impl<'a, T>(
     actual: &'a ActualLock![T],
     init: &ActualInit![T],

--- a/crates/zng-var/src/impls.rs
+++ b/crates/zng-var/src/impls.rs
@@ -330,7 +330,7 @@ fn lerp_rgba_linear(mut from: Rgba, to: Rgba, factor: Factor) -> Rgba {
 }
 
 /// API for app implementers to replace the transitionable implementation for foreign types.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub struct TRANSITIONABLE_APP;
 impl TRANSITIONABLE_APP {
     /// Replace the [`Rgba`] lerp implementation.

--- a/crates/zng-var/src/lib.rs
+++ b/crates/zng-var/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
 // suppress nag about very simple boxed closure signatures.
-#![allow(clippy::type_complexity)]
+#![expect(clippy::type_complexity)]
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 #![deny(clippy::future_not_send)]

--- a/crates/zng-var/src/merge.rs
+++ b/crates/zng-var/src/merge.rs
@@ -57,7 +57,7 @@ impl<T: VarValue, V: Var<T>> ArcMergeVarInput<T, V> {
         ArcMergeVarInput(PhantomData)
     }
 
-    #[allow(clippy::borrowed_box)]
+    #[expect(clippy::borrowed_box)]
     pub fn get<'v>(&self, value: &'v Box<dyn AnyVarValue>) -> &'v T {
         (**value).as_any().downcast_ref::<T>().unwrap()
     }
@@ -83,7 +83,7 @@ pub struct WeakMergeVar<T: VarValue>(Weak<Data<T>>);
 
 impl<T: VarValue> ArcMergeVar<T> {
     #[doc(hidden)]
-    #[allow(clippy::new_ret_no_self)]
+    #[expect(clippy::new_ret_no_self)]
     pub fn new(inputs: Box<[BoxedAnyVar]>, merge: impl FnMut(&[Box<dyn AnyVarValue>]) -> T + Send + 'static) -> BoxedVar<T> {
         if inputs.iter().any(|v| v.is_contextual()) {
             let merge = Arc::new(Mutex::new(merge));
@@ -511,7 +511,7 @@ pub struct MergeVarInputs<'a, I: VarValue> {
 }
 impl<'a, I: VarValue> MergeVarInputs<'a, I> {
     /// Number of inputs.
-    #[allow(clippy::len_without_is_empty)]
+    #[expect(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.inputs.len()
     }

--- a/crates/zng-var/src/vars.rs
+++ b/crates/zng-var/src/vars.rs
@@ -302,7 +302,7 @@ impl VARS {
 }
 
 /// VARS APP integration.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub struct VARS_APP;
 impl VARS_APP {
     /// Register a closure called when [`apply_updates`] should be called because there are changes pending.

--- a/crates/zng-var/src/when.rs
+++ b/crates/zng-var/src/when.rs
@@ -110,7 +110,7 @@ impl<T: VarValue> WhenVarBuilder<T> {
     fn build_impl(mut self) -> ArcWhenVar<T> {
         self.conditions.shrink_to_fit();
         for (c, v) in self.conditions.iter_mut() {
-            #[allow(unreachable_code)]
+            #[expect(unreachable_code)]
             fn panic_placeholder<T: VarValue>() -> BoxedVar<T> {
                 types::ContextualizedVar::<T>::new(|| LocalVar(unreachable!())).boxed()
             }

--- a/crates/zng-view-api/src/dialog.rs
+++ b/crates/zng-view-api/src/dialog.rs
@@ -65,13 +65,13 @@ pub enum MsgDialogButtons {
 /// Response to a message dialog.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum MsgDialogResponse {
-    #[allow(missing_docs)]
+    /// Message received or approved.
     Ok,
-    #[allow(missing_docs)]
+    /// Question approved.
     Yes,
-    #[allow(missing_docs)]
+    /// Question denied.
     No,
-    #[allow(missing_docs)]
+    /// Message denied.
     Cancel,
     /// Failed to show the message.
     ///

--- a/crates/zng-view-api/src/display_list.rs
+++ b/crates/zng-view-api/src/display_list.rs
@@ -238,7 +238,7 @@ impl DisplayListBuilder {
     }
 
     /// Push a normal border.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn push_border(
         &mut self,
         bounds: PxRect,
@@ -258,7 +258,6 @@ impl DisplayListBuilder {
     }
 
     /// Push a nine-patch border.
-    #[allow(clippy::too_many_arguments)]
     pub fn push_nine_patch_border(
         &mut self,
         bounds: PxRect,
@@ -297,7 +296,7 @@ impl DisplayListBuilder {
     }
 
     /// Push an image.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn push_image(
         &mut self,
         clip_rect: PxRect,
@@ -333,7 +332,7 @@ impl DisplayListBuilder {
     }
 
     /// Push a linear gradient rectangle.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn push_linear_gradient(
         &mut self,
         clip_rect: PxRect,
@@ -358,7 +357,7 @@ impl DisplayListBuilder {
     }
 
     /// Push a radial gradient rectangle.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn push_radial_gradient(
         &mut self,
         clip_rect: PxRect,
@@ -387,7 +386,7 @@ impl DisplayListBuilder {
     }
 
     /// Push a conic gradient rectangle.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn push_conic_gradient(
         &mut self,
         clip_rect: PxRect,

--- a/crates/zng-view-api/src/font.rs
+++ b/crates/zng-view-api/src/font.rs
@@ -41,9 +41,9 @@ pub type FontVariationName = [u8; 4];
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct GlyphInstance {
-    #[allow(missing_docs)]
+    /// Glyph id.
     pub index: GlyphIndex,
-    #[allow(missing_docs)]
+    /// Glyph position.
     pub point: euclid::Point2D<f32, Px>,
 }
 

--- a/crates/zng-view-api/src/image.rs
+++ b/crates/zng-view-api/src/image.rs
@@ -279,7 +279,7 @@ pub struct ImagePpi {
     pub y: f32,
 }
 impl ImagePpi {
-    #[allow(missing_docs)]
+    /// New from x, y.
     pub const fn new(x: f32, y: f32) -> Self {
         Self { x, y }
     }

--- a/crates/zng-view-api/src/ipc.rs
+++ b/crates/zng-view-api/src/ipc.rs
@@ -302,7 +302,6 @@ pub(crate) struct AppInit {
     //    Workaround-sender-for-response-channel,
     //    EventReceiver,
     // )
-    #[allow(clippy::type_complexity)]
     init: flume::Receiver<AppInitMsg>,
     name: Txt,
 }
@@ -491,7 +490,7 @@ fn handle_recv_error(e: flume::RecvError) -> Disconnected {
 }
 
 #[cfg(ipc)]
-#[allow(clippy::boxed_local)]
+#[expect(clippy::boxed_local)]
 fn handle_send_error(e: ipc_channel::Error) -> Disconnected {
     match *e {
         ipc_channel::ErrorKind::Io(e) => {

--- a/crates/zng-view-api/src/keyboard.rs
+++ b/crates/zng-view-api/src/keyboard.rs
@@ -1986,7 +1986,7 @@ impl Key {
     }
 
     /// Gets the named key, or `Char` or `Str`.
-    #[allow(clippy::should_implement_trait)]
+    #[expect(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         let mut n = s.chars();
         if let Some(c) = n.next() {

--- a/crates/zng-view-api/src/types.rs
+++ b/crates/zng-view-api/src/types.rs
@@ -565,7 +565,7 @@ pub enum Event {
 }
 impl Event {
     /// Change `self` to incorporate `other` or returns `other` if both events cannot be coalesced.
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn coalesce(&mut self, other: Event) -> Result<(), Event> {
         use Event::*;
 

--- a/crates/zng-view/build.rs
+++ b/crates/zng-view/build.rs
@@ -10,7 +10,6 @@ fn main() {
 fn tp_licenses() {
     #[cfg(feature = "bundle_licenses")]
     {
-        #[allow(unused_mut)]
         let mut licenses = zng_tp_licenses::collect_cargo_about("../../.cargo/about.toml");
 
         avif_licenses(&mut licenses);

--- a/crates/zng-view/src/display_list.rs
+++ b/crates/zng-view/src/display_list.rs
@@ -269,7 +269,7 @@ impl DisplayListCache {
         r
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn reuse(
         &self,
         frame_id: FrameId,
@@ -339,7 +339,7 @@ impl DisplayListCache {
 
     /// Apply updates, returns the webrender update if the renderer can also be updated and there are any updates,
     /// or returns a new frame if a new frame must be rendered.
-    #[allow(clippy::result_large_err)] // both are large
+    #[expect(clippy::result_large_err)] // both are large
     pub fn update(
         &mut self,
         ext: &mut dyn DisplayListExtension,

--- a/crates/zng-view/src/extensions.rs
+++ b/crates/zng-view/src/extensions.rs
@@ -365,7 +365,7 @@ pub trait AsyncBlobRasterizer: Send + Any {
 
 /// Arguments for [`BlobExtension::prepare_resources`].
 pub struct BlobPrepareArgs<'a> {
-    #[allow(missing_docs)]
+    /// Webrender services.
     pub services: &'a dyn webrender::api::BlobImageResources,
     /// Requests targeting any of the blob extensions. Each extension must
     /// inspect the requests to find the ones targeting it.
@@ -381,9 +381,9 @@ pub struct BlobAddArgs {
     /// Encoded data.
     pub data: std::sync::Arc<webrender::api::BlobImageData>,
 
-    #[allow(missing_docs)]
+    /// Webrender value.
     pub visible_rect: webrender::api::units::DeviceIntRect,
-    #[allow(missing_docs)]
+    /// Webrender value.
     pub tile_size: webrender::api::TileSize,
 }
 
@@ -395,9 +395,9 @@ pub struct BlobUpdateArgs {
     pub key: webrender::api::BlobImageKey,
     /// Encoded data.
     pub data: std::sync::Arc<webrender::api::BlobImageData>,
-    #[allow(missing_docs)]
+    /// Webrender value.
     pub visible_rect: webrender::api::units::DeviceIntRect,
-    #[allow(missing_docs)]
+    /// Webrender value.
     pub dirty_rect: webrender::api::units::BlobDirtyRect,
 }
 

--- a/crates/zng-view/src/gl.rs
+++ b/crates/zng-view/src/gl.rs
@@ -318,7 +318,6 @@ impl GlContextManager {
         Ok((window, context))
     }
 
-    #[allow(unreachable_code)]
     fn create_headed_swgl(
         &mut self,
         event_loop: &ActiveEventLoop,
@@ -474,7 +473,6 @@ impl GlContextManager {
         Ok(context)
     }
 
-    #[allow(unreachable_code)]
     fn create_headless_swgl(&mut self, id: WindowId) -> Result<GlContext, Box<dyn Error>> {
         #[cfg(not(feature = "software"))]
         {
@@ -540,13 +538,15 @@ impl fmt::Debug for GlContext {
 }
 impl GlContext {
     /// If the context is backed by SWGL.
-    #[allow(unreachable_code)]
     pub(crate) fn is_software(&self) -> bool {
         #[cfg(feature = "software")]
         {
-            return matches!(&self.backend, GlBackend::Swgl { .. });
+            matches!(&self.backend, GlBackend::Swgl { .. })
         }
-        false
+        #[cfg(not(feature = "software"))]
+        {
+            false
+        }
     }
 
     pub fn is_current(&self) -> bool {
@@ -906,7 +906,6 @@ mod blit {
         };
         use x11_dl::xlib::{GCGraphicsExposures, TrueColor, XGCValues, XVisualInfo, Xlib, ZPixmap, _XDisplay};
 
-        #[allow(clippy::large_enum_variant)]
         pub enum XLibOrWaylandBlit {
             XLib { xlib: Xlib, display: *mut _XDisplay, window: u64 },
             Wayland { surface: *const WlSurface, data: WaylandData },

--- a/crates/zng-view/src/image_cache.rs
+++ b/crates/zng-view/src/image_cache.rs
@@ -1257,7 +1257,6 @@ mod capture {
 
     impl ImageCache {
         /// Create frame_image for an `Api::frame_image` request.
-        #[allow(clippy::too_many_arguments)]
         pub fn frame_image(
             &mut self,
             gl: &dyn gleam::gl::Gl,

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -85,7 +85,6 @@
 //! # Crate
 //!
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
-#![allow(clippy::needless_doctest_main)]
 #![doc(test(no_crate_inject))]
 #![warn(missing_docs)]
 #![warn(unused_extern_crates)]
@@ -279,7 +278,7 @@ pub extern "C" fn extern_run_same_process(patch: &StaticPatch, run_app: extern "
         patch.install();
     }
 
-    #[allow(clippy::redundant_closure)]
+    #[expect(clippy::redundant_closure)] // false positive
     run_same_process(move || run_app())
 }
 #[cfg(ipc)]
@@ -2175,7 +2174,6 @@ pub(crate) enum AppEvent {
 /// These *events* are detached from [`AppEvent`] so that we can continue receiving requests while
 /// the main loop is blocked in a resize operation.
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
 enum RequestEvent {
     /// A request from the [`Api`].
     Request(Request),

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -283,18 +283,15 @@ pub extern "C" fn extern_run_same_process(patch: &StaticPatch, run_app: extern "
     run_same_process(move || run_app())
 }
 #[cfg(ipc)]
-#[allow(deprecated)] // std::panic::PanicInfo is deprecated on nightly (>=1.81)
-fn init_abort(info: &std::panic::PanicInfo) {
+fn init_abort(info: &std::panic::PanicHookInfo) {
     panic_hook(info, "note: aborting to respawn");
 }
 #[cfg(ipc)]
-#[allow(deprecated)] // std::panic::PanicInfo is deprecated on nightly (>=1.81)
-fn ffi_abort(info: &std::panic::PanicInfo) {
+fn ffi_abort(info: &std::panic::PanicHookInfo) {
     panic_hook(info, "note: aborting to avoid unwind across FFI");
 }
 #[cfg(ipc)]
-#[allow(deprecated)] // std::panic::PanicInfo is deprecated on nightly (>=1.81)
-fn panic_hook(info: &std::panic::PanicInfo, details: &str) {
+fn panic_hook(info: &std::panic::PanicHookInfo, details: &str) {
     // see `default_hook` in https://doc.rust-lang.org/src/std/panicking.rs.html#182
 
     let panic = util::SuppressedPanic::from_hook(info, std::backtrace::Backtrace::force_capture());

--- a/crates/zng-view/src/util.rs
+++ b/crates/zng-view/src/util.rs
@@ -1067,8 +1067,8 @@ pub fn get_instance_handle() -> isize {
 pub mod taskbar_com {
     // copied from winit
 
-    #![allow(non_snake_case)]
-    #![allow(non_upper_case_globals)]
+    #![expect(non_snake_case)]
+    #![expect(non_upper_case_globals)]
 
     use std::ffi::c_void;
 

--- a/crates/zng-view/src/util.rs
+++ b/crates/zng-view/src/util.rs
@@ -957,8 +957,7 @@ pub(crate) struct SuppressedPanic {
 }
 impl SuppressedPanic {
     #[cfg(ipc)]
-    #[allow(deprecated)] // std::panic::PanicInfo is deprecated on nightly (>=1.81)
-    pub fn from_hook(info: &std::panic::PanicInfo, backtrace: Backtrace) -> Self {
+    pub fn from_hook(info: &std::panic::PanicHookInfo, backtrace: Backtrace) -> Self {
         let current_thread = std::thread::current();
         let thread = current_thread.name().unwrap_or("<unnamed>");
         let msg = Self::payload(info.payload());

--- a/crates/zng-view/src/window.rs
+++ b/crates/zng-view/src/window.rs
@@ -138,7 +138,7 @@ impl fmt::Debug for Window {
     }
 }
 impl Window {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn open(
         gen: ViewProcessGen,
         cfg_icon: Option<Icon>,

--- a/crates/zng-wgt-grid/src/lib.rs
+++ b/crates/zng-wgt-grid/src/lib.rs
@@ -1126,7 +1126,7 @@ impl GridLayout {
 
                 let rows_len = children[1].len();
 
-                #[allow(clippy::comparison_chain)]
+                #[expect(clippy::comparison_chain)]
                 if rows_len < max_needed_len {
                     let auto = downcast_auto(&mut children[1]);
                     let mut index = rows_len;
@@ -1167,7 +1167,7 @@ impl GridLayout {
 
                 let cols_len = children[0].len();
 
-                #[allow(clippy::comparison_chain)]
+                #[expect(clippy::comparison_chain)]
                 if cols_len < max_needed_len {
                     let auto = downcast_auto(&mut children[0]);
                     let mut index = cols_len;

--- a/crates/zng-wgt-input/src/state.rs
+++ b/crates/zng-wgt-input/src/state.rs
@@ -288,7 +288,7 @@ pub fn is_touched(child: impl UiNode, state: impl IntoVar<bool>) -> impl UiNode 
 /// [`is_cap_touched_from_start`]: fn@is_cap_touched_from_start
 #[property(EVENT)]
 pub fn is_touched_from_start(child: impl UiNode, state: impl IntoVar<bool>) -> impl UiNode {
-    #[allow(clippy::mutable_key_type)] // EventPropagationHandle compares pointers, not value
+    #[expect(clippy::mutable_key_type)] // EventPropagationHandle compares pointers, not value
     let mut touches_started = HashSet::new();
     event_state(child, state, false, TOUCHED_EVENT, move |args| {
         if args.is_touch_enter_enabled() {
@@ -356,7 +356,7 @@ pub fn is_cap_touched(child: impl UiNode, state: impl IntoVar<bool>) -> impl UiN
 /// [`ENABLED`]: Interactivity::ENABLED
 #[property(EVENT)]
 pub fn is_cap_touched_from_start(child: impl UiNode, state: impl IntoVar<bool>) -> impl UiNode {
-    #[allow(clippy::mutable_key_type)] // EventPropagationHandle compares pointers, not value
+    #[expect(clippy::mutable_key_type)] // EventPropagationHandle compares pointers, not value
     let mut touches_started = HashSet::new();
     event_state2(
         child,

--- a/crates/zng-wgt-material-icons/src/lib.rs
+++ b/crates/zng-wgt-material-icons/src/lib.rs
@@ -56,7 +56,7 @@ impl zng_app::AppExtension for MaterialIconsManager {
 
         ICONS.register(wgt_fn!(|args: IconRequestArgs| {
             if let Some(strong_key) = args.name().strip_prefix("material/") {
-                #[allow(clippy::type_complexity)]
+                #[expect(clippy::type_complexity)]
                 let sets: &[(&str, fn(&str) -> Option<GlyphIcon>)] = &[
                     #[cfg(feature = "outlined")]
                     ("outlined/", outlined::get),

--- a/crates/zng-wgt-size-offset/src/lib.rs
+++ b/crates/zng-wgt-size-offset/src/lib.rs
@@ -790,7 +790,7 @@ pub fn sticky_size(child: impl UiNode, sticky: impl IntoVar<bool>) -> impl UiNod
 /// [`width`]: fn@width
 /// [`height`]: fn@height
 /// [`Length::Leftover`]: zng_wgt::prelude::Length::Leftover
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub struct WIDGET_SIZE;
 impl WIDGET_SIZE {
     /// Set the width state.

--- a/crates/zng-wgt-style/src/lib.rs
+++ b/crates/zng-wgt-style/src/lib.rs
@@ -9,7 +9,7 @@
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 // suppress nag about very simple boxed closure signatures.
-#![allow(clippy::type_complexity)]
+#![expect(clippy::type_complexity)]
 
 use zng_app::widget::builder::{Importance, PropertyId};
 use zng_wgt::prelude::*;

--- a/crates/zng-wgt-text/src/lib.rs
+++ b/crates/zng-wgt-text/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
 // suppress nag about very simple boxed closure signatures.
-#![allow(clippy::type_complexity)]
+#![expect(clippy::type_complexity)]
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 

--- a/crates/zng-wgt-toggle/src/lib.rs
+++ b/crates/zng-wgt-toggle/src/lib.rs
@@ -1175,7 +1175,6 @@ pub fn checked_popup(child: impl UiNode, popup: impl IntoVar<WidgetFn<()>>) -> i
     })
 }
 
-#[allow(non_snake_case)]
 fn combomark_visual() -> impl UiNode {
     let dropdown = ICONS.get_or(
         ["toggle.dropdown", "material/rounded/keyboard-arrow-down", "keyboard-arrow-down"],

--- a/crates/zng-wgt-window/src/lib.rs
+++ b/crates/zng-wgt-window/src/lib.rs
@@ -25,8 +25,6 @@ use zng_wgt_text::{font_color, lang, FONT_SIZE_VAR};
 pub mod events;
 mod window_properties;
 
-#[allow(clippy::useless_attribute)] // not useless
-#[allow(ambiguous_glob_reexports)] // we override `font_size`.
 pub use self::window_properties::*;
 
 /// A window container.

--- a/crates/zng-wgt/src/func.rs
+++ b/crates/zng-wgt/src/func.rs
@@ -234,7 +234,6 @@ macro_rules! wgt_fn {
 /// service to instantiate widgets for each item.
 ///
 /// The main crate registers some common editors.
-#[allow(non_camel_case_types)]
 pub struct EDITORS;
 impl EDITORS {
     /// Register an `editor` handler.

--- a/crates/zng-wgt/src/lib.rs
+++ b/crates/zng-wgt/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
 // suppress nag about very simple boxed closure signatures.
-#![allow(clippy::type_complexity)]
+#![expect(clippy::type_complexity)]
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 

--- a/crates/zng-wgt/src/node.rs
+++ b/crates/zng-wgt/src/node.rs
@@ -1068,7 +1068,7 @@ pub fn event_state<A: EventArgs, S: VarValue>(
 ///
 /// When the `event#` is received `on_event#` is called, if it provides a new value `merge` is called, if merge
 /// provides a new value the `state` variable is set.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn event_state2<A0, A1, S0, S1, S>(
     child: impl UiNode,
     state: impl IntoVar<S>,
@@ -1136,7 +1136,7 @@ where
 ///
 /// When the `event#` is received `on_event#` is called, if it provides a new value `merge` is called, if merge
 /// provides a new value the `state` variable is set.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn event_state3<A0, A1, A2, S0, S1, S2, S>(
     child: impl UiNode,
     state: impl IntoVar<S>,
@@ -1216,7 +1216,7 @@ where
 ///
 /// When the `event#` is received `on_event#` is called, if it provides a new value `merge` is called, if merge
 /// provides a new value the `state` variable is set.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn event_state4<A0, A1, A2, A3, S0, S1, S2, S3, S>(
     child: impl UiNode,
     state: impl IntoVar<S>,

--- a/crates/zng/src/app.rs
+++ b/crates/zng/src/app.rs
@@ -146,7 +146,7 @@
 //!
 //! ```
 //! # use zng::var::*;
-//! #[allow(non_camel_case_types)]
+//! #[expect(non_camel_case_types)]
 //! pub struct SCREAMING_CASE;
 //! impl SCREAMING_CASE {
 //!     pub fn state(&self) -> impl Var<bool> {
@@ -476,7 +476,7 @@ pub use zng_ext_single_instance::{AppInstanceArgs, APP_INSTANCE_EVENT};
 ///                         child = Text!("Crash (access violation)");
 ///                         on_click = hn_once!(|_| {
 ///                             // SAFETY: deliberate access violation
-///                             #[allow(deref_nullptr)]
+///                             #[expect(deref_nullptr)]
 ///                             unsafe {
 ///                                 *std::ptr::null_mut() = true;
 ///                             }

--- a/crates/zng/src/lib.rs
+++ b/crates/zng/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::needless_doctest_main)]
+#![expect(clippy::needless_doctest_main)]
 #![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
 

--- a/examples/cursor/src/main.rs
+++ b/examples/cursor/src/main.rs
@@ -127,6 +127,6 @@ pub const CURSORS: &[(CursorIcon, &[u8])] = &[
 ];
 
 // (label, cursor_img, fallback)
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub const CURSOR_IMGS: &[(&str, (&[u8], i32, i32), CursorIcon)] =
     &[("custom", (include_bytes!("../../image/res/RGBA8.png"), 4, 6), CursorIcon::Default)];

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -29,7 +29,6 @@ fn main() {
                     image_resolver = markdown::ImageResolver::new(|img| {
                         let mut r: ImageSource = img.into();
                         if let ImageSource::Read(file) = &mut r {
-                            #[allow(clippy::needless_borrows_for_generic_args)] // false positive
                             if file.is_relative() {
                                 *file = zng::env::res(&file);
                             }

--- a/examples/respawn/src/main.rs
+++ b/examples/respawn/src/main.rs
@@ -159,7 +159,7 @@ fn app_crash(crash_name: &'static str) -> impl UiNode {
                 "panic" => panic!("Test app-process crash!"),
                 "access violation" => {
                     // SAFETY: deliberate access violation
-                    #[allow(deref_nullptr)]
+                    #[expect(deref_nullptr)]
                     unsafe {
                         *std::ptr::null_mut() = true;
                     }


### PR DESCRIPTION
Draft until the next Rust Analyzer update, it shows warnings for `#[expect(non_camel_case_types)]` that where suppressed by `allow`.