### PR TITLE
Add retries for apt calls in workflows

### DIFF
--- a/.github/workflows/check-features.yml
+++ b/.github/workflows/check-features.yml
@@ -26,6 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - run: cargo do check-all-features ${{ matrix.profile }} --max ${{ github.event.inputs.max }} --clean ${{ github.event.inputs.clean }} --chunk "${{ matrix.chunk }}/12"
       - run: cargo clean

--- a/.github/workflows/check-features.yml
+++ b/.github/workflows/check-features.yml
@@ -26,6 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - run: cargo do check-all-features ${{ matrix.profile }} --max ${{ github.event.inputs.max }} --clean ${{ github.event.inputs.clean }} --chunk "${{ matrix.chunk }}/12"
       - run: cargo clean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - uses: Swatinem/rust-cache@v2
       - run: cargo do version --verbose
       - run: cargo do fmt --check
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --examples --tests --release
   check-wasm:
@@ -137,7 +137,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - uses: Swatinem/rust-cache@v2
         with:
           cache-targets: false # do doc needs a clean target/doc
@@ -157,7 +157,7 @@ jobs:
       uses: taiki-e/install-action@v2
       with:
         tool: cargo-nextest
-    - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+    - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
     - run: cargo do test --nextest
@@ -205,7 +205,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - uses: Swatinem/rust-cache@v2
       - run: cargo do test --doc
   test-macro:
@@ -216,7 +216,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-src
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - uses: Swatinem/rust-cache@v2
       - run: cargo do test --macro --all
   test-render-ubuntu:
@@ -229,7 +229,7 @@ jobs:
              sudo apt-get update
              sudo apt install libxkbcommon-x11-0
       - uses: actions/checkout@v4
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - uses: Swatinem/rust-cache@v2
       - name: cargo do test --render --no-prebuilt
         uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - uses: Swatinem/rust-cache@v2
       - run: cargo do version --verbose
       - run: cargo do fmt --check
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --examples --tests --release
   check-wasm:
@@ -137,7 +137,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - uses: Swatinem/rust-cache@v2
         with:
           cache-targets: false # do doc needs a clean target/doc
@@ -157,7 +157,7 @@ jobs:
       uses: taiki-e/install-action@v2
       with:
         tool: cargo-nextest
-    - run: sudo apt install libfontconfig1-dev
+    - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
     - run: cargo do test --nextest
@@ -205,7 +205,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - uses: Swatinem/rust-cache@v2
       - run: cargo do test --doc
   test-macro:
@@ -216,7 +216,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-src
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - uses: Swatinem/rust-cache@v2
       - run: cargo do test --macro --all
   test-render-ubuntu:
@@ -229,7 +229,7 @@ jobs:
              sudo apt-get update
              sudo apt install libxkbcommon-x11-0
       - uses: actions/checkout@v4
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - uses: Swatinem/rust-cache@v2
       - name: cargo do test --render --no-prebuilt
         uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -26,7 +26,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-about
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - run: cargo +nightly check --workspace ${{ matrix.feature }} ${{ matrix.profile }} 
   check-windows:
     needs: [check-ubuntu]
@@ -73,5 +73,5 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-about
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - run: cargo +nightly doc --all-features --no-deps

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -26,7 +26,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-about
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - run: cargo +nightly check --workspace ${{ matrix.feature }} ${{ matrix.profile }} 
   check-windows:
     needs: [check-ubuntu]
@@ -73,5 +73,5 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-about
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - run: cargo +nightly doc --all-features --no-deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ github.event.inputs.skip_checks != 'true' }}
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ github.event.inputs.skip_checks != 'true' }}
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
         if: ${{ github.event.inputs.skip_checks != 'true' }}
       - run: cargo do version --verbose
         if: ${{ github.event.inputs.skip_checks != 'true' }}
