### PR TITLE
Fix `cargo zng res` not getting explicit metadata from lib crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix `cargo zng res` not getting explicit metadata from lib crates.
+* Implement `--verbose` for `cargo zng res`.
 * Localize settings search box placeholder text.
 
 # 0.12.1

--- a/crates/cargo-zng/src/res/tool.rs
+++ b/crates/cargo-zng/src/res/tool.rs
@@ -299,9 +299,12 @@ pub struct Tools {
     about: About,
 }
 impl Tools {
-    pub fn capture(local: &Path, cache: PathBuf, about: About) -> anyhow::Result<Self> {
+    pub fn capture(local: &Path, cache: PathBuf, about: About, verbose: bool) -> anyhow::Result<Self> {
         let mut tools = vec![];
         visit_tools(local, |t| {
+            if verbose {
+                println!("found tool `{}` in `{}`", t.name, t.path.display())
+            }
             tools.push(t);
             Ok(ControlFlow::Continue(()))
         })?;


### PR DESCRIPTION
Fixes #489

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->