### PR TITLE
Remove punctuation from command info texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Remove end punctuation from command `info` fields
 
 # 0.11.6
 

--- a/crates/zng-app/l10n/en-US/_.ftl
+++ b/crates/zng-app/l10n/en-US/_.ftl
@@ -1,5 +1,5 @@
 EXIT_CMD =
-    .info = Close all windows and exit.
+    .info = Close all windows and exit
     .name = Exit
 
 OPEN_LICENSES_CMD =

--- a/crates/zng-app/l10n/pt-BR/_.ftl
+++ b/crates/zng-app/l10n/pt-BR/_.ftl
@@ -1,5 +1,5 @@
 EXIT_CMD =
-    .info = Fechar todas as janelas e sair.
+    .info = Fechar todas as janelas e sair
     .name = Sair
 
 OPEN_LICENSES_CMD =

--- a/crates/zng-app/l10n/template/_.ftl
+++ b/crates/zng-app/l10n/template/_.ftl
@@ -1,5 +1,5 @@
 EXIT_CMD =
-    .info = Close all windows and exit.
+    .info = Close all windows and exit
     .name = Exit
 
 OPEN_LICENSES_CMD =

--- a/crates/zng-app/src/event/command.rs
+++ b/crates/zng-app/src/event/command.rs
@@ -56,7 +56,7 @@ use super::*;
 ///     /// Represents the **foo** action.
 ///     pub static FOO_CMD = {
 ///         name: "Foo!",
-///         info: "Does the foo thing.",
+///         info: "Does the foo thing",
 ///         shortcut: shortcut![CTRL+'F'],
 ///     };
 /// }
@@ -92,7 +92,7 @@ use super::*;
 ///     pub static FOO_CMD = {
 ///         l10n!: true,
 ///         name: "Foo!",
-///         info: "Does the foo thing.",
+///         info: "Does the foo thing",
 ///     };
 /// }
 /// ```

--- a/crates/zng-app/src/running.rs
+++ b/crates/zng-app/src/running.rs
@@ -1180,7 +1180,7 @@ command! {
     pub static EXIT_CMD = {
         l10n!: true,
         name: "Exit",
-        info: "Close all windows and exit.",
+        info: "Close all windows and exit",
         shortcut: shortcut!(Exit),
     };
 }

--- a/crates/zng-ext-clipboard/l10n/en-US/_.ftl
+++ b/crates/zng-ext-clipboard/l10n/en-US/_.ftl
@@ -1,11 +1,11 @@
 COPY_CMD =
-    .info = Place a copy of the selection in the clipboard.
+    .info = Place a copy of the selection in the clipboard
     .name = Copy
 
 CUT_CMD =
-    .info = Remove the selection and place it in the clipboard.
+    .info = Remove the selection and place it in the clipboard
     .name = Cut
 
 PASTE_CMD =
-    .info = Insert content from the clipboard.
+    .info = Insert content from the clipboard
     .name = Paste

--- a/crates/zng-ext-clipboard/l10n/pt-BR/_.ftl
+++ b/crates/zng-ext-clipboard/l10n/pt-BR/_.ftl
@@ -1,11 +1,11 @@
 COPY_CMD =
-    .info = Colocar uma cópia da seleção na área de transferência.
+    .info = Colocar uma cópia da seleção na área de transferência
     .name = Copiar
 
 CUT_CMD =
-    .info = Remover a seleção e colocá-la na área de transferência.
+    .info = Remover a seleção e colocá-la na área de transferência
     .name = Recortar
 
 PASTE_CMD =
-    .info = Inserir o conteúdo da área de transferência.
+    .info = Inserir o conteúdo da área de transferência
     .name = Colar

--- a/crates/zng-ext-clipboard/l10n/template/_.ftl
+++ b/crates/zng-ext-clipboard/l10n/template/_.ftl
@@ -1,11 +1,11 @@
 COPY_CMD =
-    .info = Place a copy of the selection in the clipboard.
+    .info = Place a copy of the selection in the clipboard
     .name = Copy
 
 CUT_CMD =
-    .info = Remove the selection and place it in the clipboard.
+    .info = Remove the selection and place it in the clipboard
     .name = Cut
 
 PASTE_CMD =
-    .info = Insert content from the clipboard.
+    .info = Insert content from the clipboard
     .name = Paste

