### PR TITLE
Fix audit error in CI for `paste` unmaintained

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,19 @@
+[advisories]
+ignore = [
+    # paste! no longer maintained
+    #
+    # already replaced in project crates, some dependencies still use it:
+    #
+    # └── accesskit_windows 0.24.1
+    # └── accesskit_winit 0.23.1
+    #     └── zng-view 0.8.0
+    # ├── rav1e 0.7.1
+    # └── ravif 0.11.11
+    #     └── image 0.25.5
+    #         ├── zng-view 0.8.0
+    #         └── arboard 3.4.1
+    #             └── zng-view 0.8.0
+    #
+    # remove this ignore when all dependencies are fixes
+    "RUSTSEC-2024-0436",
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix rustsec adivisory warning by replacing `paste` dependency with the new maintained `pastey` crate. 
 
 # 0.14.0
 

--- a/crates/zng-app/Cargo.toml
+++ b/crates/zng-app/Cargo.toml
@@ -104,7 +104,7 @@ bytemuck = { version = "1.15", features = ["derive"] }
 flume = "0.11"
 atomic = "0.6"
 bitflags = { version = "2.5", features = ["serde", "bytemuck"] }
-paste = "1.0"
+pastey = "0.1"
 once_cell = "1.19"
 unic-langid = { version = "0.9", features = ["serde"] }
 unicase = "2.7"

--- a/crates/zng-app/Cargo.toml
+++ b/crates/zng-app/Cargo.toml
@@ -104,7 +104,7 @@ bytemuck = { version = "1.15", features = ["derive"] }
 flume = "0.11"
 atomic = "0.6"
 bitflags = { version = "2.5", features = ["serde", "bytemuck"] }
-pastey = "0.1"
+pastey = "=0.1.0"
 once_cell = "1.19"
 unic-langid = { version = "0.9", features = ["serde"] }
 unicase = "2.7"

--- a/crates/zng-app/src/event/command.rs
+++ b/crates/zng-app/src/event/command.rs
@@ -162,7 +162,7 @@ use zng_var::{AnyVar, ArcVar, BoxedVar, ReadOnlyArcVar, Var, VarValue, impl_from
 pub use zng_app_context::app_local;
 
 #[doc(hidden)]
-pub use paste::paste;
+pub use pastey::paste;
 
 #[doc(hidden)]
 #[macro_export]

--- a/crates/zng-color/Cargo.toml
+++ b/crates/zng-color/Cargo.toml
@@ -18,5 +18,5 @@ zng-app-context = { path = "../zng-app-context", version = "0.6.0" }
 zng-var = { path = "../zng-var", version = "0.6.0" }
 zng-view-api = { path = "../zng-view-api", version = "0.12.0" }
 
-paste = "1.0"
+pastey = "0.1"
 serde = "1.0"

--- a/crates/zng-color/Cargo.toml
+++ b/crates/zng-color/Cargo.toml
@@ -18,5 +18,5 @@ zng-app-context = { path = "../zng-app-context", version = "0.6.0" }
 zng-var = { path = "../zng-var", version = "0.6.0" }
 zng-view-api = { path = "../zng-view-api", version = "0.12.0" }
 
-pastey = "0.1"
+pastey = "=0.1.0"
 serde = "1.0"

--- a/crates/zng-color/src/mix.rs
+++ b/crates/zng-color/src/mix.rs
@@ -1,7 +1,7 @@
 use super::{Hsla, Hsva, PreMulRgba, Rgba, clamp_normal};
 use zng_layout::unit::Factor;
 
-use paste::*;
+use pastey::*;
 
 /// Webrender [`MixBlendMode`].
 pub type RenderMixBlendMode = zng_view_api::MixBlendMode;

--- a/crates/zng-ext-font/Cargo.toml
+++ b/crates/zng-ext-font/Cargo.toml
@@ -45,7 +45,7 @@ byteorder = "1.5"
 icu_properties = "1.4"
 bitflags = { version = "2.5", features = ["serde", "bytemuck"] }
 tracing = "0.1"
-pastey = "0.1"
+pastey = "=0.1.0"
 num_enum = "0.7"
 hyphenation = "0.8"
 regex = "1.10"

--- a/crates/zng-ext-font/Cargo.toml
+++ b/crates/zng-ext-font/Cargo.toml
@@ -45,7 +45,7 @@ byteorder = "1.5"
 icu_properties = "1.4"
 bitflags = { version = "2.5", features = ["serde", "bytemuck"] }
 tracing = "0.1"
-paste = "1.0"
+pastey = "0.1"
 num_enum = "0.7"
 hyphenation = "0.8"
 regex = "1.10"

--- a/crates/zng-ext-font/src/lib.rs
+++ b/crates/zng-ext-font/src/lib.rs
@@ -44,7 +44,7 @@ mod unit;
 pub use unit::*;
 
 use parking_lot::{Mutex, RwLock};
-use paste::paste;
+use pastey::paste;
 use zng_app::{
     AppExtension,
     event::{event, event_args},

--- a/crates/zng-unique-id/Cargo.toml
+++ b/crates/zng-unique-id/Cargo.toml
@@ -25,7 +25,7 @@ hot_reload = ["dep:linkme"]
 rayon = "1.10"
 hashbrown = { version = "0.15", features = ["rayon"] }
 tracing = "0.1"
-pastey = "0.1"
+pastey = "=0.1.0"
 once_cell = "1.19"
 
 zng-txt = { path = "../zng-txt", version = "0.3.0", optional = true }

--- a/crates/zng-unique-id/Cargo.toml
+++ b/crates/zng-unique-id/Cargo.toml
@@ -25,7 +25,7 @@ hot_reload = ["dep:linkme"]
 rayon = "1.10"
 hashbrown = { version = "0.15", features = ["rayon"] }
 tracing = "0.1"
-paste = "1.0"
+pastey = "0.1"
 once_cell = "1.19"
 
 zng-txt = { path = "../zng-txt", version = "0.3.0", optional = true }

--- a/crates/zng-unique-id/src/lib.rs
+++ b/crates/zng-unique-id/src/lib.rs
@@ -51,7 +51,7 @@ pub use hot_reload::lazy_static_init;
 pub use named::*;
 
 #[doc(hidden)]
-pub use paste::paste;
+pub use pastey::paste;
 
 /// Declare a new unique id type that is backed by a `NonZeroU32`.
 #[macro_export]

--- a/crates/zng-view/Cargo.toml
+++ b/crates/zng-view/Cargo.toml
@@ -127,14 +127,14 @@ winit = { version = "0.30", default-features = false, features = [
 glutin = "0.32"
 raw-window-handle = "0.6" # matches glutin
 flume = "0.11"
-image = { version = "0.25", default-features = false, features = ["rayon"] }
+image = { version = "0.25", default-features = false, features = ["rayon"] } # on upgrade review audit.toml
 img-parts = "0.3"
 byteorder = "1.5"
 rustc-hash = "2.0"
 rayon = "1.10"
 serde = "1.0"
-accesskit = "0.17"
-accesskit_winit = "0.23"
+accesskit = "0.18"
+accesskit_winit = "0.26"
 # rfd
 ## cfg(not(linux, android, ios))
 [target.'cfg(not(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "android", target_os = "ios")))'.dependencies.rfd]

--- a/crates/zng-view/src/window.rs
+++ b/crates/zng-view/src/window.rs
@@ -419,6 +419,7 @@ impl Window {
         drop(wr_scope);
 
         let access = accesskit_winit::Adapter::with_direct_handlers(
+            winit_loop,
             &winit_window,
             AccessActivateHandler {
                 id,

--- a/crates/zng-wgt-window/Cargo.toml
+++ b/crates/zng-wgt-window/Cargo.toml
@@ -39,7 +39,7 @@ zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.5.0" }
 zng-wgt-button = { path = "../zng-wgt-button", version = "0.6.0", default-features = false }
 
 serde = { version = "1.0", features = ["derive"] }
-pastey = "0.1"
+pastey = "=0.1.0"
 parking_lot = "0.12"
 euclid = "0.22"
 tracing = "0.1"

--- a/crates/zng-wgt-window/Cargo.toml
+++ b/crates/zng-wgt-window/Cargo.toml
@@ -39,7 +39,7 @@ zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.5.0" }
 zng-wgt-button = { path = "../zng-wgt-button", version = "0.6.0", default-features = false }
 
 serde = { version = "1.0", features = ["derive"] }
-paste = "1.0"
+pastey = "0.1"
 parking_lot = "0.12"
 euclid = "0.22"
 tracing = "0.1"

--- a/crates/zng-wgt-window/src/window_properties.rs
+++ b/crates/zng-wgt-window/src/window_properties.rs
@@ -49,7 +49,7 @@ macro_rules! set_properties {
     ($(
         $ident:ident: $Type:ty,
     )+) => {
-        $(paste::paste! {
+        $(pastey::paste! {
             #[doc = "Binds the [`"$ident "`](fn@WindowVars::"$ident ") window var with the property value."]
             ///
             /// The binding is bidirectional and the window variable is assigned on init.
@@ -101,7 +101,7 @@ set_properties! {
 macro_rules! map_properties {
     ($(
         $ident:ident . $member:ident = $name:ident : $Type:ty,
-    )+) => {$(paste::paste! {
+    )+) => {$(pastey::paste! {
         #[doc = "Binds the `"$member "` of the [`"$ident "`](fn@WindowVars::"$ident ") window var with the property value."]
         ///
         /// The binding is bidirectional and the window variable is assigned on init.

--- a/crates/zng-wgt/Cargo.toml
+++ b/crates/zng-wgt/Cargo.toml
@@ -37,7 +37,7 @@ zng-task = { path = "../zng-task", version = "0.5.0" }
 zng-txt = { path = "../zng-txt", version = "0.3.0" }
 zng-unique-id = { path = "../zng-unique-id", version = "0.5.0" }
 
-pastey = "0.1"
+pastey = "=0.1.0"
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 pretty-type-name = "1.0"

--- a/crates/zng-wgt/Cargo.toml
+++ b/crates/zng-wgt/Cargo.toml
@@ -37,7 +37,7 @@ zng-task = { path = "../zng-task", version = "0.5.0" }
 zng-txt = { path = "../zng-txt", version = "0.3.0" }
 zng-unique-id = { path = "../zng-unique-id", version = "0.5.0" }
 
-paste = "1.0"
+pastey = "0.1"
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 pretty-type-name = "1.0"

--- a/crates/zng-wgt/src/node.rs
+++ b/crates/zng-wgt/src/node.rs
@@ -29,7 +29,7 @@ use zng_state_map::{StateId, StateMapRef, StateValue};
 use zng_var::{types::VecChange, *};
 
 #[doc(hidden)]
-pub use paste::paste;
+pub use pastey::paste;
 
 #[doc(hidden)]
 pub use zng_app;


### PR DESCRIPTION
Replace `paste` dep with `pastey` in project crates.

Upgrade `accesskit_winit` to newer version that also removes it.

Add `audit.toml` to ignore other dependencies that still use paste.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->