### PR TITLE
Ignore not found error on `cargo zng l10n` cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Ignore not found error on `cargo zng l10n` cleanup.
 
 # 0.13.0
 

--- a/crates/cargo-zng/src/l10n.rs
+++ b/crates/cargo-zng/src/l10n.rs
@@ -198,7 +198,9 @@ fn run_impl(mut args: L10nArgs, is_local_scrap_recursion: bool) {
                             println!("removing `{}` to clean template", output.display());
                         }
                         if let Err(e) = fs::remove_dir_all(&output) {
-                            error!("cannot remove `{}`, {e}", output.display());
+                            if !matches!(e.kind(), io::ErrorKind::NotFound) {
+                                error!("cannot remove `{}`, {e}", output.display());
+                            }
                         }
                     }
                     util::check_or_create_dir_all(args.check, &output)?;
@@ -222,7 +224,9 @@ fn run_impl(mut args: L10nArgs, is_local_scrap_recursion: bool) {
                     println!("removing `{}` to clean deps", dir.display());
                 }
                 if let Err(e) = std::fs::remove_dir_all(&dir) {
-                    error!("cannot remove `{}`, {e}", dir.display());
+                    if !matches!(e.kind(), io::ErrorKind::NotFound) {
+                        error!("cannot remove `{}`, {e}", dir.display());
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->