### PR TITLE
Revert `fs4` upgrade

### DIFF
--- a/crates/zng-ext-fs-watcher/Cargo.toml
+++ b/crates/zng-ext-fs-watcher/Cargo.toml
@@ -47,7 +47,7 @@ ron = { version = "0.8", optional = true, features = ["indexmap"] }
 serde_yaml = { version = "0.9", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-fs4 = "0.10"
+fs4 = "0.9"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/zng-task/Cargo.toml
+++ b/crates/zng-task/Cargo.toml
@@ -87,7 +87,7 @@ dunce = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 duct = { version = "0.13", optional = true }
-fs4 = { version = "0.10", optional = true }
+fs4 = { version = "0.9", optional = true }
 
 [build-dependencies]
 cfg_aliases = "0.2"


### PR DESCRIPTION
Back to version `0.9`. Version `0.10` was yanked.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->