### PR TITLE
Fix window text properties affecting the Wayland fallback chrome text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix window text properties affecting the Wayland fallback chrome text.
 * Changed how relative lengths are computed in `offset`, `x` and `y`, now uses the maximum bounded length from constraint, the same as `size` properties.
 * Fix display print of `FactorPercent` not rounding.
 * `ChildInsert::{Over, Under}` now allows insert to affect layout size, like other inserts.


### PR DESCRIPTION
Fixes #528