### PR TITLE
Fix breaking change in 0.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix breaking change in 0.11.5, `UiNodeVec` is only deprecated, but was removed from preludes and re-exports.
 
 # 0.11.5
 

--- a/crates/zng-wgt/src/lib.rs
+++ b/crates/zng-wgt/src/lib.rs
@@ -28,6 +28,8 @@ pub mod prelude {
     pub use crate::__prelude::*;
 }
 mod __prelude {
+    #[allow(deprecated)]
+    pub use zng_app::widget::node::UiNodeVec;
     pub use zng_app::{
         event::{
             command, event, event_args, AnyEventArgs as _, Command, CommandHandle, CommandInfoExt as _, CommandNameExt as _, Event,

--- a/crates/zng/src/lib.rs
+++ b/crates/zng/src/lib.rs
@@ -568,6 +568,8 @@ mod __prelude {
         AsyncBufRead as _, AsyncRead as _, AsyncReadExt as _, AsyncSeek as _, AsyncSeekExt as _, AsyncWrite as _, AsyncWriteExt as _,
     };
 
+    #[allow(deprecated)]
+    pub use zng_app::widget::node::UiNodeVec;
     pub use zng_app::{
         event::{AnyEventArgs as _, CommandInfoExt as _, CommandNameExt as _, CommandParam, EventArgs as _},
         handler::{app_hn, app_hn_once, async_app_hn, async_app_hn_once, async_hn, async_hn_once, hn, hn_once},
@@ -721,6 +723,8 @@ pub mod prelude_wgt {
     pub use crate::__prelude_wgt::*;
 }
 mod __prelude_wgt {
+    #[allow(deprecated)]
+    pub use zng_app::widget::node::UiNodeVec;
     pub use zng_app::{
         event::{
             command, event, event_args, AnyEventArgs as _, Command, CommandHandle, CommandInfoExt as _, CommandNameExt as _, CommandParam,

--- a/crates/zng/src/widget.rs
+++ b/crates/zng/src/widget.rs
@@ -226,6 +226,9 @@ pub mod node {
         with_context_local_init, with_context_var, with_context_var_init, with_index_len_node, with_index_node, with_rev_index_node,
         with_widget_state, with_widget_state_modify,
     };
+
+    #[allow(deprecated)]
+    pub use zng_app::widget::node::UiNodeVec;
 }
 
 /// Expands a struct to a widget struct and macro.

--- a/tools/cargo-do/src/main.rs
+++ b/tools/cargo-do/src/main.rs
@@ -1259,7 +1259,11 @@ fn publish(mut args: Vec<&str>) {
         }
 
         if crates.is_empty() {
-            fatal("missing at least one crate name");
+            if diff_crates {
+                fatal("no changes in main since last version tag");
+            } else {
+                fatal("missing at least one crate name or --diff");
+            }
         }
         if let Some(c) = crates.iter().find(|c| c.starts_with('-')) {
             fatal(f!("expected only crate names, found {:?}", c));


### PR DESCRIPTION
Fix breaking change in 0.11.5, `UiNodeVec` is only deprecated, but was removed from preludes and re-exports.