### PR TITLE
Remove lto from APK builds

### DIFF
--- a/tools/cargo-do/src/main.rs
+++ b/tools/cargo-do/src/main.rs
@@ -906,7 +906,9 @@ fn build_apk(mut args: Vec<&str>) {
     let mut build_args = vec!["build", "-p", &example];
     if release_lto {
         build_args.push("--profile");
-        build_args.push("release-lto");
+        // build_args.push("release-lto");
+        // LTO causes miscompilation (see https://github.com/zng-ui/zng-template/issues/16)
+        build_args.push("release");
     }
 
     // cargo ndk with all installed Android targets


### PR DESCRIPTION
LTO fat and thin causes miscompilation for Android target.

See https://github.com/zng-ui/zng/issues/488 for more details.

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->