### PR TITLE
Fix `cargo zng l10n` on files that start with `#!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Fix `cargo do fmt` on files that start with `#!`.
+* Fix `cargo zng fmt` and `cargo zng l10n` on files that start with `#!`.
 * Fix layers anchored to the root widget never rendering in some windows.
 
 # 0.12.4

--- a/crates/cargo-zng/src/l10n/scraper.rs
+++ b/crates/cargo-zng/src/l10n/scraper.rs
@@ -68,7 +68,7 @@ fn scrape_file(rs_file: PathBuf, custom_macro_names: &[&str]) -> FluentTemplate 
     // skip UTF-8 BOM
     let file = file.strip_prefix('\u{feff}').unwrap_or(file.as_str());
     // skip shebang line
-    let file = if file.starts_with("#!") {
+    let file = if file.starts_with("#!") && !file.starts_with("#![") {
         &file[file.find('\n').unwrap_or(file.len())..]
     } else {
         file


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->