### PR TITLE
Fix `zng_tp_licenses::collect_cargo_about` call in Powershell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `zng_tp_licenses::collect_cargo_about` call in Powershell.
 
 # 0.12.9
 

--- a/crates/zng-tp-licenses/Cargo.toml
+++ b/crates/zng-tp-licenses/Cargo.toml
@@ -25,3 +25,6 @@ serde_json = { version = "1.0", optional = true }
 deflate = { version = "1.0", optional = true }
 inflate = { version = "0.4", optional = true }
 bincode = { version = "1.3", optional = true }
+
+[target.'cfg(windows)'.dependencies]
+tempfile = "3.10"


### PR DESCRIPTION
cargo about now prints an error for stdio redirect in powershell

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->