### PR TITLE
Fix small `Text!` in a `Wrap!` not starting a new line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix small `Text!` in a `Wrap!` not starting a new line.
 
 # 0.13.8
 

--- a/crates/zng-ext-font/src/shaping.rs
+++ b/crates/zng-ext-font/src/shaping.rs
@@ -2280,6 +2280,7 @@ impl ShapedTextBuilder {
         word_ctx_key.direction = info.direction();
         if info.kind.is_word() {
             let max_width = self.actual_max_width();
+
             fonts.shape_segment(seg, word_ctx_key, features, |shaped_seg, font| {
                 if self.origin.x + shaped_seg.x_advance > max_width {
                     // need wrap
@@ -2300,6 +2301,8 @@ impl ShapedTextBuilder {
                             };
                             if !self.out.segments.0[current_start..].is_empty() {
                                 self.push_line_break(true, text);
+                            } else if current_start == 0 && self.allow_first_wrap {
+                                self.out.first_wrapped = true;
                             }
                             self.push_glyphs(shaped_seg, self.letter_spacing);
                             self.push_text_seg(seg, info);


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->