### PR TITLE
Fix `#[deprecation]` in property and widget proc-macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `#[deprecated]` widgets warning on declaration.
 * Fix `#[deprecated]` properties not warning on use and warning on declaration.
 * Fix text overflow truncate not applying in most texts.
 * Fix misaligned hyphenation split points.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `#[deprecated]` properties not warning on use and warning on declaration.
 * Fix text overflow truncate not applying in most texts.
 * Fix misaligned hyphenation split points.
 * Fix missing lang region in hyphenation query.

--- a/crates/zng-app-proc-macros/src/property.rs
+++ b/crates/zng-app-proc-macros/src/property.rs
@@ -1027,7 +1027,6 @@ pub fn expand_impl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     attrs.tag_doc("P", "This method is a widget property");
 
     let cfg = &attrs.cfg;
-    // let deprecated = &attrs.deprecated; !!: TODO
     let vis = p.vis;
     let path = p.path;
     let ident = &path.segments.last().unwrap().ident;

--- a/crates/zng-app-proc-macros/src/property.rs
+++ b/crates/zng-app-proc-macros/src/property.rs
@@ -141,7 +141,8 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> 
         // generate items if all is valid.
 
         let core = crate_core();
-        let cfg = Attributes::new(item.attrs.clone()).cfg;
+        let cfg = &attrs.cfg;
+        let deprecated = &attrs.deprecated;
         let vis = &item.vis;
         let ident = &item.sig.ident;
         let ident_str = ident.to_string();
@@ -589,6 +590,12 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> 
             }
         };
 
+        let allow_deprecated = deprecated.as_ref().map(|_| {
+            quote! {
+                #[allow(deprecated)]
+            }
+        });
+
         let args = quote! {
             #cfg
             #[doc(hidden)]
@@ -608,6 +615,7 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> 
                     #ident_meta { }.info #path_gens()
                 }
 
+                #allow_deprecated
                 fn instantiate(&self, __child__: #core::widget::node::BoxedUiNode) -> #core::widget::node::BoxedUiNode {
                     #instantiate
                 }
@@ -657,6 +665,7 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> 
                 #cfg
                 impl #generics_impl #target #generics {
                     #(#docs)*
+                    #deprecated
                     #vis fn #ident #impl_gens(&self, #(#input_idents: #input_tys),*) #where_gens {
                         let args = #ident_meta { }.args(#(#input_idents),*);
                         #core::widget::base::WidgetImpl::base_ref(self).mtd_property__(args)
@@ -696,6 +705,7 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> 
                 type MetaType;
 
                 #(#docs)*
+                #deprecated
                 #[allow(clippy::too_many_arguments)]
                 fn #ident #impl_gens(&mut self, #(#input_idents: #input_tys),*) #where_gens {
                     let args = #ident_meta { }.args(#(#input_idents),*);
@@ -1017,6 +1027,7 @@ pub fn expand_impl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     attrs.tag_doc("P", "This method is a widget property");
 
     let cfg = &attrs.cfg;
+    // let deprecated = &attrs.deprecated; !!: TODO
     let vis = p.vis;
     let path = p.path;
     let ident = &path.segments.last().unwrap().ident;

--- a/crates/zng-app-proc-macros/src/util.rs
+++ b/crates/zng-app-proc-macros/src/util.rs
@@ -338,6 +338,7 @@ pub struct Attributes {
     pub docs: Vec<Attribute>,
     pub inline: Option<Attribute>,
     pub cfg: Option<Attribute>,
+    pub deprecated: Option<Attribute>,
     pub lints: Vec<Attribute>,
     pub others: Vec<Attribute>,
 }
@@ -346,6 +347,7 @@ impl Attributes {
         let mut docs = vec![];
         let mut inline = None;
         let mut cfg = None;
+        let mut deprecated = None;
         let mut lints = vec![];
         let mut others = vec![];
 
@@ -358,6 +360,8 @@ impl Attributes {
                     inline = Some(attr);
                 } else if ident == "cfg" {
                     cfg = Some(attr);
+                } else if ident == "deprecated" {
+                    deprecated = Some(attr);
                 } else if ident == "allow" || ident == "expect" || ident == "warn" || ident == "deny" || ident == "forbid" {
                     lints.push(attr);
                 } else {
@@ -372,6 +376,7 @@ impl Attributes {
             docs,
             inline,
             cfg,
+            deprecated,
             lints,
             others,
         }
@@ -411,6 +416,7 @@ impl ToTokens for Attributes {
             .iter()
             .chain(&self.inline)
             .chain(&self.cfg)
+            .chain(&self.deprecated)
             .chain(&self.lints)
             .chain(&self.others)
         {

--- a/crates/zng-app-proc-macros/src/widget.rs
+++ b/crates/zng-app-proc-macros/src/widget.rs
@@ -134,6 +134,11 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream, mix
     } else {
         attrs.tag_doc("W", "Widget struct and macro");
     }
+    let allow_deprecated = attrs.deprecated.as_ref().map(|_| {
+        quote! {
+            #[allow(deprecated)]
+        }
+    });
 
     let struct_token = struct_.struct_token;
 
@@ -152,6 +157,7 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream, mix
             mod #validate_path_ident {
                 macro_rules! #validate_path_ident {
                     () => {
+                        #allow_deprecated
                         use #struct_path;
                     }
                 }
@@ -240,6 +246,7 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream, mix
 
         let source_location = widget_util::source_location(&crate_core, ident.span());
         let start_r = quote! {
+            #allow_deprecated
             impl #mixin_p_bounded #ident #mixin_p {
                 /// Start building a new instance.
                 pub fn widget_new() -> Self {
@@ -272,6 +279,7 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream, mix
         #attrs
         #docs_js
         #vis #struct_token #ident #mixin_p(#parent);
+        #allow_deprecated
         impl #mixin_p std::ops::Deref for #ident #mixin_p {
             type Target = #parent;
 
@@ -279,6 +287,7 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream, mix
                 &self.0
             }
         }
+        #allow_deprecated
         impl #mixin_p std::ops::DerefMut for #ident #mixin_p {
             fn deref_mut(&mut self) -> &mut Self::Target {
                 &mut self.0
@@ -287,6 +296,7 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream, mix
         #start_r
 
         #[doc(hidden)]
+        #allow_deprecated
         impl #mixin_p_bounded #crate_core::widget::base::WidgetImpl for #ident #mixin_p {
             fn inherit(widget: #crate_core::widget::builder::WidgetType) -> Self {
                 let mut wgt = Self(<#parent as #crate_core::widget::base::WidgetImpl>::inherit(widget));


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->