### PR TITLE
Accept NCSA license

### DIFF
--- a/.cargo/about.toml
+++ b/.cargo/about.toml
@@ -14,6 +14,7 @@ accepted = [
     "CC0-1.0",
     "Apache-2.0 WITH LLVM-exception",
     "Unicode-3.0",
+    "NCSA",
 ]
 
 ignore-build-dependencies = true


### PR DESCRIPTION
libfuzzer-sys updated their license.

[The license](https://en.wikipedia.org/wiki/University_of_Illinois/NCSA_Open_Source_License) is a MIT variant.