### PR TITLE
Changed ByteLength to display unit symbols, not full name in english

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Changed `ByteLength` to display unit symbols.
 * Ignore not found error on `cargo zng l10n` cleanup.
 
 # 0.13.0

--- a/crates/zng-unit/src/byte.rs
+++ b/crates/zng-unit/src/byte.rs
@@ -326,32 +326,34 @@ impl fmt::Debug for ByteLength {
         }
     }
 }
+
+/// Alternative mode prints in binary units (kibi, mebi, gibi, tebi)
 impl fmt::Display for ByteLength {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // alternate uses 0..=1000 units, normal used 0..=1024 units.
 
         if f.alternate() {
             if self.0 >= 1024usize.pow(4) {
-                write!(f, "{:.2} tebibytes", self.tebis())
+                write!(f, "{:.2}TiB", self.tebis())
             } else if self.0 >= 1024usize.pow(3) {
-                write!(f, "{:.2} gibibytes", self.gibis())
+                write!(f, "{:.2}GiB", self.gibis())
             } else if self.0 >= 1024usize.pow(2) {
-                write!(f, "{:.2} mebibytes", self.mebis())
+                write!(f, "{:.2}MiB", self.mebis())
             } else if self.0 >= 1024 {
-                write!(f, "{:.2} kibibytes", self.kibis())
+                write!(f, "{:.2}KiB", self.kibis())
             } else {
-                write!(f, "{} bytes", self.bytes())
+                write!(f, "{}B", self.bytes())
             }
         } else if self.0 >= 1000usize.pow(4) {
-            write!(f, "{:.2} terabytes", self.teras())
+            write!(f, "{:.2}TB", self.teras())
         } else if self.0 >= 1000usize.pow(3) {
-            write!(f, "{:.2} gigabytes", self.gigas())
+            write!(f, "{:.2}GB", self.gigas())
         } else if self.0 >= 1000usize.pow(2) {
-            write!(f, "{:.2} megabytes", self.megas())
+            write!(f, "{:.2}MB", self.megas())
         } else if self.0 >= 1000 {
-            write!(f, "{:.2} kilobytes", self.kilos())
+            write!(f, "{:.2}kB", self.kilos())
         } else {
-            write!(f, "{} bytes", self.bytes())
+            write!(f, "{}B", self.bytes())
         }
     }
 }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->