### PR TITLE
Fix fill align in `Scroll!` dimensions that do not scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix fill align in `Scroll!` dimensions that do not scroll.
 * Implement alternate `SettingsEditor!` layout for narrow width (mobile).
 * Implement equality and comparison for `Dip` and `Px` to `i32` (and `f32` for `Dip`).
 * **Breaking** Move `IS_MOBILE_VAR` to `zng-wgt` and `zng::widget`.

--- a/crates/zng-wgt-scroll/src/lib.rs
+++ b/crates/zng-wgt-scroll/src/lib.rs
@@ -211,8 +211,10 @@ fn scroll_node(
             };
         }
         UiNodeOp::Layout { wl, final_size } => {
+            let constraints = LAYOUT.constraints();
+
             // scrollbars
-            let c = LAYOUT.constraints().with_new_min(Px(0), Px(0));
+            let c = constraints.with_new_min(Px(0), Px(0));
             {
                 joiner.width = LAYOUT.with_constraints(c.with_fill(false, true), || {
                     children.with_node(1, |n| n.measure(&mut wl.to_measure(None))).width
@@ -234,7 +236,7 @@ fn scroll_node(
             scroll_info.set_joiner_size(joiner);
 
             // viewport
-            let mut vp = LAYOUT.with_constraints(c.with_less_size(joiner), || children.with_node(0, |n| n.layout(wl)));
+            let mut vp = LAYOUT.with_constraints(constraints.with_less_size(joiner), || children.with_node(0, |n| n.layout(wl)));
 
             // collapse scrollbars if they take more the 1/3 of the total area.
             if vp.width < joiner.width * 3.0.fct() {


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->