### PR TITLE
Fix text overflow truncate not applying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix text overflow truncate not applying in most texts.
 * Fix misaligned hyphenation split points.
 * Fix missing lang region in hyphenation query.
 

--- a/crates/zng-ext-font/src/shaping.rs
+++ b/crates/zng-ext-font/src/shaping.rs
@@ -698,6 +698,8 @@ impl ShapedText {
     ///
     /// The general process of shaping text is to generate a shaped-text without align during *measure*, and then reuse
     /// this shaped text every layout that does not invalidate any property that affects the text wrap.
+    ///
+    /// Note that align `FILL` is the same as `START` here, fill/justify spacing can be dynamically added during iteration later.
     #[expect(clippy::too_many_arguments)]
     pub fn reshape_lines(
         &mut self,
@@ -2585,7 +2587,6 @@ impl ShapedTextBuilder {
         info: TextSegment,
         text: &SegmentedText,
     ) -> bool {
-        println!("!!: {:?}", (seg, split_points));
         if split_points.is_empty() {
             return false;
         }

--- a/crates/zng-wgt-text/src/node/render.rs
+++ b/crates/zng-wgt-text/src/node/render.rs
@@ -459,7 +459,7 @@ pub fn render_text() -> impl UiNode {
                         frame.push_text(clip, glyphs.as_ref(), font, color_value, r.synthesis, aa);
                     };
 
-                    match (&t.overflow, TEXT_OVERFLOW_VAR.get(), !TEXT_EDITABLE_VAR.get()) {
+                    match (&t.overflow, TEXT_OVERFLOW_VAR.get(), TEXT_EDITABLE_VAR.get()) {
                         (Some(o), TextOverflow::Truncate(_), false) => {
                             for glyphs in &o.included_glyphs {
                                 for (font, glyphs) in t.shaped_text.glyphs_slice(glyphs.clone()) {

--- a/crates/zng-wgt-text/src/text_properties.rs
+++ b/crates/zng-wgt-text/src/text_properties.rs
@@ -412,7 +412,7 @@ pub enum TextOverflow {
     Ignore,
     /// Truncate the text so it will fit, the associated `Txt` is a suffix appended to the truncated text.
     ///
-    /// Note that if the suffix is not empty the text will truncated more to reserve space for the suffix. If
+    /// Note that if the suffix is not empty the text will truncate more to reserve space for the suffix. If
     /// the suffix itself is too wide it will overflow.
     Truncate(Txt),
 }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->