### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - run: sudo apt install libfontconfig1-dev
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --examples --tests --release
   check-wasm:
@@ -121,6 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - run: sudo apt install libfontconfig1-dev
       - uses: Swatinem/rust-cache@v2
         with:
           cache-targets: false # do doc needs a clean target/doc
@@ -140,6 +142,7 @@ jobs:
       uses: taiki-e/install-action@v2
       with:
         tool: cargo-nextest
+    - run: sudo apt install libfontconfig1-dev
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
     - run: cargo do test --nextest
@@ -187,6 +190,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - run: sudo apt install libfontconfig1-dev
       - uses: Swatinem/rust-cache@v2
       - run: cargo do test --doc
   test-macro:
@@ -197,6 +201,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-src
+      - run: sudo apt install libfontconfig1-dev
       - uses: Swatinem/rust-cache@v2
       - run: cargo do test --macro --all
   test-render-ubuntu:
@@ -209,6 +214,7 @@ jobs:
              sudo apt-get update
              sudo apt install libxkbcommon-x11-0
       - uses: actions/checkout@v4
+      - run: sudo apt install libfontconfig1-dev
       - uses: Swatinem/rust-cache@v2
       - name: cargo do test --render --no-prebuilt
         uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -26,6 +26,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-about
+      - run: sudo apt install libfontconfig1-dev
       - run: cargo +nightly check --workspace ${{ matrix.feature }} ${{ matrix.profile }} 
   check-windows:
     needs: [check-ubuntu]
@@ -72,4 +73,5 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-about
+      - run: sudo apt install libfontconfig1-dev
       - run: cargo +nightly doc --all-features --no-deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,9 +149,9 @@ jobs:
       - name: install dav1d python deps
         if: ${{ (github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true') && matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: |
-          pip install -U pip
-          pip install -U wheel setuptools
-          pip install -U meson ninja
+          pip install -U pip --break-system-packages
+          pip install -U wheel setuptools --break-system-packages
+          pip install -U meson ninja --break-system-packages
       - name: build dav1d
         if: ${{ (github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true') && matrix.target == 'x86_64-unknown-linux-gnu' }}
         env:
@@ -220,9 +220,9 @@ jobs:
       - name: install dav1d python deps
         if: ${{ (github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true') && matrix.target == 'x86_64-pc-windows-msvc' }}
         run: |
-          pip install -U pip
-          pip install -U wheel setuptools
-          pip install -U meson ninja
+          pip install -U pip --break-system-packages
+          pip install -U wheel setuptools --break-system-packages
+          pip install -U meson ninja --break-system-packages
       - name: setup dav1d env
         if: ${{ (github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true') && matrix.target == 'x86_64-pc-windows-msvc' }}
         shell: bash
@@ -296,9 +296,9 @@ jobs:
       - name: install dav1d python deps
         if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
         run: |
-          pip install -U pip
-          pip install -U wheel setuptools
-          pip install -U meson ninja
+          pip install -U pip --break-system-packages
+          pip install -U wheel setuptools --break-system-packages
+          pip install -U meson ninja --break-system-packages
       - name: build dav1d
         if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
         if: ${{ github.event.inputs.skip_checks != 'true' }}
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ github.event.inputs.skip_checks != 'true' }}
+      - run: sudo apt install libfontconfig1-dev
+        if: ${{ github.event.inputs.skip_checks != 'true' }}
       - run: cargo do version --verbose
         if: ${{ github.event.inputs.skip_checks != 'true' }}
       - run: cargo do fmt --check
@@ -337,6 +339,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: ${{ github.event.inputs.skip_doc != 'true' }}
+      - run: sudo apt install libfontconfig1-dev
+        if: ${{ github.event.inputs.skip_doc != 'true' }}
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ github.event.inputs.skip_doc != 'true' }}
       - run: cargo do latest_release_changes release-changes.md
@@ -368,6 +372,8 @@ jobs:
         with:
           tool: cargo-nextest
       - uses: actions/checkout@v4
+        if: ${{ github.event.inputs.skip_tests != 'true' }}
+      - run: sudo apt install libfontconfig1-dev
         if: ${{ github.event.inputs.skip_tests != 'true' }}
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ github.event.inputs.skip_tests != 'true' }}
@@ -495,6 +501,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: ${{ github.event.inputs.skip_tests != 'true' }}
+      - run: sudo apt install libfontconfig1-dev
+        if: ${{ github.event.inputs.skip_tests != 'true' }}
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ github.event.inputs.skip_tests != 'true' }}
       - run: cargo do publish --test
@@ -620,6 +628,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ github.event.inputs.skip_crates != 'true' }}
       - uses: actions/checkout@v4
+        if: ${{ github.event.inputs.skip_crates != 'true' }}
+      - run: sudo apt install libfontconfig1-dev
         if: ${{ github.event.inputs.skip_crates != 'true' }}
       - run: cargo do publish --execute ${{ github.run_attempt > 1 && '--no-burst' || '' }}
         if: ${{ github.event.inputs.skip_crates != 'true' }}

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -17,4 +17,5 @@ jobs:
         with:
           crate: cargo-semver-checks
       - uses: actions/checkout@v4
+      - run: sudo apt install libfontconfig1-dev
       - run: cargo do semver_check

--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - run: sudo apt install libfontconfig1-dev
       - run: cargo do doc
       - name: upload doc
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Ubuntu latest image does not include libfontconfig1-dev

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->