### PR TITLE
Fix OpenGL version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix OpenGL version check.
 * Fix window receiving a cursor move event while cursor is not over (on x11).
 * Remove end punctuation from command `info` fields
 * Add better custom chrome for GNOME+Wayland.


### PR DESCRIPTION
Minor version was not checked properly and versions 2 and 1 where not detected because they set an INVALID_ENUM error due to the GL_MAJOR_VERSION enum only existing in 3 or newer.