### PR TITLE
Fix window receiving a cursor move event while cursor is not over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix window receiving a cursor move event while cursor is not over (on x11).
 * Remove end punctuation from command `info` fields
 * Add better custom chrome for GNOME+Wayland.
 * Add `zng::widget::node::bind_state_init` helper.

--- a/crates/zng-view/src/window.rs
+++ b/crates/zng-view/src/window.rs
@@ -557,6 +557,11 @@ impl Window {
 
     /// Returns `true` if the cursor actually moved.
     pub fn cursor_moved(&mut self, pos: DipPoint, device: DeviceId) -> bool {
+        if !self.cursor_over {
+            // this can happen on X11
+            return false;
+        }
+
         let moved = self.cursor_pos != pos || self.cursor_device != device;
 
         if moved {


### PR DESCRIPTION
This happens on X11 at least.

Fixes #462