### PR TITLE
`WindowExtension` now also instantiated for headless surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 * Fix `view_process_extension!` not running in same-process mode.
+* **Breaking** `WindowExtension` now also instantiated for headless surfaces.
+    - Note that this is only a breaking change for direct dependents of `zng-view` extensions API.
 * **Breaking** Add `as_any` casting method for `RendererExtension` and `WindowExtension`.
     - Note that this is only a breaking change for direct dependents of `zng-view` extensions API.
 * Add `"zng-view.prefer_angle"` window extension to support enabling ANGLE EGL over WGL on Windows.

--- a/crates/zng-view/src/extensions.rs
+++ b/crates/zng-view/src/extensions.rs
@@ -441,7 +441,7 @@ pub struct WindowConfigArgs<'a> {
     pub config: Option<&'a ApiExtensionPayload>,
 
     /// Window attributes that will be used to build the headed window.
-    pub window: &'a mut winit::window::WindowAttributes,
+    pub window: Option<&'a mut winit::window::WindowAttributes>,
 }
 
 /// Arguments for [`RendererExtension::configure`]

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -1578,6 +1578,7 @@ impl App {
             config,
             &self.winit_loop,
             &mut self.gl_manager,
+            self.exts.new_window(),
             self.exts.new_renderer(),
             self.app_sender.clone(),
         );

--- a/crates/zng-view/src/window.rs
+++ b/crates/zng-view/src/window.rs
@@ -248,7 +248,7 @@ impl Window {
         for (id, ext) in &mut window_exts {
             ext.configure(&mut WindowConfigArgs {
                 config: cfg.extensions.iter().find(|(k, _)| k == id).map(|(_, p)| p),
-                window: &mut winit,
+                window: Some(&mut winit),
             });
 
             #[cfg(windows)]


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->