### PR TITLE
Fix `cargo zng fmt` for widgets with more than one `when` block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `cargo zng fmt` for widgets with more than one `when` block.
 * Fix `Wrap!` ignoring child `Text!` that is only a line-break.
 * Fix soft/hard breaks in `Markdown!`.
 * Improve cache of font data to use less memory.

--- a/crates/cargo-zng/src/fmt.rs
+++ b/crates/cargo-zng/src/fmt.rs
@@ -419,7 +419,7 @@ fn replace_widget_when(code: &str, reverse: bool) -> Cow<str> {
     static POUND_MARKER: &str = "__P_";
 
     if !reverse {
-        RGX.replace(code, |caps: &regex::Captures| {
+        RGX.replace_all(code, |caps: &regex::Captures| {
             let prefix_spaces = &caps[0][..caps.get(1).unwrap().start() - caps.get(0).unwrap().start()];
 
             let expr = &caps[0][caps.get(1).unwrap().end() - caps.get(0).unwrap().start()..];

--- a/crates/zng-wgt-button/src/lib.rs
+++ b/crates/zng-wgt-button/src/lib.rs
@@ -314,7 +314,7 @@ impl DefaultStyle {
             #[easing(150.ms())]
             border = {
                 widths: 1,
-                sides: BASE_COLOR_VAR.rgba_into()
+                sides: BASE_COLOR_VAR.rgba_into(),
             };
 
             when *#is_cap_hovered {

--- a/crates/zng-wgt-window/src/lib.rs
+++ b/crates/zng-wgt-window/src/lib.rs
@@ -82,9 +82,7 @@ impl Window {
             }
 
             when #needs_fallback_chrome {
-                custom_chrome_adorner_fn = wgt_fn!(|_| {
-                    fallback_chrome()
-                });
+                custom_chrome_adorner_fn = wgt_fn!(|_| { fallback_chrome() });
                 custom_chrome_padding_fn = ContextualizedVar::new(|| {
                     let vars = WINDOW.vars();
                     expr_var! {


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->