### PR TITLE
Fix shift+arrow key gestures not starting text selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix shift+arrow key gestures not starting text selection until next arrow key press.
+* Update dependencies.
 
 # 0.14.2
 

--- a/crates/zng-wgt-text/src/node.rs
+++ b/crates/zng-wgt-text/src/node.rs
@@ -176,7 +176,7 @@ pub struct ImePreview {
 /// Text internals used by text implementer nodes and properties.
 ///
 /// The text implementation is split between two contexts, [`resolve_text`] and [`layout_text`], this service
-/// provides access to data produced y these two contexts.
+/// provides access to data produced by these two contexts.
 pub struct TEXT;
 
 impl TEXT {


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->