### PR TITLE
Fix text size in inline layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix regression, some `Text!` in `Wrap!` not rendering.
 
 # 0.13.9
 

--- a/crates/zng-wgt-text/src/node/layout.rs
+++ b/crates/zng-wgt-text/src/node/layout.rs
@@ -560,10 +560,10 @@ impl LayoutTextFinal {
 
         if self.pending.contains(PendingLayout::RESHAPE_LINES) && metrics.inline_constraints().is_none() {
             // Affects block size in measure too
-            // 
+            //
             // This breaks inline context, so it is avoided here and called later in the `if !is_measure` block.
             // This is needed to measure the same block size a layout call would output.
-            // 
+            //
             // Not sure if it is a bug that it does not work inlining, but it is not needed there anyway, so for now
             // this fix is sufficient.
             ctx.shaped_text.reshape_lines(


### PR DESCRIPTION
Fixes #609

Cannot `reshape_lines` during inline measure, so the quick fix is to only reshape_lines in block layout contexts for now.