### PR TITLE
Fix layers anchored to the root widget never rendering in some windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix layers anchored to the root widget never rendering in some windows.
 
 # 0.12.4
 

--- a/crates/zng-wgt-layer/Cargo.toml
+++ b/crates/zng-wgt-layer/Cargo.toml
@@ -22,6 +22,7 @@ zng-ext-window = { path = "../zng-ext-window", version = "0.3.27" }
 zng-app = { path = "../zng-app", version = "0.13.2" }
 zng-var = { path = "../zng-var", version = "0.5.7" }
 zng-ext-input = { path = "../zng-ext-input", version = "0.5.26" }
+zng-view-api = { path = "../zng-view-api", version = "0.10.2", default-features = false }
 
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/zng-wgt-layer/src/lib.rs
+++ b/crates/zng-wgt-layer/src/lib.rs
@@ -18,6 +18,7 @@ use zng_ext_input::mouse::MOUSE;
 use zng_ext_input::touch::TOUCH;
 use zng_ext_window::WINDOW_Ext as _;
 use zng_var::{animation, ContextInitHandle, ReadOnlyContextVar};
+use zng_view_api::window::FrameId;
 use zng_wgt::prelude::*;
 
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -596,7 +597,13 @@ impl LAYERS {
                         }
                     } else {
                         // anchor not visible, call render to properly hide or collapse (if collapsed during layout)
-                        frame.hide(|frame| widget.render(frame))
+                        frame.hide(|frame| widget.render(frame));
+
+                        if frame.frame_id() == FrameId::first() && anchor.get() == WIDGET.id() {
+                            // anchor is the root widget, the only widget that is not done rendering before the layers
+                            // if only the first frame is rendered the layer can remain hidden, so ensure a second frame renders.
+                            WIDGET.render();
+                        }
                     }
                 } else {
                     widget.render(frame);


### PR DESCRIPTION
The root widget is the only one that is not done rendering before the layers, if only the first frame is rendered the layer can remain hidden. This fix ensures a second frame renders on this case.