@@ -342,7 +342,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: ${{ github.event.inputs.skip_doc != 'true' }}
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
         if: ${{ github.event.inputs.skip_doc != 'true' }}
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ github.event.inputs.skip_doc != 'true' }}
@@ -376,7 +376,7 @@ jobs:
           tool: cargo-nextest
       - uses: actions/checkout@v4
         if: ${{ github.event.inputs.skip_tests != 'true' }}
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
         if: ${{ github.event.inputs.skip_tests != 'true' }}
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ github.event.inputs.skip_tests != 'true' }}
@@ -504,7 +504,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: ${{ github.event.inputs.skip_tests != 'true' }}
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
         if: ${{ github.event.inputs.skip_tests != 'true' }}
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ github.event.inputs.skip_tests != 'true' }}
@@ -632,7 +632,7 @@ jobs:
         if: ${{ github.event.inputs.skip_crates != 'true' }}
       - uses: actions/checkout@v4
         if: ${{ github.event.inputs.skip_crates != 'true' }}
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
         if: ${{ github.event.inputs.skip_crates != 'true' }}
       - run: cargo do publish --execute ${{ github.run_attempt > 1 && '--no-burst' || '' }}
         if: ${{ github.event.inputs.skip_crates != 'true' }}
@@ -644,7 +644,7 @@ jobs:
         if: ${{ github.event.inputs.skip_crates != 'true' }}
       - uses: actions/checkout@v4
         if: ${{ github.event.inputs.skip_crates != 'true' }}
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
         if: ${{ github.event.inputs.skip_crates != 'true' }}
       - run: cargo do test --published
         if: ${{ github.event.inputs.skip_crates != 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ github.event.inputs.skip_checks != 'true' }}
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ github.event.inputs.skip_checks != 'true' }}
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
         if: ${{ github.event.inputs.skip_checks != 'true' }}
       - run: cargo do version --verbose
         if: ${{ github.event.inputs.skip_checks != 'true' }}
@@ -342,7 +342,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: ${{ github.event.inputs.skip_doc != 'true' }}
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
         if: ${{ github.event.inputs.skip_doc != 'true' }}
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ github.event.inputs.skip_doc != 'true' }}
@@ -376,7 +376,7 @@ jobs:
           tool: cargo-nextest
       - uses: actions/checkout@v4
         if: ${{ github.event.inputs.skip_tests != 'true' }}
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
         if: ${{ github.event.inputs.skip_tests != 'true' }}
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ github.event.inputs.skip_tests != 'true' }}
@@ -504,7 +504,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: ${{ github.event.inputs.skip_tests != 'true' }}
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
         if: ${{ github.event.inputs.skip_tests != 'true' }}
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ github.event.inputs.skip_tests != 'true' }}
@@ -632,7 +632,7 @@ jobs:
         if: ${{ github.event.inputs.skip_crates != 'true' }}
       - uses: actions/checkout@v4
         if: ${{ github.event.inputs.skip_crates != 'true' }}
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
         if: ${{ github.event.inputs.skip_crates != 'true' }}
       - run: cargo do publish --execute ${{ github.run_attempt > 1 && '--no-burst' || '' }}
         if: ${{ github.event.inputs.skip_crates != 'true' }}
@@ -644,7 +644,7 @@ jobs:
         if: ${{ github.event.inputs.skip_crates != 'true' }}
       - uses: actions/checkout@v4
         if: ${{ github.event.inputs.skip_crates != 'true' }}
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
         if: ${{ github.event.inputs.skip_crates != 'true' }}
       - run: cargo do test --published
         if: ${{ github.event.inputs.skip_crates != 'true' }}

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -17,5 +17,5 @@ jobs:
         with:
           crate: cargo-semver-checks
       - uses: actions/checkout@v4
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - run: cargo do semver_check

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -17,5 +17,5 @@ jobs:
         with:
           crate: cargo-semver-checks
       - uses: actions/checkout@v4
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - run: cargo do semver_check

--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
+      - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - run: cargo do doc
       - name: upload doc
         uses: actions/upload-artifact@v4

--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: sudo apt install libfontconfig1-dev
+      - run: sudo apt install libfontconfig1-dev -o Acquire::Retries=5
       - run: cargo do doc
       - name: upload doc
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The command `sudo apt install libfontconfig1-dev` keeps failing due to failed fetches, lets see if  this helps.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->