### PR TITLE
Var debloat

### DIFF
--- a/crates/zng-var/src/_idea.rs
+++ b/crates/zng-var/src/_idea.rs
@@ -1,0 +1,151 @@
+/*
+IDEA
+
+* Have all variables have a type erased core.
+* Var<T>: Deref<AnyVar> (the core).
+    - Deref so we don't endup with huge dyn tables for all Var<T>: AnyVar.
+* Implement everything type erased, map, animation.
+* Var<T> is just a PhantomData<T> wrapper that casts for the user.
+
+* LocalVar<T> could implement AnyVar directly, but when boxed have a LocalVarAny core too?
+* Is there any actual bloat from dyn tables? Maybe try just the Any core for now, add a modify_any (internal for this release) and profile.
+
+*/
+
+use std::{marker::PhantomData, sync::Arc};
+
+use parking_lot::RwLock;
+use zng_txt::formatx;
+
+use crate::{animation::ModifyInfo, private, AnyVar, VarCapability, VarHandle, VarHook, VarUpdateId, VarValue};
+
+pub struct ArcVarAny(Arc<RwLock<ArcVarInner>>);
+
+pub struct ArcVar<T: VarValue>(ArcVarAny, PhantomData<T>);
+
+struct ArcVarInner {
+    value: Box<dyn crate::AnyVarValue>,
+    last_update: VarUpdateId,
+    hooks: Vec<VarHook>,
+    animation: ModifyInfo,
+}
+
+impl ArcVarAny {
+    pub fn new(value: Box<dyn crate::AnyVarValue>) -> Self {
+        Self(Arc::new(RwLock::new(ArcVarInner {
+            value,
+            last_update: VarUpdateId::never(),
+                hooks: vec![],
+                animation: ModifyInfo::never(),
+        })))
+    }
+}
+
+impl private::Sealed for ArcVarAny { }
+
+impl AnyVar for ArcVarAny {
+    fn clone_any(&self) -> crate::BoxedAnyVar {
+        todo!()
+    }
+
+    // Limitation, can't cast back to ArcVar<T>
+    // 
+    // * Maybe just this methods can be a separate trait
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_unboxed_any(&self) -> &dyn std::any::Any {
+        todo!()
+    }
+
+    fn double_boxed_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+        todo!()
+    }
+
+    fn var_type_id(&self) -> std::any::TypeId {
+        self.0.read().value.type_id()
+    }
+
+    fn get_any(&self) -> Box<dyn crate::AnyVarValue> {
+        self.0.read().value.clone_boxed()
+    }
+
+    fn with_any(&self, read: &mut dyn FnMut(&dyn crate::AnyVarValue)) {
+        read(&*self.0.read().value)
+    }
+
+    fn with_new_any(&self, read: &mut dyn FnMut(&dyn crate::AnyVarValue)) -> bool {
+        if self.is_new() {
+            read(&*self.0.read().value);
+            return true;
+        }
+        false
+    }
+
+    fn set_any(&self, value: Box<dyn crate::AnyVarValue>) -> Result<(), crate::VarIsReadOnlyError> {
+        todo!()
+    }
+
+    fn last_update(&self) -> VarUpdateId {
+        self.0.read().last_update
+    }
+
+    fn is_contextual(&self) -> bool {
+        false
+    }
+
+    fn capabilities(&self) -> VarCapability {
+        VarCapability::MODIFY
+    }
+
+    fn is_animating(&self) -> bool {
+        self.0.read().animation.is_animating()
+    }
+
+    fn modify_importance(&self) -> usize {
+        self.0.read().animation.importance()
+    }
+
+    fn hook_any(&self, pos_modify_action: Box<dyn Fn(&crate::AnyVarHookArgs) -> bool + Send + Sync>) -> VarHandle {
+        let (handle, hook) = VarHandle::new(pos_modify_action);
+        self.0.write().hooks.push(hook);
+        handle
+    }
+
+    fn hook_animation_stop(&self, handler: Box<dyn FnOnce() + Send>) -> Result<(), Box<dyn FnOnce() + Send>> {
+        self.0.read().animation.hook_animation_stop(handler)
+    }
+
+    fn strong_count(&self) -> usize {
+        Arc::strong_count(&self.0)
+    }
+
+    fn weak_count(&self) -> usize {
+        Arc::weak_count(&self.0)
+    }
+
+    fn actual_var_any(&self) -> crate::BoxedAnyVar {
+        todo!()
+    }
+
+    fn downgrade_any(&self) -> crate::BoxedAnyWeakVar {
+        todo!()
+    }
+
+    fn var_ptr(&self) -> crate::VarPtr {
+        todo!()
+    }
+
+    fn get_debug(&self) -> zng_txt::Txt {
+        formatx!("{:?}", self.0.read().value)
+    }
+
+    fn update(&self) -> Result<(), crate::VarIsReadOnlyError> {
+        todo!()
+    }
+
+    fn map_debug(&self) -> crate::BoxedVar<zng_txt::Txt> {
+        todo!()
+    }
+}

