### PR TITLE
Remove prebuilt libraries on `cargo do clean`

### DIFF
--- a/tools/cargo-do/src/main.rs
+++ b/tools/cargo-do/src/main.rs
@@ -1257,6 +1257,18 @@ fn clean(mut args: Vec<&str>) {
         let manifest_path = dunce::canonicalize(manifest_path).unwrap().display().to_string();
         cmd_external("cargo", &["clean", "--manifest-path", &manifest_path], &args);
     }
+
+    if all || prebuild {
+        let mut count = 0;
+        for file in glob::glob("crates/zng-view-prebuilt/lib/*").unwrap() {
+            let file = file.unwrap();
+            if !file.ends_with("README.md") {
+                std::fs::remove_file(file).unwrap();
+                count += 1;
+            }
+        }
+        println!("     Removed {count} prebuild files")
+    }
 }
 
 // do asm [r --rust] [--debug] [<FN-PATH>] [<cargo-asm-args>]


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->