### PR TITLE
Fix `cargo do fmt` on files that start with `#!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `cargo do fmt` on files that start with `#!`.
 * Fix layers anchored to the root widget never rendering in some windows.
 
 # 0.12.4

--- a/crates/cargo-zng/src/fmt.rs
+++ b/crates/cargo-zng/src/fmt.rs
@@ -130,7 +130,7 @@ fn custom_fmt(rs_file: &Path, check: bool) -> io::Result<()> {
     // skip UTF-8 BOM
     let file_code = file.strip_prefix('\u{feff}').unwrap_or(file.as_str());
     // skip shebang line
-    let file_code = if file_code.starts_with("#!") {
+    let file_code = if file_code.starts_with("#!") && !file_code.starts_with("#![") {
         &file_code[file_code.find('\n').unwrap_or(file_code.len())..]
     } else {
         file_code


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->