### PR TITLE
Add test of previous release after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -636,6 +636,19 @@ jobs:
         if: ${{ github.event.inputs.skip_crates != 'true' }}
       - run: cargo do publish --execute ${{ github.run_attempt > 1 && '--no-burst' || '' }}
         if: ${{ github.event.inputs.skip_crates != 'true' }}
+  test-previous:
+    runs-on: ubuntu-latest
+    needs: [publish-crates]
+    steps:
+      - uses: dtolnay/rust-toolchain@stable
+        if: ${{ github.event.inputs.skip_crates != 'true' }}
+      - uses: actions/checkout@v4
+        if: ${{ github.event.inputs.skip_crates != 'true' }}
+      - run: sudo apt install libfontconfig1-dev
+        if: ${{ github.event.inputs.skip_crates != 'true' }}
+      - run: cargo do test --published
+        if: ${{ github.event.inputs.skip_crates != 'true' }}
+
 
   cleanup:
     runs-on: ubuntu-latest

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -30,10 +30,10 @@ To make a release a `zng-ui` project owner needs to follow/monitor these steps:
     * If GitHub release and docs update:
         - It will publish to crates.io using `do publish --execute`.
 
-4. Test previous breaking version.
-   * Make a test crate that depends on the previous minor version of `zng`.
-   * If it does not build a breaking change in the public API was introduced.
-   * Unfortunately there is no "staging" for publish so you might need to yank all the affected crates.
+4. Tests after publish
+   * Make a test crate that depends on the previous minor version of `zng`, it must still build.
+      You can use `cargo do test --published` to automatically do this.
+   * Update and test the template project (`zng-template`) repository.
 
 ## Webrender
 


### PR DESCRIPTION
Continuing from #561, at least automate the test of previous version.