--- a/crates/zng-var/src/lib.rs
+++ b/crates/zng-var/src/lib.rs
@@ -36,8 +36,6 @@ use zng_clone_move::clmv;
 use zng_txt::{formatx, ToTxt, Txt};
 use zng_unit::{Factor, FactorUnits};
 
-pub mod _idea;
-
 pub mod animation;
 mod arc;
 mod boxed;

--- a/crates/zng-var/src/lib.rs
+++ b/crates/zng-var/src/lib.rs
@@ -36,6 +36,8 @@ use zng_clone_move::clmv;
 use zng_txt::{formatx, ToTxt, Txt};
 use zng_unit::{Factor, FactorUnits};
 
+pub mod _idea;
+
 pub mod animation;
 mod arc;
 mod boxed;

--- a/crates/zng-var/src/merge.rs
+++ b/crates/zng-var/src/merge.rs
@@ -72,7 +72,7 @@ struct MergeData<T> {
 
 struct Data<T: VarValue> {
     m: Mutex<MergeData<T>>,
-    value: VarData<T>,
+    value: VarData,
 }
 
 /// See [`merge_var!`].

--- a/crates/zng-var/src/util.rs
+++ b/crates/zng-var/src/util.rs
@@ -63,7 +63,7 @@ macro_rules! impl_from_and_into_var {
 
 use parking_lot::RwLock;
 
-use crate::AnyVarHookArgs;
+use crate::{AnyVarHookArgs, AnyVarValue};
 
 use super::{animation::ModifyInfo, VarHandle, VarHook, VarModify, VarUpdateId, VarValue, VARS};
 
@@ -306,70 +306,35 @@ impl VarMeta {
     }
 }
 
-#[cfg(feature = "dyn_closure")]
 struct VarDataInner {
-    value: Box<dyn crate::AnyVarValue>,
+    value: Box<dyn AnyVarValue>,
     meta: VarMeta,
 }
 
-#[cfg(not(feature = "dyn_closure"))]
-struct VarDataInner<T> {
-    value: T,
-    meta: VarMeta,
-}
+pub(super) struct VarData(RwLock<VarDataInner>);
 
-#[cfg(feature = "dyn_closure")]
-pub(super) struct VarData<T: VarValue>(RwLock<VarDataInner>, std::marker::PhantomData<T>);
-
-#[cfg(not(feature = "dyn_closure"))]
-pub(super) struct VarData<T: VarValue>(RwLock<VarDataInner<T>>);
-
-impl<T: VarValue> VarData<T> {
-    pub fn new(value: T) -> Self {
-        #[cfg(feature = "dyn_closure")]
-        let value = Box::new(value);
-        let inner = RwLock::new(VarDataInner {
+impl VarData {
+    pub fn new(value: impl VarValue) -> Self {
+        Self::new_impl(Box::new(value))
+    }
+    fn new_impl(value: Box<dyn AnyVarValue>) -> Self {
+        Self(RwLock::new(VarDataInner {
             value,
             meta: VarMeta {
                 last_update: VarUpdateId::never(),
                 hooks: vec![],
                 animation: ModifyInfo::never(),
             },
-        });
-
-        #[cfg(feature = "dyn_closure")]
-        {
-            Self(inner, std::marker::PhantomData)
-        }
-
-        #[cfg(not(feature = "dyn_closure"))]
-        {
-            Self(inner)
-        }
+        }))
     }
 
-    pub fn into_value(self) -> T {
-        #[cfg(feature = "dyn_closure")]
-        {
-            *self.0.into_inner().value.into_any().downcast::<T>().unwrap()
-        }
-        #[cfg(not(feature = "dyn_closure"))]
-        {
-            self.0.into_inner().value
-        }
+    pub fn into_value<T: VarValue>(self) -> T {
+        *self.0.into_inner().value.into_any().downcast::<T>().unwrap()
     }
 
     /// Read the value.
-    pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
-        #[cfg(feature = "dyn_closure")]
-        {
-            f(self.0.read().value.as_any().downcast_ref::<T>().unwrap())
-        }
-
-        #[cfg(not(feature = "dyn_closure"))]
-        {
-            f(&self.0.read().value)
-        }
+    pub fn with<T: VarValue, R>(&self, f: impl FnOnce(&T) -> R) -> R {
+        f(self.0.read().value.as_any().downcast_ref::<T>().unwrap())
     }
 
     pub fn last_update(&self) -> VarUpdateId {
@@ -393,7 +358,7 @@ impl<T: VarValue> VarData<T> {
     }
 
     #[cfg(feature = "dyn_closure")]
-    pub fn apply_modify(&self, modify: Box<dyn FnOnce(&mut VarModify<T>) + 'static>) {
+    pub fn apply_modify<T: VarValue>(&self, modify: Box<dyn FnOnce(&mut VarModify<T>) + 'static>) {
         apply_modify(
             &self.0,
             Box::new(move |v| {
@@ -415,25 +380,31 @@ impl<T: VarValue> VarData<T> {
     }
 
     #[cfg(not(feature = "dyn_closure"))]
-    pub fn apply_modify(&self, modify: impl FnOnce(&mut VarModify<T>) + 'static) {
-        apply_modify(&self.0, modify)
+    pub fn apply_modify<T: VarValue>(&self, modify: impl FnOnce(&mut VarModify<T>) + 'static) {
+        apply_modify(
+            &self.0,
+            Box::new(move |v| {
+                let mut value = VarModify::new(v.as_any().downcast_ref::<T>().unwrap());
+                modify(&mut value);
+                let (notify, new_value, update, tags, importance) = value.finish();
+                (
+                    notify,
+                    match new_value {
+                        Some(v) => Some(Box::new(v)),
+                        None => None,
+                    },
+                    update,
+                    tags,
+                    importance,
+                )
+            }),
+        )
     }
 }
 
-#[cfg(feature = "dyn_closure")]
 fn apply_modify(
     inner: &RwLock<VarDataInner>,
-    modify: Box<
-        dyn FnOnce(
-            &dyn crate::AnyVarValue,
-        ) -> (
-            bool,
-            Option<Box<dyn crate::AnyVarValue>>,
-            bool,
-            Vec<Box<dyn crate::AnyVarValue>>,
-            Option<usize>,
-        ),
-    >,
+    modify: Box<dyn FnOnce(&dyn AnyVarValue) -> (bool, Option<Box<dyn AnyVarValue>>, bool, Vec<Box<dyn AnyVarValue>>, Option<usize>)>,
 ) {
     let mut data = inner.write();
     if data.meta.skip_modify() {
@@ -462,7 +433,7 @@ fn apply_modify(
             let meta = parking_lot::RwLockWriteGuard::downgrade(data);
 
             let args = AnyVarHookArgs::new(&*meta.value, update, &tags);
-            call_hooks(&mut hooks, args);
+            hooks.retain(|h| h.call(&args));
             drop(meta);
 
             let mut data = inner.write();
@@ -478,64 +449,3 @@ fn apply_modify(
     }
 }
 
-#[cfg(not(feature = "dyn_closure"))]
-fn apply_modify<T: VarValue>(inner: &RwLock<VarDataInner<T>>, modify: impl FnOnce(&mut VarModify<T>)) {
-    use crate::AnyVarValue;
-
-    let mut data = inner.write();
-    if data.meta.skip_modify() {
-        return;
-    }
-
-    let meta = parking_lot::RwLockWriteGuard::downgrade(data);
-    let mut value = VarModify::new(&meta.value);
-    modify(&mut value);
-    let (notify, new_value, update, tags, custom_importance) = value.finish();
-    drop(meta);
-
-    // code size optimization, removes the impl FnOnce generic
-    fn finish<T: VarValue>(
-        inner: &RwLock<VarDataInner<T>>,
-        notify: bool,
-        new_value: Option<T>,
-        update: bool,
-        tags: Vec<Box<dyn AnyVarValue>>,
-        custom_importance: Option<usize>,
-    ) {
-        if notify {
-            let mut data = inner.write();
-            if let Some(nv) = new_value {
-                data.value = nv;
-            }
-            data.meta.last_update = VARS.update_id();
-
-            if let Some(i) = custom_importance {
-                data.meta.animation.importance = i;
-            }
-
-            if !data.meta.hooks.is_empty() {
-                let mut hooks = std::mem::take(&mut data.meta.hooks);
-
-                let meta = parking_lot::RwLockWriteGuard::downgrade(data);
-
-                let args = AnyVarHookArgs::new(&meta.value, update, &tags);
-                call_hooks(&mut hooks, args);
-                drop(meta);
-
-                let mut data = inner.write();
-                hooks.append(&mut data.meta.hooks);
-                data.meta.hooks = hooks;
-            }
-
-            VARS.wake_app();
-        } else if let Some(i) = custom_importance {
-            let mut data = inner.write();
-            data.meta.animation.importance = i;
-        }
-    }
-    finish(inner, notify, new_value, update, tags, custom_importance);
-}
-
-fn call_hooks(hooks: &mut Vec<VarHook>, args: AnyVarHookArgs) {
-    hooks.retain(|h| h.call(&args));
-}

--- a/crates/zng-var/src/util.rs
+++ b/crates/zng-var/src/util.rs
@@ -332,9 +332,14 @@ impl VarData {
         *self.0.into_inner().value.into_any().downcast::<T>().unwrap()
     }
 
+    fn read<T: VarValue>(&self) -> parking_lot::MappedRwLockReadGuard<T> {
+        let read = self.0.read();
+        parking_lot::RwLockReadGuard::map(read, |r|r.value.as_any().downcast_ref::<T>().unwrap())
+    }
+
     /// Read the value.
     pub fn with<T: VarValue, R>(&self, f: impl FnOnce(&T) -> R) -> R {
-        f(self.0.read().value.as_any().downcast_ref::<T>().unwrap())
+        f(&*self.read())
     }
 
     pub fn last_update(&self) -> VarUpdateId {

--- a/crates/zng-var/src/util.rs
+++ b/crates/zng-var/src/util.rs
@@ -334,7 +334,7 @@ impl VarData {
 
     fn read<T: VarValue>(&self) -> parking_lot::MappedRwLockReadGuard<T> {
         let read = self.0.read();
-        parking_lot::RwLockReadGuard::map(read, |r|r.value.as_any().downcast_ref::<T>().unwrap())
+        parking_lot::RwLockReadGuard::map(read, |r| r.value.as_any().downcast_ref::<T>().unwrap())
     }
 
     /// Read the value.
@@ -453,4 +453,3 @@ fn apply_modify(
         data.meta.animation.importance = i;
     }
 }
-

--- a/crates/zng-var/src/when.rs
+++ b/crates/zng-var/src/when.rs
@@ -316,10 +316,7 @@ fn handle_condition(wk_when: Weak<Data>, i: usize, type_name: &'static str) -> B
 
             if update {
                 drop(data);
-                VARS.schedule_update(
-                    apply_update(rc_when, false, args.tags_vec()),
-                    type_name,
-                );
+                VARS.schedule_update(apply_update(rc_when, false, args.tags_vec()), type_name);
             }
 
             true
@@ -335,10 +332,7 @@ fn handle_value(wk_when: Weak<Data>, i: usize, type_name: &'static str) -> Box<d
             let data = rc_when.w.lock();
             if data.active == i {
                 drop(data);
-                VARS.schedule_update(
-                    apply_update(rc_when, args.update(), args.tags_vec()),
-                    type_name,
-                );
+                VARS.schedule_update(apply_update(rc_when, args.update(), args.tags_vec()), type_name);
             }
             true
         } else {
@@ -385,12 +379,15 @@ impl<T: VarValue> ArcWhenVar<T> {
         }
     }
 
-    
     /// Reference condition, value pairs.
     ///
     /// The active condition is the first `true`.
     pub fn conditions(&self) -> Vec<(BoxedVar<bool>, BoxedVar<T>)> {
-        self.0.conditions.iter().map(|(c, v)| (c.clone(), *v.clone().double_boxed_any().downcast::<BoxedVar<T>>().unwrap())).collect()
+        self.0
+            .conditions
+            .iter()
+            .map(|(c, v)| (c.clone(), *v.clone().double_boxed_any().downcast::<BoxedVar<T>>().unwrap()))
+            .collect()
     }
 
     /// The default value var.
@@ -635,7 +632,12 @@ impl<T: VarValue> Var<T> for ArcWhenVar<T> {
     where
         F: FnOnce(&mut VarModify<T>) + Send + 'static,
     {
-        self.active().clone().double_boxed_any().downcast::<BoxedVar<T>>().unwrap().modify(modify)
+        self.active()
+            .clone()
+            .double_boxed_any()
+            .downcast::<BoxedVar<T>>()
+            .unwrap()
+            .modify(modify)
     }
 
     fn set<I>(&self, value: I) -> Result<(), VarIsReadOnlyError>


### PR DESCRIPTION
Experiment, remove all generics from core var implementations, replacing with a wrapper Phantom<T> that just casts to the strong type.

Improves #559