--- a/crates/zng-ext-clipboard/src/lib.rs
+++ b/crates/zng-ext-clipboard/src/lib.rs
@@ -428,7 +428,7 @@ command! {
     pub static CUT_CMD = {
         l10n!: true,
         name: "Cut",
-        info: "Remove the selection and place it in the clipboard.",
+        info: "Remove the selection and place it in the clipboard",
         shortcut: [shortcut!(CTRL+'X'), shortcut!(SHIFT+Delete), shortcut!(Cut)],
         shortcut_filter: ShortcutFilter::FOCUSED | ShortcutFilter::CMD_ENABLED,
         icon: wgt_fn!(|_| ICONS.get("cut")),
@@ -438,7 +438,7 @@ command! {
     pub static COPY_CMD = {
         l10n!: true,
         name: "Copy",
-        info: "Place a copy of the selection in the clipboard.",
+        info: "Place a copy of the selection in the clipboard",
         shortcut: [shortcut!(CTRL+'C'), shortcut!(CTRL+Insert), shortcut!(Copy)],
         shortcut_filter: ShortcutFilter::FOCUSED | ShortcutFilter::CMD_ENABLED,
         icon: wgt_fn!(|_| ICONS.get("copy")),
@@ -448,7 +448,7 @@ command! {
     pub static PASTE_CMD = {
         l10n!: true,
         name: "Paste",
-        info: "Insert content from the clipboard.",
+        info: "Insert content from the clipboard",
         shortcut: [shortcut!(CTRL+'V'), shortcut!(SHIFT+Insert), shortcut!(Paste)],
         shortcut_filter: ShortcutFilter::FOCUSED | ShortcutFilter::CMD_ENABLED,
         icon: wgt_fn!(|_| ICONS.get("paste")),

--- a/crates/zng-ext-input/l10n/en-US/_.ftl
+++ b/crates/zng-ext-input/l10n/en-US/_.ftl
@@ -1,9 +1,9 @@
 FOCUS_ALT_CMD =
-    .info = Focus alt scope.
+    .info = Focus alt scope
     .name = Focus Alt
 
 FOCUS_DOWN_CMD =
-    .info = Focus closest focusable down.
+    .info = Focus closest focusable down
     .name = Focus Down
 
 FOCUS_ENTER_CMD =
@@ -11,25 +11,25 @@ FOCUS_ENTER_CMD =
     .name = Focus Enter
 
 FOCUS_EXIT_CMD =
-    .info = Focus parent focusable, or return focus.
+    .info = Focus parent focusable, or return focus
     .name = Focus Exit
 
 FOCUS_LEFT_CMD =
-    .info = Focus closest focusable left.
+    .info = Focus closest focusable left
     .name = Focus Left
 
 FOCUS_NEXT_CMD =
-    .info = Focus next focusable.
+    .info = Focus next focusable
     .name = Focus Next
 
 FOCUS_PREV_CMD =
-    .info = Focus previous focusable.
+    .info = Focus previous focusable
     .name = Focus Previous
 
 FOCUS_RIGHT_CMD =
-    .info = Focus closest focusable right.
+    .info = Focus closest focusable right
     .name = Focus Right
 
 FOCUS_UP_CMD =
-    .info = Focus closest focusable up.
+    .info = Focus closest focusable up
     .name = Focus Up

--- a/crates/zng-ext-input/l10n/pt-BR/_.ftl
+++ b/crates/zng-ext-input/l10n/pt-BR/_.ftl
@@ -1,35 +1,35 @@
 FOCUS_ALT_CMD =
-    .info = Focar no escopo alternativo.
+    .info = Focar no escopo alternativo
     .name = Focar Alternativo
 
 FOCUS_DOWN_CMD =
-    .info = Focar no focalizável mais próximo abaixo.
+    .info = Focar no focalizável mais próximo abaixo
     .name = Focar Abaixo
 
 FOCUS_ENTER_CMD =
-    .info = Focar no filho focalizável.
+    .info = Focar no filho focalizável
     .name = Focar Entrar
 
 FOCUS_EXIT_CMD =
-    .info = Focar no pai focalizável ou retornar o foco.
+    .info = Focar no pai focalizável ou retornar o foco
     .name = Focar Sair
 
 FOCUS_LEFT_CMD =
-    .info = Focar no focalizável mais próximo à esquerda.
+    .info = Focar no focalizável mais próximo à esquerda
     .name = Focar Esquerda
 
 FOCUS_NEXT_CMD =
-    .info = Focar no próximo focalizável.
+    .info = Focar no próximo focalizável
     .name = Focar Próximo
 
 FOCUS_PREV_CMD =
-    .info = Focar no focalizável anterior.
+    .info = Focar no focalizável anterior
     .name = Focar Anterior
 
 FOCUS_RIGHT_CMD =
-    .info = Focar no focalizável mais próximo à direita.
+    .info = Focar no focalizável mais próximo à direita
     .name = Focar Direita
 
 FOCUS_UP_CMD =
-    .info = Focar no focalizável mais próximo acima.
+    .info = Focar no focalizável mais próximo acima
     .name = Focar Acima

--- a/crates/zng-ext-input/l10n/template/_.ftl
+++ b/crates/zng-ext-input/l10n/template/_.ftl
@@ -1,35 +1,35 @@
 FOCUS_ALT_CMD =
-    .info = Focus alt scope.
+    .info = Focus alt scope
     .name = Focus Alt
 
 FOCUS_DOWN_CMD =
-    .info = Focus closest focusable down.
+    .info = Focus closest focusable down
     .name = Focus Down
 
 FOCUS_ENTER_CMD =
-    .info = Focus child focusable.
+    .info = Focus child focusable
     .name = Focus Enter
 
 FOCUS_EXIT_CMD =
-    .info = Focus parent focusable, or return focus.
+    .info = Focus parent focusable, or return focus
     .name = Focus Exit
 
 FOCUS_LEFT_CMD =
-    .info = Focus closest focusable left.
+    .info = Focus closest focusable left
     .name = Focus Left
 
 FOCUS_NEXT_CMD =
-    .info = Focus next focusable.
+    .info = Focus next focusable
     .name = Focus Next
 
 FOCUS_PREV_CMD =
-    .info = Focus previous focusable.
+    .info = Focus previous focusable
     .name = Focus Previous
 
 FOCUS_RIGHT_CMD =
-    .info = Focus closest focusable right.
+    .info = Focus closest focusable right
     .name = Focus Right
 
 FOCUS_UP_CMD =
-    .info = Focus closest focusable up.
+    .info = Focus closest focusable up
     .name = Focus Up

--- a/crates/zng-ext-input/src/focus/cmd.rs
+++ b/crates/zng-ext-input/src/focus/cmd.rs
@@ -17,7 +17,7 @@ command! {
     pub static FOCUS_NEXT_CMD = {
         l10n!: true,
         name: "Focus Next",
-        info: "Focus next focusable.",
+        info: "Focus next focusable",
         shortcut: shortcut!(Tab),
     };
 
@@ -25,7 +25,7 @@ command! {
     pub static FOCUS_PREV_CMD = {
         l10n!: true,
         name: "Focus Previous",
-        info: "Focus previous focusable.",
+        info: "Focus previous focusable",
         shortcut: shortcut!(SHIFT+Tab),
     };
 
@@ -33,7 +33,7 @@ command! {
     pub static FOCUS_ALT_CMD = {
         l10n!: true,
         name: "Focus Alt",
-        info: "Focus alt scope.",
+        info: "Focus alt scope",
         shortcut: shortcut!(Alt),
     };
 
@@ -41,7 +41,7 @@ command! {
     pub static FOCUS_ENTER_CMD = {
         l10n!: true,
         name: "Focus Enter",
-        info: "Focus child focusable.",
+        info: "Focus child focusable",
         shortcut: [shortcut!(Enter), shortcut!(ALT+Enter)],
     };
 
@@ -49,7 +49,7 @@ command! {
     pub static FOCUS_EXIT_CMD = {
         l10n!: true,
         name: "Focus Exit",
-        info: "Focus parent focusable, or return focus.",
+        info: "Focus parent focusable, or return focus",
         shortcut: [shortcut!(Escape), shortcut!(ALT+Escape)],
     };
 
@@ -57,7 +57,7 @@ command! {
     pub static FOCUS_UP_CMD = {
         l10n!: true,
         name: "Focus Up",
-        info: "Focus closest focusable up.",
+        info: "Focus closest focusable up",
         shortcut: [shortcut!(ArrowUp), shortcut!(ALT+ArrowUp)],
     };
 
@@ -65,7 +65,7 @@ command! {
     pub static FOCUS_DOWN_CMD = {
         l10n!: true,
         name: "Focus Down",
-        info: "Focus closest focusable down.",
+        info: "Focus closest focusable down",
         shortcut: [shortcut!(ArrowDown), shortcut!(ALT+ArrowDown)],
     };
 
@@ -73,7 +73,7 @@ command! {
     pub static FOCUS_LEFT_CMD = {
         l10n!: true,
         name: "Focus Left",
-        info: "Focus closest focusable left.",
+        info: "Focus closest focusable left",
         shortcut: [shortcut!(ArrowLeft), shortcut!(ALT+ArrowLeft)],
     };
 
@@ -81,7 +81,7 @@ command! {
     pub static FOCUS_RIGHT_CMD = {
         l10n!: true,
         name: "Focus Right",
-        info: "Focus closest focusable right.",
+        info: "Focus closest focusable right",
         shortcut: [shortcut!(ArrowRight), shortcut!(ALT+ArrowRight)],
     };
 

--- a/crates/zng-ext-window/l10n/en-US/_.ftl
+++ b/crates/zng-ext-window/l10n/en-US/_.ftl
@@ -1,23 +1,23 @@
 CLOSE_CMD =
-    .info = Close the window.
+    .info = Close the window
     .name = Close
 
 EXCLUSIVE_FULLSCREEN_CMD =
-    .info = Toggle exclusive fullscreen mode on the window.
+    .info = Toggle exclusive fullscreen mode on the window
     .name = Exclusive Fullscreen
 
 FULLSCREEN_CMD =
-    .info = Toggle fullscreen mode on the window.
+    .info = Toggle fullscreen mode on the window
     .name = Fullscreen
 
 MAXIMIZE_CMD =
-    .info = Maximize the window.
+    .info = Maximize the window
     .name = Maximize
 
 MINIMIZE_CMD =
-    .info = Minimize the window.
+    .info = Minimize the window
     .name = Minimize
 
 RESTORE_CMD =
-    .info = Restores the window to its previous non-minimized state or normal state.
+    .info = Restores the window to its previous non-minimized state or normal state
     .name = Restore

--- a/crates/zng-ext-window/l10n/pt-BR/_.ftl
+++ b/crates/zng-ext-window/l10n/pt-BR/_.ftl
@@ -1,23 +1,23 @@
 CLOSE_CMD =
-    .info = Fechar a janela.
+    .info = Fechar a janela
     .name = Fechar
 
 EXCLUSIVE_FULLSCREEN_CMD =
-    .info = Alternar o modo de tela cheia exclusivo na janela.
+    .info = Alternar o modo de tela cheia exclusivo na janela
     .name = Tela Cheia Exclusiva
 
 FULLSCREEN_CMD =
-    .info = Alternar o modo tela cheia na janela.
+    .info = Alternar o modo tela cheia na janela
     .name = Tela Cheia
 
 MAXIMIZE_CMD =
-    .info = Maximizar a janela.
+    .info = Maximizar a janela
     .name = Maximizar
 
 MINIMIZE_CMD =
-    .info = Minimizar a janela.
+    .info = Minimizar a janela
     .name = Minimizar
 
 RESTORE_CMD =
-    .info = Restaurar a janela para sua posição e tamanho anterior.
+    .info = Restaurar a janela para sua posição e tamanho anterior
     .name = Restaurar

--- a/crates/zng-ext-window/l10n/template/_.ftl
+++ b/crates/zng-ext-window/l10n/template/_.ftl
@@ -1,23 +1,23 @@
 CLOSE_CMD =
-    .info = Close the window.
+    .info = Close the window
     .name = Close
 
 EXCLUSIVE_FULLSCREEN_CMD =
-    .info = Toggle exclusive fullscreen mode on the window.
+    .info = Toggle exclusive fullscreen mode on the window
     .name = Exclusive Fullscreen
 
 FULLSCREEN_CMD =
-    .info = Toggle fullscreen mode on the window.
+    .info = Toggle fullscreen mode on the window
     .name = Fullscreen
 
 MAXIMIZE_CMD =
-    .info = Maximize the window.
+    .info = Maximize the window
     .name = Maximize
 
 MINIMIZE_CMD =
-    .info = Minimize the window.
+    .info = Minimize the window
     .name = Minimize
 
 RESTORE_CMD =
-    .info = Restores the window to its previous non-minimized state or normal state.
+    .info = Restores the window to its previous non-minimized state or normal state
     .name = Restore

--- a/crates/zng-ext-window/src/cmd.rs
+++ b/crates/zng-ext-window/src/cmd.rs
@@ -19,7 +19,7 @@ command! {
     pub static CLOSE_CMD = {
         l10n!: true,
         name: "Close",
-        info: "Close the window.",
+        info: "Close the window",
         shortcut: [shortcut!(ALT+F4), shortcut!(CTRL+'W')],
         icon: wgt_fn!(|_| ICONS.get("close")),
     };
@@ -28,7 +28,7 @@ command! {
     pub static MINIMIZE_CMD = {
         l10n!: true,
         name: "Minimize",
-        info: "Minimize the window.",
+        info: "Minimize the window",
         icon: wgt_fn!(|_| ICONS.get("minimize")),
     };
 
@@ -36,7 +36,7 @@ command! {
     pub static MAXIMIZE_CMD = {
         l10n!: true,
         name: "Maximize",
-        info: "Maximize the window.",
+        info: "Maximize the window",
         icon: wgt_fn!(|_| ICONS.get("maximize")),
     };
 
@@ -49,7 +49,7 @@ command! {
     pub static FULLSCREEN_CMD = {
         l10n!: true,
         name: "Fullscreen",
-        info: "Toggle fullscreen mode on the window.",
+        info: "Toggle fullscreen mode on the window",
         shortcut: {
             let a = if cfg!(target_os = "macos") {
                 shortcut!(CTRL|SHIFT+'F')
@@ -70,7 +70,7 @@ command! {
     pub static EXCLUSIVE_FULLSCREEN_CMD = {
         l10n!: true,
         name: "Exclusive Fullscreen",
-        info: "Toggle exclusive fullscreen mode on the window.",
+        info: "Toggle exclusive fullscreen mode on the window",
         icon: wgt_fn!(|_| ICONS.get("fullscreen")),
     };
 
@@ -80,7 +80,7 @@ command! {
     pub static RESTORE_CMD = {
         l10n!: true,
         name: "Restore",
-        info: "Restores the window to its previous non-minimized state or normal state.",
+        info: "Restores the window to its previous non-minimized state or normal state",
         icon: wgt_fn!(|_| ICONS.get("restore")),
     };
 

--- a/crates/zng-wgt-inspector/l10n/en-US/inspector.ftl
+++ b/crates/zng-wgt-inspector/l10n/en-US/inspector.ftl
@@ -1,5 +1,5 @@
 INSPECT_CMD =
-    .info = Inspect the window.
+    .info = Inspect the window
     .name = Debug Inspector
 
 ## Inspector Window (always en-US)

--- a/crates/zng-wgt-inspector/l10n/pt-BR/inspector.ftl
+++ b/crates/zng-wgt-inspector/l10n/pt-BR/inspector.ftl
@@ -1,3 +1,3 @@
 INSPECT_CMD =
-    .info = Inspecionar a janela.
+    .info = Inspecionar a janela
     .name = Inspetor de Depuração

--- a/crates/zng-wgt-inspector/l10n/template/inspector.ftl
+++ b/crates/zng-wgt-inspector/l10n/template/inspector.ftl
@@ -1,5 +1,5 @@
 INSPECT_CMD =
-    .info = Inspect the window.
+    .info = Inspect the window
     .name = Debug Inspector
 
 ## Inspector Window (always en-US)

--- a/crates/zng-wgt-inspector/src/lib.rs
+++ b/crates/zng-wgt-inspector/src/lib.rs
@@ -24,7 +24,7 @@ command! {
     pub static INSPECT_CMD = {
         l10n!: "inspector",
         name: "Debug Inspector",
-        info: "Inspect the window.",
+        info: "Inspect the window",
         shortcut: [shortcut!(CTRL|SHIFT+'I'), shortcut!(F12)],
         icon: wgt_fn!(|_| ICONS.get(["inspector", "screen-search-desktop"])),
     };

--- a/crates/zng-wgt-scroll/l10n/en-US/_.ftl
+++ b/crates/zng-wgt-scroll/l10n/en-US/_.ftl
@@ -1,49 +1,49 @@
 PAGE_DOWN_CMD =
-    .info = Scroll down by one page unit.
+    .info = Scroll down by one page unit
     .name = Page Down
 
 PAGE_LEFT_CMD =
-    .info = Scroll Left by one page unit.
+    .info = Scroll Left by one page unit
     .name = Page Left
 
 PAGE_RIGHT_CMD =
-    .info = Scroll Right by one page unit.
+    .info = Scroll Right by one page unit
     .name = Page Right
 
 PAGE_UP_CMD =
-    .info = Scroll Up by one page unit.
+    .info = Scroll Up by one page unit
     .name = Page Up
 
 SCROLL_DOWN_CMD =
-    .info = Scroll Down by one scroll unit.
+    .info = Scroll Down by one scroll unit
     .name = Scroll Down
 
 SCROLL_LEFT_CMD =
-    .info = Scroll Left by one scroll unit.
+    .info = Scroll Left by one scroll unit
     .name = Scroll Left
 
 SCROLL_RIGHT_CMD =
-    .info = Scroll Right by one scroll unit.
+    .info = Scroll Right by one scroll unit
     .name = Scroll Right
 
 SCROLL_TO_BOTTOM_CMD =
-    .info = Scroll down to the content bottom.
+    .info = Scroll down to the content bottom
     .name = Scroll to Bottom
 
 SCROLL_TO_LEFTMOST_CMD =
-    .info = Scroll left to the content left edge.
+    .info = Scroll left to the content left edge
     .name = Scroll to Leftmost
 
 SCROLL_TO_RIGHTMOST_CMD =
-    .info = Scroll right to the content right edge.
+    .info = Scroll right to the content right edge
     .name = Scroll to Rightmost
 
 SCROLL_TO_TOP_CMD =
-    .info = Scroll up to the content top.
+    .info = Scroll up to the content top
     .name = Scroll to Top
 
 SCROLL_UP_CMD =
-    .info = Scroll Up by one scroll unit.
+    .info = Scroll Up by one scroll unit
     .name = Scroll Up
 
 ZOOM_IN_CMD =

--- a/crates/zng-wgt-scroll/l10n/pt-BR/_.ftl
+++ b/crates/zng-wgt-scroll/l10n/pt-BR/_.ftl
@@ -1,49 +1,49 @@
 PAGE_DOWN_CMD =
-    .info = Rolar uma página abaixo.
+    .info = Rolar uma página abaixo
     .name = Página Abaixo
 
 PAGE_LEFT_CMD =
-    .info = Rolar uma página a esquerda.
+    .info = Rolar uma página a esquerda
     .name = Página a Esquerda
 
 PAGE_RIGHT_CMD =
-    .info = Rolar uma página a direita.
+    .info = Rolar uma página a direita
     .name = Página a Direita
 
 PAGE_UP_CMD =
-    .info = Rolar uma página acima.
+    .info = Rolar uma página acima
     .name = Página Acima
 
 SCROLL_DOWN_CMD =
-    .info = Rolar uma unidade de rolagem abaixo.
+    .info = Rolar uma unidade de rolagem abaixo
     .name = Rolar Abaixo
 
 SCROLL_LEFT_CMD =
-    .info = Rolar uma unidade de rolagem a esquerda.
+    .info = Rolar uma unidade de rolagem a esquerda
     .name = Rolar a Esquerda
 
 SCROLL_RIGHT_CMD =
-    .info = Rolar uma unidade de rolagem a direita.
+    .info = Rolar uma unidade de rolagem a direita
     .name = Rolar a Direita
 
 SCROLL_TO_BOTTOM_CMD =
-    .info = Rolar abaixo até o fim.
+    .info = Rolar abaixo até o fim
     .name = Rolar até o Fim
 
 SCROLL_TO_LEFTMOST_CMD =
-    .info = Rolar a esquerda até a borda do conteúdo.
+    .info = Rolar a esquerda até a borda do conteúdo
     .name = Rolar a Esquerda Max.
 
 SCROLL_TO_RIGHTMOST_CMD =
-    .info = Rolar a direita até a borda do conteúdo.
+    .info = Rolar a direita até a borda do conteúdo
     .name = Rolar a Direita Max.
 
 SCROLL_TO_TOP_CMD =
-    .info = Rolar acima até o topo.
+    .info = Rolar acima até o topo
     .name = Rolar ao Topo
 
 SCROLL_UP_CMD =
-    .info = Rolar uma unidade de rolagem acima.
+    .info = Rolar uma unidade de rolagem acima
     .name = Rolar Acima
 
 ZOOM_IN_CMD =

--- a/crates/zng-wgt-scroll/l10n/template/_.ftl
+++ b/crates/zng-wgt-scroll/l10n/template/_.ftl
@@ -1,29 +1,29 @@
 PAGE_DOWN_CMD =
-    .info = Scroll down by one page unit.
+    .info = Scroll down by one page unit
     .name = Page Down
 
 PAGE_LEFT_CMD =
-    .info = Scroll Left by one page unit.
+    .info = Scroll Left by one page unit
     .name = Page Left
 
 PAGE_RIGHT_CMD =
-    .info = Scroll Right by one page unit.
+    .info = Scroll Right by one page unit
     .name = Page Right
 
 PAGE_UP_CMD =
-    .info = Scroll Up by one page unit.
+    .info = Scroll Up by one page unit
     .name = Page Up
 
 SCROLL_DOWN_CMD =
-    .info = Scroll Down by one scroll unit.
+    .info = Scroll Down by one scroll unit
     .name = Scroll Down
 
 SCROLL_LEFT_CMD =
-    .info = Scroll Left by one scroll unit.
+    .info = Scroll Left by one scroll unit
     .name = Scroll Left
 
 SCROLL_RIGHT_CMD =
-    .info = Scroll Right by one scroll unit.
+    .info = Scroll Right by one scroll unit
     .name = Scroll Right
 
 SCROLL_TO_BOTTOM_CMD =
@@ -31,19 +31,19 @@ SCROLL_TO_BOTTOM_CMD =
     .name = Scroll to Bottom
 
 SCROLL_TO_LEFTMOST_CMD =
-    .info = Scroll left to the content left edge.
+    .info = Scroll left to the content left edge
     .name = Scroll to Leftmost
 
 SCROLL_TO_RIGHTMOST_CMD =
-    .info = Scroll right to the content right edge.
+    .info = Scroll right to the content right edge
     .name = Scroll to Rightmost
 
 SCROLL_TO_TOP_CMD =
-    .info = Scroll up to the content top.
+    .info = Scroll up to the content top
     .name = Scroll to Top
 
 SCROLL_UP_CMD =
-    .info = Scroll Up by one scroll unit.
+    .info = Scroll Up by one scroll unit
     .name = Scroll Up
 
 ZOOM_IN_CMD =

--- a/crates/zng-wgt-scroll/src/cmd.rs
+++ b/crates/zng-wgt-scroll/src/cmd.rs
@@ -22,7 +22,7 @@ command! {
     pub static SCROLL_UP_CMD = {
         l10n!: true,
         name: "Scroll Up",
-        info: "Scroll Up by one scroll unit.",
+        info: "Scroll Up by one scroll unit",
         shortcut: shortcut!(ArrowUp),
         shortcut_filter: ShortcutFilter::FOCUSED | ShortcutFilter::CMD_ENABLED,
     };
@@ -38,7 +38,7 @@ command! {
     pub static SCROLL_DOWN_CMD = {
         l10n!: true,
         name: "Scroll Down",
-        info: "Scroll Down by one scroll unit.",
+        info: "Scroll Down by one scroll unit",
         shortcut: shortcut!(ArrowDown),
         shortcut_filter: ShortcutFilter::FOCUSED | ShortcutFilter::CMD_ENABLED,
     };
@@ -54,7 +54,7 @@ command! {
     pub static SCROLL_LEFT_CMD = {
         l10n!: true,
         name: "Scroll Left",
-        info: "Scroll Left by one scroll unit.",
+        info: "Scroll Left by one scroll unit",
         shortcut: shortcut!(ArrowLeft),
         shortcut_filter: ShortcutFilter::FOCUSED | ShortcutFilter::CMD_ENABLED,
     };
@@ -70,7 +70,7 @@ command! {
     pub static SCROLL_RIGHT_CMD = {
         l10n!: true,
         name: "Scroll Right",
-        info: "Scroll Right by one scroll unit.",
+        info: "Scroll Right by one scroll unit",
         shortcut: shortcut!(ArrowRight),
         shortcut_filter: ShortcutFilter::FOCUSED | ShortcutFilter::CMD_ENABLED,
     };
@@ -90,7 +90,7 @@ command! {
     pub static PAGE_UP_CMD = {
         l10n!: true,
         name: "Page Up",
-        info: "Scroll Up by one page unit.",
+        info: "Scroll Up by one page unit",
         shortcut: shortcut!(PageUp),
         shortcut_filter: ShortcutFilter::FOCUSED | ShortcutFilter::CMD_ENABLED,
     };
@@ -106,7 +106,7 @@ command! {
     pub static PAGE_DOWN_CMD = {
         l10n!: true,
         name: "Page Down",
-        info: "Scroll down by one page unit.",
+        info: "Scroll down by one page unit",
         shortcut: shortcut!(PageDown),
         shortcut_filter: ShortcutFilter::FOCUSED | ShortcutFilter::CMD_ENABLED,
     };
@@ -122,7 +122,7 @@ command! {
     pub static PAGE_LEFT_CMD = {
         l10n!: true,
         name: "Page Left",
-        info: "Scroll Left by one page unit.",
+        info: "Scroll Left by one page unit",
         shortcut: shortcut!(SHIFT+PageUp),
         shortcut_filter: ShortcutFilter::FOCUSED | ShortcutFilter::CMD_ENABLED,
     };
@@ -138,7 +138,7 @@ command! {
     pub static PAGE_RIGHT_CMD = {
         l10n!: true,
         name: "Page Right",
-        info: "Scroll Right by one page unit.",
+        info: "Scroll Right by one page unit",
         shortcut: shortcut!(SHIFT+PageDown),
         shortcut_filter: ShortcutFilter::FOCUSED | ShortcutFilter::CMD_ENABLED,
     };
@@ -147,7 +147,7 @@ command! {
     pub static SCROLL_TO_TOP_CMD = {
         l10n!: true,
         name: "Scroll to Top",
-        info: "Scroll up to the content top.",
+        info: "Scroll up to the content top",
         shortcut: [shortcut!(Home), shortcut!(CTRL+Home)],
         shortcut_filter: ShortcutFilter::FOCUSED | ShortcutFilter::CMD_ENABLED,
         icon: wgt_fn!(|_| ICONS.get(["scroll-top", "vertical-align-top"])),
@@ -167,7 +167,7 @@ command! {
     pub static SCROLL_TO_LEFTMOST_CMD = {
         l10n!: true,
         name: "Scroll to Leftmost",
-        info: "Scroll left to the content left edge.",
+        info: "Scroll left to the content left edge",
         shortcut: [shortcut!(SHIFT+Home), shortcut!(CTRL|SHIFT+Home)],
         shortcut_filter: ShortcutFilter::FOCUSED | ShortcutFilter::CMD_ENABLED,
     };
@@ -176,7 +176,7 @@ command! {
     pub static SCROLL_TO_RIGHTMOST_CMD = {
         l10n!: true,
         name: "Scroll to Rightmost",
-        info: "Scroll right to the content right edge.",
+        info: "Scroll right to the content right edge",
         shortcut: [shortcut!(SHIFT+End), shortcut!(CTRL|SHIFT+End)],
         shortcut_filter: ShortcutFilter::FOCUSED | ShortcutFilter::CMD_ENABLED,
     };

--- a/crates/zng/src/l10n.rs
+++ b/crates/zng/src/l10n.rs
@@ -110,7 +110,7 @@
 //!     pub static FOO_CMD = {
 //!         l10n!: true,
 //!         name: "Foo!",
-//!         info: "Does the foo thing.",
+//!         info: "Does the foo thing",
 //!     };
 //! }
 //! ```

--- a/examples/localize/res/ar/_.ftl
+++ b/examples/localize/res/ar/_.ftl
@@ -8,9 +8,9 @@ window =
 example-cmds = أوامر المثال:
 
 LOCALIZED_CMD =
-    .info = مترجم في الملف الافتراضي.
+    .info = مترجم في الملف الافتراضي
     .name = مترجم
 
 PRIVATE_LOCALIZED_CMD =
-    .info = أمر خاص، نص الترجمة العامة.
+    .info = أمر خاص، نص الترجمة العامة
     .name = خاص

--- a/examples/localize/res/ar/msg.ftl
+++ b/examples/localize/res/ar/msg.ftl
@@ -6,5 +6,5 @@ click-count = {$n ->
 }
 
 LOCALIZED_FILE_CMD =
-    .info = مترجم في ملف مسمى 'msg'.
+    .info = مترجم في ملف مسمى 'msg'
     .name = ملف مترجم

--- a/examples/localize/res/pt-BR/_.ftl
+++ b/examples/localize/res/pt-BR/_.ftl
@@ -6,9 +6,9 @@ window =
 example-cmds = Exemplos de Comandos:
 
 LOCALIZED_CMD =
-    .info = Localizado no arquivo padrão.
+    .info = Localizado no arquivo padrão
     .name = Localizado
 
 PRIVATE_LOCALIZED_CMD =
-    .info = Comando privado, texto de localização público.
+    .info = Comando privado, texto de localização público
     .name = Privado

--- a/examples/localize/res/pt-BR/msg.ftl
+++ b/examples/localize/res/pt-BR/msg.ftl
@@ -4,5 +4,5 @@ click-count = {$n ->
 }
 
 LOCALIZED_FILE_CMD =
-    .info = Localizado em um arquivo nomeado 'msg'.
+    .info = Localizado em um arquivo nomeado 'msg'
     .name = Arquivo Localizado

--- a/examples/localize/res/template/_.ftl
+++ b/examples/localize/res/template/_.ftl
@@ -14,11 +14,11 @@ window =
 ## Commands
 
 LOCALIZED_CMD =
-    .info = Localized in the default file.
+    .info = Localized in the default file
     .name = Localized
 
 PRIVATE_LOCALIZED_CMD =
-    .info = Private command, public localization text.
+    .info = Private command, public localization text
     .name = Private
 
 ## Example Section

--- a/examples/localize/res/template/msg.ftl
+++ b/examples/localize/res/template/msg.ftl
@@ -5,7 +5,7 @@
 ## Commands
 
 LOCALIZED_FILE_CMD =
-    .info = Localized in a named file 'msg'.
+    .info = Localized in a named file 'msg'
     .name = Localized File
 
 ## Example Section

--- a/examples/localize/src/main.rs
+++ b/examples/localize/src/main.rs
@@ -199,13 +199,13 @@ zng::event::command! {
     pub static LOCALIZED_CMD = {
         l10n!: true,
         name: "Localized",
-        info: "Localized in the default file.",
+        info: "Localized in the default file",
     };
 
     static PRIVATE_LOCALIZED_CMD = {
         l10n!: true,
         name: "Private",
-        info: "Private command, public localization text.",
+        info: "Private command, public localization text",
     };
 
     pub static L10N_FALSE_CMD = {
@@ -216,6 +216,6 @@ zng::event::command! {
     pub static LOCALIZED_FILE_CMD = {
         l10n!: "msg",
         name: "Localized File",
-        info: "Localized in a named file 'msg'."
+        info: "Localized in a named file 'msg'"
     };
 }


### PR DESCRIPTION
Does not look right as tooltip for Button!(CMD).

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->