### PR TITLE
Allow missing trailing comma in `event_property!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Allow missing trailing comma in `event_property!`.
 * Fix visibility and transform events losing track of a widget after info rebuild.
 * Add visibility changed event properties, `on_visibility_changed`, `on_show`, `on_collapse` and others.
 * Add `VisibilityChangedArgs` helper methods for tracking changes for a specific widget.

--- a/crates/zng-wgt/src/node.rs
+++ b/crates/zng-wgt/src/node.rs
@@ -292,10 +292,11 @@ macro_rules! event_property {
         $(#[$on_event_attrs:meta])*
         $vis:vis fn $event:ident {
             event: $EVENT:path,
-            args: $Args:path,
-            $(filter: $filter:expr,)?
-            $(widget_impl: $Wgt:ty,)?
-            $(with: $with:expr,)?
+            args: $Args:path
+            $(, filter: $filter:expr)?
+            $(, widget_impl: $Wgt:ty)?
+            $(, with: $with:expr)?
+            $(,)?
         }
     )+) => {$(
         $crate::__event_property! {


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->