### PR TITLE
Debloat

### DIFF
--- a/crates/zng-app/src/widget.rs
+++ b/crates/zng-app/src/widget.rs
@@ -906,11 +906,15 @@ impl WIDGET {
         let w = WIDGET_CTX.get();
         let s = var.subscribe(op, w.id);
 
-        if WIDGET_HANDLES_CTX.is_default() {
-            w.handles.var_handles.lock().push(s);
-        } else {
-            WIDGET_HANDLES_CTX.get().var_handles.lock().push(s);
+        // function to avoid generics code bloat
+        fn push(w: Arc<WidgetCtxData>, s: VarHandle) {
+            if WIDGET_HANDLES_CTX.is_default() {
+                w.handles.var_handles.lock().push(s);
+            } else {
+                WIDGET_HANDLES_CTX.get().var_handles.lock().push(s);
+            }
         }
+        push(w, s);
 
         self
     }
@@ -927,11 +931,15 @@ impl WIDGET {
         let w = WIDGET_CTX.get();
         let s = var.subscribe_when(op, w.id, predicate);
 
-        if WIDGET_HANDLES_CTX.is_default() {
-            w.handles.var_handles.lock().push(s);
-        } else {
-            WIDGET_HANDLES_CTX.get().var_handles.lock().push(s);
+        // function to avoid generics code bloat
+        fn push(w: Arc<WidgetCtxData>, s: VarHandle) {
+            if WIDGET_HANDLES_CTX.is_default() {
+                w.handles.var_handles.lock().push(s);
+            } else {
+                WIDGET_HANDLES_CTX.get().var_handles.lock().push(s);
+            }
         }
+        push(w, s);
 
         self
     }
@@ -1000,12 +1008,17 @@ impl WIDGET {
         let w = WIDGET_CTX.get();
         let s = event.subscribe(w.id);
 
-        if WIDGET_HANDLES_CTX.is_default() {
-            w.handles.event_handles.lock().push(s);
-        } else {
-            WIDGET_HANDLES_CTX.get().event_handles.lock().push(s);
+        // function to avoid generics code bloat
+        fn push(w: Arc<WidgetCtxData>, s: EventHandle) {
+            if WIDGET_HANDLES_CTX.is_default() {
+                w.handles.event_handles.lock().push(s);
+            } else {
+                WIDGET_HANDLES_CTX.get().event_handles.lock().push(s);
+            }    
         }
+        push(w, s);
 
+        
         self
     }
 

--- a/crates/zng-app/src/widget.rs
+++ b/crates/zng-app/src/widget.rs
@@ -1014,11 +1014,10 @@ impl WIDGET {
                 w.handles.event_handles.lock().push(s);
             } else {
                 WIDGET_HANDLES_CTX.get().event_handles.lock().push(s);
-            }    
+            }
         }
         push(w, s);
 
-        
         self
     }
 

--- a/crates/zng-var/src/lib.rs
+++ b/crates/zng-var/src/lib.rs
@@ -655,11 +655,15 @@ pub trait AnyVar: Any + Send + Sync + crate::private::Sealed {
 
     /// Keep `other` alive until the handle or `self` are dropped.
     fn hold_any(&self, value: Box<dyn Any + Send + Sync>) -> VarHandle {
-        self.hook_any(Box::new(move |_| {
-            let _hold = &value;
-            true
-        }))
+        self.hook_any(hold_any_impl(value))
     }
+}
+// separate function to avoid code bloat
+fn hold_any_impl(value: Box<dyn Any + Send + Sync>) -> Box<dyn Fn(&AnyVarHookArgs) -> bool + Send + Sync> {
+    Box::new(move |_| {
+        let _hold = &value;
+        true
+    })
 }
 
 #[derive(Debug)]

--- a/tools/cargo-do/src/main.rs
+++ b/tools/cargo-do/src/main.rs
@@ -905,7 +905,12 @@ fn mono_stats(mut args: Vec<&str>) {
     } else {
         rust_flags.push_str(" -Zdump-mono-stats=./mono-stats");
     }
-    cmd_env("cargo", &["+nightly", "build", "-p", crate_], &[], &[("RUSTFLAGS", rust_flags.as_str())]);
+    cmd_env(
+        "cargo",
+        &["+nightly", "build", "-p", crate_],
+        &[],
+        &[("RUSTFLAGS", rust_flags.as_str())],
+    );
 }
 
 // do build-apk <EXAMPLE> [--release-lto] [--no-strip]

--- a/tools/cargo-do/src/main.rs
+++ b/tools/cargo-do/src/main.rs
@@ -32,6 +32,7 @@ fn main() {
         "publish_version_tag" => publish_version_tag(args),
         "comment_feature" => comment_feature(args),
         "latest_release_changes" => latest_release_changes(args),
+        "mono-stats" => mono_stats(args),
         "just" => just(args),
         "version" => version(args),
         "ls" => ls(args),
@@ -884,6 +885,27 @@ fn build(mut args: Vec<&str>) {
     }
 
     cmd_env("cargo", &cargo_args, &args, rust_flags);
+}
+
+// do mono-stats <CRATE> [--print]
+//    Compile the crate and dump generic instances
+// USAGE
+//    mono-stats --print --dump <CRATE>
+//       Don't group/sort items in files, just print, to a dump file
+fn mono_stats(mut args: Vec<&str>) {
+    let print = take_flag(&mut args, &["--print"]);
+    if args.is_empty() {
+        fatal("expected a project <CRATE>")
+    }
+    let crate_ = &args[0];
+    let mut rust_flags = std::env::var("RUSTFLAGS").unwrap_or_default();
+    rust_flags.push_str("-C link-args=-znostart-stop-gc"); // fix linkme bug
+    if print {
+        rust_flags.push_str(" -Zprint-mono-items=lazy");
+    } else {
+        rust_flags.push_str(" -Zdump-mono-stats=./mono-stats");
+    }
+    cmd_env("cargo", &["+nightly", "build", "-p", crate_], &[], &[("RUSTFLAGS", rust_flags.as_str())]);
 }
 
 // do build-apk <EXAMPLE> [--release-lto] [--no-strip]

--- a/tools/cargo-do/src/main.rs
+++ b/tools/cargo-do/src/main.rs
@@ -903,7 +903,10 @@ fn mono_stats(mut args: Vec<&str>) {
     if print {
         rust_flags.push_str(" -Zprint-mono-items=lazy");
     } else {
-        rust_flags.push_str(" -Zdump-mono-stats=./mono-stats");
+        rust_flags.push_str(&format!(
+            " -Zdump-mono-stats={}",
+            std::env::current_dir().unwrap().join("mono-stats").display()
+        ));
     }
     cmd_env(
         "cargo",


### PR DESCRIPTION
Using `cargo bloat` and the new `cargo do mono-stats` to find generic functions that are generating excessive binary code.

Improves #559