### PR TITLE
Use prebuilt in more examples

### DIFF
--- a/examples/border/Cargo.toml
+++ b/examples/border/Cargo.toml
@@ -5,4 +5,4 @@ publish = false
 edition = "2021"
 
 [dependencies]
-zng = { path = "../../crates/zng", features = ["view"] }
+zng = { path = "../../crates/zng", features = ["view_prebuilt"] }

--- a/examples/shortcut/Cargo.toml
+++ b/examples/shortcut/Cargo.toml
@@ -5,5 +5,5 @@ publish = false
 edition = "2021"
 
 [dependencies]
-zng = { path = "../../crates/zng", features = ["view"] }
+zng = { path = "../../crates/zng", features = ["view_prebuilt"] }
 tracing = "0.1"


### PR DESCRIPTION
Some examples are configured to compile the view-process when they don't need too, this can be changed for more easy access now that the renderer issues are debugged for each.