### PR TITLE
Fix misaligned hyphenation split points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix misaligned hyphenation split points.
 * Fix missing lang region in hyphenation query.
 
 # 0.13.10


### PR DESCRIPTION
This closes #66, turns out it was a bug.