### PR TITLE
Implement rich text selection and copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix incorrect `Wrap!` debug validation with negative spacing.
 * Fix shift+arrow key gestures not starting text selection until next arrow key press.
 * Update dependencies.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Enable basic text selection and copy for `Markdown!` and `AnsiText!`.
 * Add `WidgetBoundsInfo::inner_rects` and associated methods.
 * Add `WidgetInfo::nearest_rect` and associated methods.
 * Text now clears selection on `Key::Escape`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Text now clears selection on `Key::Escape`.
 * Implement all `FromIterator` and `Extend` that `String` implements for `Txt`.
 * Fix Alt focus scope navigation from inside nested focus scopes.
 * Implement `From<WidgetFocusInfo> for WidgetInfo`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix Alt focus scope navigation from inside nested focus scopes.
 * Implement `From<WidgetFocusInfo> for WidgetInfo`.
 * Surface `zng::text::txt_selectable` property.
 * Fix incorrect `Wrap!` debug validation with negative spacing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add `WidgetBoundsInfo::inner_rects` and associated methods.
+* Add `WidgetInfo::nearest_rect` and associated methods.
 * Text now clears selection on `Key::Escape`.
 * Implement all `FromIterator` and `Extend` that `String` implements for `Txt`.
 * Fix Alt focus scope navigation from inside nested focus scopes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Add missing `zng::text::txt_selectable` reexport.
 * Fix incorrect `Wrap!` debug validation with negative spacing.
 * Fix shift+arrow key gestures not starting text selection until next arrow key press.
 * Update dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Implement all `FromIterator` and `Extend` that `String` implements for `Txt`.
 * Fix Alt focus scope navigation from inside nested focus scopes.
 * Implement `From<WidgetFocusInfo> for WidgetInfo`.
 * Surface `zng::text::txt_selectable` property.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-* Add missing `zng::text::txt_selectable` reexport.
+* Implement `From<WidgetFocusInfo> for WidgetInfo`.
+* Surface `zng::text::txt_selectable` property.
 * Fix incorrect `Wrap!` debug validation with negative spacing.
 * Fix shift+arrow key gestures not starting text selection until next arrow key press.
 * Update dependencies.

--- a/crates/zng-app/src/event/command.rs
+++ b/crates/zng-app/src/event/command.rs
@@ -558,6 +558,12 @@ impl Command {
         ))
     }
 
+    /// Create an event update for this command with custom `param`.
+    pub fn new_update_param(&self, param: impl Any + Send + Sync) -> EventUpdate {
+        self.event
+            .new_update(CommandArgs::now(CommandParam::new(param), self.scope, self.is_enabled_value()))
+    }
+
     /// Creates a preview event handler for the command.
     ///
     /// This is similar to [`Event::on_pre_event`], but `handler` is only called if the command

--- a/crates/zng-app/src/widget/info.rs
+++ b/crates/zng-app/src/widget/info.rs
@@ -524,7 +524,7 @@ impl WidgetBoundsInfo {
         self.0.lock().baseline
     }
 
-    /// Gets the baseline of the widget after [`inner_offset`] is applied.
+    /// Gets the baseline offset of the widget after [`inner_offset`] is applied.
     ///
     /// Returns `Px(0)` if [`inner_offset_baseline`], otherwise returns [`baseline`].
     ///

--- a/crates/zng-app/src/widget/info.rs
+++ b/crates/zng-app/src/widget/info.rs
@@ -1509,6 +1509,19 @@ impl WidgetInfo {
         }
     }
 
+    /// Compare the position of `self` and `sibling` in the `ancestor` [`descendants`].
+    ///
+    /// [`descendants`]: Self::descendants
+    pub fn cmp_sibling_in(&self, sibling: &WidgetInfo, ancestor: &WidgetInfo) -> Option<std::cmp::Ordering> {
+        let range = ancestor.node().descendants_range();
+        let index = self.node_id.get();
+        let sibling_index = sibling.node_id.get();
+        if range.contains(&index) && self.tree == sibling.tree && self.tree == ancestor.tree {
+            return Some(index.cmp(&sibling_index));
+        }
+        None
+    }
+
     /// If `self` is an ancestor of `maybe_descendant`.
     pub fn is_ancestor(&self, maybe_descendant: &WidgetInfo) -> bool {
         self.descendants_range().contains(maybe_descendant)

--- a/crates/zng-app/src/widget/node/list.rs
+++ b/crates/zng-app/src/widget/node/list.rs
@@ -970,6 +970,7 @@ impl_from_and_into_var! {
     fn from(index: u32) -> ZIndex {
         ZIndex(index)
     }
+    fn from(index: ZIndex) -> Option<ZIndex>;
 }
 
 /// Represents an [`UiNodeList::update_all`] observer that can be used to monitor widget insertion, removal and re-order.

--- a/crates/zng-ext-input/src/focus.rs
+++ b/crates/zng-ext-input/src/focus.rs
@@ -139,7 +139,7 @@ impl FocusChangedArgs {
         }
     }
 
-    /// If `widget_id` is the new focus or a parent of the new focus and was not a parent of the previous focus.
+    /// If `widget_id` is the new focus or a parent of the new focus and was not the focus nor the parent of the previous focus.
     pub fn is_focus_enter(&self, widget_id: WidgetId) -> bool {
         match (&self.prev_focus, &self.new_focus) {
             (Some(prev), Some(new)) => !prev.contains(widget_id) && new.contains(widget_id),
@@ -148,7 +148,7 @@ impl FocusChangedArgs {
         }
     }
 
-    /// If `widget_id` is the previous focus or a parent of the previous focus and is not a parent of the new focus.
+    /// If `widget_id` is the previous focus or a parent of the previous focus and is not the new focus nor a parent of the new focus.
     pub fn is_focus_leave(&self, widget_id: WidgetId) -> bool {
         match (&self.prev_focus, &self.new_focus) {
             (Some(prev), Some(new)) => prev.contains(widget_id) && !new.contains(widget_id),

--- a/crates/zng-ext-input/src/focus.rs
+++ b/crates/zng-ext-input/src/focus.rs
@@ -312,7 +312,7 @@ event! {
 ///
 /// # About Focus
 ///
-/// See the [module level](crate::focus) documentation for an overview of the keyboard
+/// See the [module level](../) documentation for an overview of the keyboard
 /// focus concepts implemented by this app extension.
 ///
 /// [`SHORTCUT_EVENT`]: crate::gesture::SHORTCUT_EVENT

--- a/crates/zng-ext-input/src/focus/focus_info.rs
+++ b/crates/zng-ext-input/src/focus/focus_info.rs
@@ -1702,6 +1702,11 @@ impl WidgetFocusInfo {
         nav
     }
 }
+impl_from_and_into_var! {
+    fn from(focus_info: WidgetFocusInfo) -> WidgetInfo {
+        focus_info.info
+    }
+}
 
 /// Focus metadata associated with a widget info tree.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]

--- a/crates/zng-ext-input/src/focus/focus_info.rs
+++ b/crates/zng-ext-input/src/focus/focus_info.rs
@@ -170,7 +170,7 @@ impl<'de> serde::Deserialize<'de> for TabIndex {
 
 /// Tab navigation configuration of a focus scope.
 ///
-/// See the [module level](crate::focus#tab-navigation) for an overview of tab navigation.
+/// See the [module level](../#tab-navigation) for an overview of tab navigation.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum TabNav {
     /// Tab can move into the scope, but does not move the focus inside the scope.
@@ -201,7 +201,7 @@ impl fmt::Debug for TabNav {
 
 /// Directional navigation configuration of a focus scope.
 ///
-/// See the [module level](crate::focus#directional-navigation) for an overview of directional navigation.
+/// See the [module level](../#directional-navigation) for an overview of directional navigation.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum DirectionalNav {
     /// Arrows can move into the scope, but does not move the focus inside the scope.

--- a/crates/zng-unit/src/distance_key.rs
+++ b/crates/zng-unit/src/distance_key.rs
@@ -1,4 +1,4 @@
-use crate::{Px, PxPoint};
+use crate::{Px, PxPoint, PxRect};
 
 use serde::{Deserialize, Serialize};
 
@@ -30,6 +30,11 @@ impl DistanceKey {
         Self((pa + pb) + 1)
     }
 
+    /// New distance key computed from the nearest point inside `a` to `b`.
+    pub fn from_rect_to_point(a: PxRect, b: PxPoint) -> Self {
+        Self::from_points(b.clamp(a.min(), a.max()), b)
+    }
+
     /// New distance key from already computed actual distance.
     ///
     /// Note that computing the actual distance is slower then using [`from_points`] to compute just the distance key.
@@ -58,5 +63,15 @@ impl DistanceKey {
 
             Some(Px(d.round() as i32))
         }
+    }
+
+    /// Compares and returns the minimum distance.
+    pub fn min(self, other: Self) -> Self {
+        Self(self.0.min(other.0))
+    }
+
+    /// Compares and returns the maximum distance.
+    pub fn max(self, other: Self) -> Self {
+        Self(self.0.max(other.0))
     }
 }

--- a/crates/zng-wgt-ansi-text/Cargo.toml
+++ b/crates/zng-wgt-ansi-text/Cargo.toml
@@ -19,5 +19,6 @@ zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.4.2" }
 zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.6.2" }
 zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.5.2" }
 zng-ext-font = { path = "../zng-ext-font", version = "0.6.2" }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.4.2" }
 
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/zng-wgt-ansi-text/src/lib.rs
+++ b/crates/zng-wgt-ansi-text/src/lib.rs
@@ -15,6 +15,7 @@ use zng_ext_font::*;
 use zng_wgt::{prelude::*, *};
 use zng_wgt_fill::*;
 use zng_wgt_filter::*;
+use zng_wgt_input::{CursorIcon, cursor};
 use zng_wgt_scroll::{LazyMode, lazy};
 use zng_wgt_stack::{Stack, StackDirection};
 use zng_wgt_text::*;
@@ -50,6 +51,11 @@ impl AnsiText {
         widget_set! {
             self;
             font_family = ["JetBrains Mono", "Consolas", "monospace"];
+            rich_text = true;
+
+            when #txt_selectable {
+                cursor = CursorIcon::Text;
+            }
         };
 
         self.widget_builder().push_build_action(|wgt| {
@@ -62,6 +68,11 @@ impl AnsiText {
     widget_impl! {
         /// ANSI text.
         pub txt(text: impl IntoVar<Txt>);
+
+        /// Enable text selection, copy.
+        ///
+        /// Note that the copy is only in plain text, without the ANSI escape codes.
+        pub zng_wgt_text::txt_selectable(enabled: impl IntoVar<bool>);
     }
 }
 
@@ -524,6 +535,7 @@ mod ansi_fn {
             args.text.remove(0)
         } else {
             Stack! {
+                rich_text = true;
                 direction = StackDirection::start_to_end();
                 children = args.text;
             }
@@ -544,6 +556,7 @@ mod ansi_fn {
         } else {
             let len = args.lines.len();
             Stack! {
+                rich_text = true;
                 direction = StackDirection::top_to_bottom();
                 children = args.lines;
                 lazy = LazyMode::lazy_vertical(wgt_fn!(|_| {
@@ -567,6 +580,7 @@ mod ansi_fn {
             args.pages.remove(0)
         } else {
             Stack! {
+                rich_text = true;
                 direction = StackDirection::top_to_bottom();
                 children = args.pages;
             }

--- a/crates/zng-wgt-markdown/src/lib.rs
+++ b/crates/zng-wgt-markdown/src/lib.rs
@@ -17,6 +17,7 @@ pub use pulldown_cmark::HeadingLevel;
 
 use zng_ext_font::WhiteSpace;
 use zng_wgt::prelude::*;
+use zng_wgt_input::{CursorIcon, cursor};
 
 #[doc(hidden)]
 pub use zng_wgt_text::__formatx;
@@ -57,6 +58,10 @@ impl Markdown {
             on_link = hn!(|args: &LinkArgs| {
                 try_default_link_action(args);
             });
+
+            when #txt_selectable {
+                cursor = CursorIcon::Text;
+            }
         };
 
         self.widget_builder().push_build_action(|wgt| {
@@ -69,6 +74,11 @@ impl Markdown {
     widget_impl! {
         /// Markdown text.
         pub text::txt(txt: impl IntoVar<Txt>);
+
+        /// Enable text selection, copy.
+        ///
+        /// Note that the copy is only in plain text, without any style.
+        pub zng_wgt_text::txt_selectable(enabled: impl IntoVar<bool>);
     }
 }
 

--- a/crates/zng-wgt-text/src/cmd.rs
+++ b/crates/zng-wgt-text/src/cmd.rs
@@ -1592,12 +1592,16 @@ fn continue_rich_clear_line_start_end_inside_caret(is_end: bool, caret: &WidgetF
     if !is_inside {
         if is_end {
             let mut prev = caret.info().clone();
+            let mut found = false;
             for next in caret.info().rich_text_next() {
                 let info = next.info().rich_text_line_info();
+                println!("!!: {:?}", (next.info().id(), &info));
                 if info.starts_new_line {
                     // prev's text end is the line end
                     new_caret_id = prev.id();
                     SELECT_CMD.scoped(new_caret_id).notify_param(TextSelectOp::local_text_end());
+                    found = true;
+                    break;
                 } else if info.ends_in_new_line {
                     // next's first row end is the line end
                     new_caret_id = next.info().id();
@@ -1608,13 +1612,17 @@ fn continue_rich_clear_line_start_end_inside_caret(is_end: bool, caret: &WidgetF
                         ctx.clear_selection();
                         ctx.set_index(CaretIndex { index: new_idx, line: 0 });
                     }));
+                    found = true;
+                    break;
                 } else {
                     prev = next.into();
                 }
             }
-            // end of text is line end
-            new_caret_id = prev.id();
-            SELECT_CMD.scoped(new_caret_id).notify_param(TextSelectOp::local_text_end());
+            if !found {
+                // end of text is line end
+                new_caret_id = prev.id();
+                SELECT_CMD.scoped(new_caret_id).notify_param(TextSelectOp::local_text_end());
+            }
         } else {
             let line_info = caret.info().rich_text_line_info();
             if !line_info.starts_new_line {
@@ -1624,6 +1632,7 @@ fn continue_rich_clear_line_start_end_inside_caret(is_end: bool, caret: &WidgetF
                         // prev's text start is the line start
                         new_caret_id = prev.info().id();
                         SELECT_CMD.scoped(new_caret_id).notify_param(TextSelectOp::local_text_start());
+                        break;
                     } else if info.ends_in_new_line {
                         // prev's last row start is the line start
                         new_caret_id = prev.info().id();
@@ -1638,6 +1647,7 @@ fn continue_rich_clear_line_start_end_inside_caret(is_end: bool, caret: &WidgetF
                                 line: last_i,
                             });
                         }));
+                        break;
                     }
                 }
             }

--- a/crates/zng-wgt-text/src/cmd.rs
+++ b/crates/zng-wgt-text/src/cmd.rs
@@ -1595,7 +1595,6 @@ fn continue_rich_clear_line_start_end_inside_caret(is_end: bool, caret: &WidgetF
             let mut found = false;
             for next in caret.info().rich_text_next() {
                 let info = next.info().rich_text_line_info();
-                println!("!!: {:?}", (next.info().id(), &info));
                 if info.starts_new_line {
                     // prev's text end is the line end
                     new_caret_id = prev.id();

--- a/crates/zng-wgt-text/src/cmd.rs
+++ b/crates/zng-wgt-text/src/cmd.rs
@@ -899,56 +899,56 @@ impl TextSelectOp {
     ///
     /// This is the `Up` key operation.
     pub fn line_up() -> Self {
-        Self::new(|| line_up_down(true, -1))
+        Self::new(|| rich_line_up_down(true, -1))
     }
 
     /// Extend or shrink selection by moving the caret to the nearest insert index on the previous line.
     ///
     /// This is the `SHIFT+Up` key operation.
     pub fn select_line_up() -> Self {
-        Self::new(|| line_up_down(false, -1))
+        Self::new(|| rich_line_up_down(false, -1))
     }
 
     /// Clear selection and move the caret to the nearest insert index on the next line.
     ///
     /// This is the `Down` key operation.
     pub fn line_down() -> Self {
-        Self::new(|| line_up_down(true, 1))
+        Self::new(|| rich_line_up_down(true, 1))
     }
 
     /// Extend or shrink selection by moving the caret to the nearest insert index on the next line.
     ///
     /// This is the `SHIFT+Down` key operation.
     pub fn select_line_down() -> Self {
-        Self::new(|| line_up_down(false, 1))
+        Self::new(|| rich_line_up_down(false, 1))
     }
 
     /// Clear selection and move the caret one viewport up.
     ///
     /// This is the `PageUp` key operation.
     pub fn page_up() -> Self {
-        Self::new(|| page_up_down(true, -1))
+        Self::new(|| rich_page_up_down(true, -1))
     }
 
     /// Extend or shrink selection by moving the caret one viewport up.
     ///
     /// This is the `SHIFT+PageUp` key operation.
     pub fn select_page_up() -> Self {
-        Self::new(|| page_up_down(false, -1))
+        Self::new(|| rich_page_up_down(false, -1))
     }
 
     /// Clear selection and move the caret one viewport down.
     ///
     /// This is the `PageDown` key operation.
     pub fn page_down() -> Self {
-        Self::new(|| page_up_down(true, 1))
+        Self::new(|| rich_page_up_down(true, 1))
     }
 
     /// Extend or shrink selection by moving the caret one viewport down.
     ///
     /// This is the `SHIFT+PageDown` key operation.
     pub fn select_page_down() -> Self {
-        Self::new(|| page_up_down(false, 1))
+        Self::new(|| rich_page_up_down(false, 1))
     }
 
     /// Clear selection and move the caret to the start of the line.
@@ -1012,7 +1012,7 @@ impl TextSelectOp {
     /// This is the mouse primary button down operation.
     pub fn nearest_to(window_point: DipPoint) -> Self {
         Self::new(move || {
-            nearest_to(true, window_point);
+            rich_nearest_to(true, window_point);
         })
     }
 
@@ -1021,7 +1021,7 @@ impl TextSelectOp {
     /// This is the mouse primary button down when holding SHIFT operation.
     pub fn select_nearest_to(window_point: DipPoint) -> Self {
         Self::new(move || {
-            nearest_to(false, window_point);
+            rich_nearest_to(false, window_point);
         })
     }
 
@@ -1030,7 +1030,7 @@ impl TextSelectOp {
     /// This is the touch selection caret drag operation.
     pub fn select_index_nearest_to(window_point: DipPoint, move_selection_index: bool) -> Self {
         Self::new(move || {
-            index_nearest_to(window_point, move_selection_index);
+            rich_index_nearest_to(window_point, move_selection_index);
         })
     }
 
@@ -1038,14 +1038,14 @@ impl TextSelectOp {
     ///
     /// This is the mouse primary button double click.
     pub fn select_word_nearest_to(replace_selection: bool, window_point: DipPoint) -> Self {
-        Self::new(move || select_line_word_nearest_to(replace_selection, true, window_point))
+        Self::new(move || rich_select_line_word_nearest_to(replace_selection, true, window_point))
     }
 
     /// Replace or extend selection with the line nearest to the `window_point`
     ///
     /// This is the mouse primary button triple click.
     pub fn select_line_nearest_to(replace_selection: bool, window_point: DipPoint) -> Self {
-        Self::new(move || select_line_word_nearest_to(replace_selection, false, window_point))
+        Self::new(move || rich_select_line_word_nearest_to(replace_selection, false, window_point))
     }
 
     /// Select the full text.
@@ -1257,99 +1257,99 @@ impl TextSelectOp {
 
     /// Like [`line_up`]  but stays within the same text widget, ignores rich text context.
     ///
-    /// [`line_up`]: Self::line_up !!:
+    /// [`line_up`]: Self::line_up
     pub fn local_line_up() -> Self {
-        Self::new(|| line_up_down(true, -1))
+        Self::new(|| local_line_up_down(true, -1))
     }
 
     /// Like [`select_line_up`]  but stays within the same text widget, ignores rich text context.
     ///
-    /// [`select_line_up`]: Self::select_line_up !!:
+    /// [`select_line_up`]: Self::select_line_up
     pub fn local_select_line_up() -> Self {
-        Self::new(|| line_up_down(false, -1))
+        Self::new(|| local_line_up_down(false, -1))
     }
 
     /// Like [`line_down`]  but stays within the same text widget, ignores rich text context.
     ///
-    /// [`line_down`]: Self::line_down !!:
+    /// [`line_down`]: Self::line_down
     pub fn local_line_down() -> Self {
-        Self::new(|| line_up_down(true, 1))
+        Self::new(|| local_line_up_down(true, 1))
     }
 
     /// Like [`select_line_down`]  but stays within the same text widget, ignores rich text context.
     ///
-    /// [`select_line_down`]: Self::select_line_down !!:
+    /// [`select_line_down`]: Self::select_line_down
     pub fn local_select_line_down() -> Self {
-        Self::new(|| line_up_down(false, 1))
+        Self::new(|| local_line_up_down(false, 1))
     }
 
     /// Like [`page_up`]  but stays within the same text widget, ignores rich text context.
     ///
-    /// [`page_up`]: Self::page_up !!:
+    /// [`page_up`]: Self::page_up
     pub fn local_page_up() -> Self {
-        Self::new(|| page_up_down(true, -1))
+        Self::new(|| local_page_up_down(true, -1))
     }
 
     /// Like [`select_page_up`]  but stays within the same text widget, ignores rich text context.
     ///
-    /// [`select_page_up`]: Self::select_page_up !!:
+    /// [`select_page_up`]: Self::select_page_up
     pub fn local_select_page_up() -> Self {
-        Self::new(|| page_up_down(false, -1))
+        Self::new(|| local_page_up_down(false, -1))
     }
 
     /// Like [`page_down`]  but stays within the same text widget, ignores rich text context.
     ///
-    /// [`page_down`]: Self::page_down !!:
+    /// [`page_down`]: Self::page_down
     pub fn local_page_down() -> Self {
-        Self::new(|| page_up_down(true, 1))
+        Self::new(|| local_page_up_down(true, 1))
     }
 
     /// Like [`select_page_down`]  but stays within the same text widget, ignores rich text context.
     ///
-    /// [`select_page_down`]: Self::select_page_down !!:
+    /// [`select_page_down`]: Self::select_page_down
     pub fn local_select_page_down() -> Self {
-        Self::new(|| page_up_down(false, 1))
+        Self::new(|| local_page_up_down(false, 1))
     }
 
     /// Like [`nearest_to`]  but stays within the same text widget, ignores rich text context.
     ///
-    /// [`nearest_to`]: Self::nearest_to !!:
+    /// [`nearest_to`]: Self::nearest_to
     pub fn local_nearest_to(window_point: DipPoint) -> Self {
         Self::new(move || {
-            nearest_to(true, window_point);
+            local_nearest_to(true, window_point);
         })
     }
 
     /// Like [`select_nearest_to`]  but stays within the same text widget, ignores rich text context.
     ///
-    /// [`select_nearest_to`]: Self::select_nearest_to !!:
+    /// [`select_nearest_to`]: Self::select_nearest_to
     pub fn local_select_nearest_to(window_point: DipPoint) -> Self {
         Self::new(move || {
-            nearest_to(false, window_point);
+            local_nearest_to(false, window_point);
         })
     }
 
     /// Like [`select_index_nearest_to`]  but stays within the same text widget, ignores rich text context.
     ///
-    /// [`select_index_nearest_to`]: Self::select_index_nearest_to !!:
+    /// [`select_index_nearest_to`]: Self::select_index_nearest_to
     pub fn local_select_index_nearest_to(window_point: DipPoint, move_selection_index: bool) -> Self {
         Self::new(move || {
-            index_nearest_to(window_point, move_selection_index);
+            local_index_nearest_to(window_point, move_selection_index);
         })
     }
 
-    /// Like [`word_nearest_to`]  but stays within the same text widget, ignores rich text context.
+    /// Like [`select_word_nearest_to`]  but stays within the same text widget, ignores rich text context.
     ///
-    /// [`word_nearest_to`]: Self::word_nearest_to !!:
-    pub fn local_word_nearest_to(replace_selection: bool, window_point: DipPoint) -> Self {
-        Self::new(move || select_line_word_nearest_to(replace_selection, true, window_point))
+    /// [`select_word_nearest_to`]: Self::select_word_nearest_to
+    pub fn local_select_word_nearest_to(replace_selection: bool, window_point: DipPoint) -> Self {
+        Self::new(move || local_select_line_word_nearest_to(replace_selection, true, window_point))
     }
 
-    /// Like [`line_nearest_to`]  but stays within the same text widget, ignores rich text context.
+    /// Like [`select_line_nearest_to`]  but stays within the same text widget, ignores rich text context.
     ///
-    /// [`line_nearest_to`]: Self::line_nearest_to !!:
-    pub fn local_line_nearest_to(replace_selection: bool, window_point: DipPoint) -> Self {
-        Self::new(move || select_line_word_nearest_to(replace_selection, false, window_point))
+    /// [`select_line_nearest_to`]: Self::select_line_nearest_to
+    pub fn local_select_line_nearest_to(replace_selection: bool, window_point: DipPoint) -> Self {
+        Self::new(move || local_select_line_word_nearest_to(replace_selection, false, window_point))
     }
 }
 
@@ -1572,7 +1572,14 @@ fn local_select_next_prev(is_next: bool, is_word: bool) -> bool {
     current_index == next_index || next_index == CaretIndex::ZERO && !is_next
 }
 
-fn line_up_down(clear_selection: bool, diff: i8) {
+fn rich_line_up_down(clear_selection: bool, diff: i8) {
+    if let Some(_ctx) = TEXT.try_rich() {
+        // !!: TODO
+    } else {
+        local_line_up_down(clear_selection, diff);
+    }
+}
+fn local_line_up_down(clear_selection: bool, diff: i8) {
     let diff = diff as isize;
 
     let mut caret = TEXT.resolve_caret();
@@ -1623,7 +1630,14 @@ fn line_up_down(clear_selection: bool, diff: i8) {
     }
 }
 
-fn page_up_down(clear_selection: bool, diff: i8) {
+fn rich_page_up_down(clear_selection: bool, diff: i8) {
+    if let Some(_ctx) = TEXT.try_rich() {
+        // !!: TODO
+    } else {
+        local_page_up_down(clear_selection, diff);
+    }
+}
+fn local_page_up_down(clear_selection: bool, diff: i8) {
     let diff = diff as i32;
 
     let mut caret = TEXT.resolve_caret();
@@ -2168,7 +2182,14 @@ fn local_select_text_start_end(is_end: bool) {
     ctx.used_retained_x = false;
 }
 
-fn nearest_to(clear_selection: bool, window_point: DipPoint) {
+fn rich_nearest_to(clear_selection: bool, window_point: DipPoint) {
+    if let Some(_ctx) = TEXT.try_rich() {
+        // !!: TODO
+    } else {
+        local_nearest_to(clear_selection, window_point);
+    }
+}
+fn local_nearest_to(clear_selection: bool, window_point: DipPoint) {
     let mut caret = TEXT.resolve_caret();
     let mut i = caret.index.unwrap_or(CaretIndex::ZERO);
 
@@ -2178,7 +2199,7 @@ fn nearest_to(clear_selection: bool, window_point: DipPoint) {
         caret.selection_index = Some(i);
     } else if let Some((_, is_word)) = caret.initial_selection.clone() {
         drop(caret);
-        return select_line_word_nearest_to(false, is_word, window_point);
+        return local_select_line_word_nearest_to(false, is_word, window_point);
     }
 
     caret.used_retained_x = false;
@@ -2219,7 +2240,14 @@ fn nearest_to(clear_selection: bool, window_point: DipPoint) {
     }
 }
 
-fn index_nearest_to(window_point: DipPoint, move_selection_index: bool) {
+fn rich_index_nearest_to(window_point: DipPoint, move_selection_index: bool) {
+    if let Some(_ctx) = TEXT.try_rich() {
+        // !!: TODO
+    } else {
+        local_index_nearest_to(window_point, move_selection_index);
+    }
+}
+fn local_index_nearest_to(window_point: DipPoint, move_selection_index: bool) {
     let mut caret = TEXT.resolve_caret();
 
     if caret.index.is_none() {
@@ -2265,7 +2293,14 @@ fn index_nearest_to(window_point: DipPoint, move_selection_index: bool) {
     }
 }
 
-fn select_line_word_nearest_to(replace_selection: bool, select_word: bool, window_point: DipPoint) {
+fn rich_select_line_word_nearest_to(replace_selection: bool, select_word: bool, window_point: DipPoint) {
+    if let Some(_ctx) = TEXT.try_rich() {
+        // !!: TODO
+    } else {
+        local_select_line_word_nearest_to(replace_selection, select_word, window_point);
+    }
+}
+fn local_select_line_word_nearest_to(replace_selection: bool, select_word: bool, window_point: DipPoint) {
     let mut caret = TEXT.resolve_caret();
 
     //if there was at least one laidout

--- a/crates/zng-wgt-text/src/cmd.rs
+++ b/crates/zng-wgt-text/src/cmd.rs
@@ -787,7 +787,7 @@ impl RedoAction for UndoTextEditOp {
     }
 }
 
-/// Represents a text selection operation that can be send to an editable text using [`SELECT_CMD`].
+/// Represents a text caret/selection operation that can be send to an editable text using [`SELECT_CMD`].
 #[derive(Clone)]
 pub struct TextSelectOp {
     op: Arc<Mutex<dyn FnMut() + Send>>,
@@ -801,11 +801,11 @@ impl TextSelectOp {
     /// New text select operation.
     ///
     /// The editable text widget that handles [`SELECT_CMD`] will call `op` during event handling in
-    /// the [`node::layout_text`] context. You can position the caret using [`ResolvedText::caret`],
+    /// the [`node::layout_text`] context. You can position the caret using [`TEXT.resolve_caret`],
     /// the text widget will detect changes to it and react accordingly (updating caret position and animation),
     /// the caret index is also snapped to the nearest grapheme start.
     ///
-    /// [`ResolvedText::caret`]: super::node::ResolvedText::caret
+    /// [`TEXT.resolve_caret`]: super::node::TEXT::resolve_caret
     pub fn new(op: impl FnMut() + Send + 'static) -> Self {
         Self {
             op: Arc::new(Mutex::new(op)),
@@ -1069,6 +1069,12 @@ fn next_prev(
     }
     c.set_index(next_index);
     c.used_retained_x = false;
+
+    if current_index == next_index {
+        if let Some(ctx) = TEXT.try_rich() {
+            println!("!!: TODO try to navigate to next")
+        }
+    }
 }
 
 fn line_up_down(clear_selection: bool, diff: i8) {

--- a/crates/zng-wgt-text/src/cmd.rs
+++ b/crates/zng-wgt-text/src/cmd.rs
@@ -1137,7 +1137,7 @@ impl TextSelectOp {
     ///
     /// This is the `CTRL+Home` shortcut operation.
     pub fn text_start() -> Self {
-        Self::new(|| text_start_end(true, |_| 0, Some(|w| w.rich_text_leafs().next()), Self::local_text_start))
+        Self::new(|| text_start_end(true, |_| 0, Some(|w| w.rich_text_leaves().next()), Self::local_text_start))
     }
     /// Like [`text_start`] but stays within the same text widget, ignores rich text context.
     ///
@@ -1151,7 +1151,7 @@ impl TextSelectOp {
     /// This is the `CTRL+SHIFT+Home` shortcut operation.
     pub fn select_text_start() -> Self {
         // !!: TODO
-        Self::new(|| text_start_end(false, |_| 0, Some(|w| w.rich_text_leafs().next()), Self::local_select_text_start))
+        Self::new(|| text_start_end(false, |_| 0, Some(|w| w.rich_text_leaves().next()), Self::local_select_text_start))
     }
     /// Like [`select_text_start`] but stays within the same text widget, ignores rich text context.
     ///
@@ -1164,7 +1164,7 @@ impl TextSelectOp {
     ///
     /// This is the `CTRL+End` shortcut operation.
     pub fn text_end() -> Self {
-        Self::new(|| text_start_end(true, |s| s.len(), Some(|w| w.rich_text_leafs_rev().next()), Self::local_text_end))
+        Self::new(|| text_start_end(true, |s| s.len(), Some(|w| w.rich_text_leaves_rev().next()), Self::local_text_end))
     }
     /// Like [`text_end`] but stays within the same text widget, ignores rich text context.
     ///
@@ -1182,7 +1182,7 @@ impl TextSelectOp {
             text_start_end(
                 false,
                 |s| s.len(),
-                Some(|w| w.rich_text_leafs_rev().next()),
+                Some(|w| w.rich_text_leaves_rev().next()),
                 Self::local_select_text_end,
             )
         })
@@ -1241,7 +1241,7 @@ impl TextSelectOp {
             if let Some(ctx) = TEXT.try_rich() {
                 if let Some(info) = ctx.root_info() {
                     let mut last_id = None;
-                    for leaf in info.rich_text_leafs() {
+                    for leaf in info.rich_text_leaves() {
                         let leaf_id = leaf.info().id();
                         SELECT_CMD.scoped(leaf_id).notify_param(Self::local_select_all());
                         last_id = Some(leaf_id);
@@ -1312,9 +1312,10 @@ fn next_prev(
     c.used_retained_x = false;
 
     if current_index == next_index || next_index == CaretIndex::ZERO {
-        // !!: TODO prev_word to next_index=0 causes jump to start
         if let Some(widget_from_current) = widget_from_current {
             if let Some(_ctx) = TEXT.try_rich() {
+                // prev/next widget
+
                 let info = WIDGET.info();
                 if matches!(info.rich_text_component(), Some(RichTextComponent::Leaf { .. })) {
                     if let Some(next) = widget_from_current(info) {

--- a/crates/zng-wgt-text/src/lib.rs
+++ b/crates/zng-wgt-text/src/lib.rs
@@ -223,7 +223,10 @@ impl Text {
             } else {
                 wgt.capture_var_or_default(property_id!(Self::txt))
             };
-            wgt.push_intrinsic(NestGroup::EVENT, "resolve_text", |child| node::resolve_text(child, text));
+            wgt.push_intrinsic(NestGroup::EVENT, "resolve_text", |child| {
+                let child = node::rich_text_component(child);
+                node::resolve_text(child, text)
+            });
         });
     }
 }

--- a/crates/zng-wgt-text/src/lib.rs
+++ b/crates/zng-wgt-text/src/lib.rs
@@ -224,7 +224,7 @@ impl Text {
                 wgt.capture_var_or_default(property_id!(Self::txt))
             };
             wgt.push_intrinsic(NestGroup::EVENT, "resolve_text", |child| {
-                let child = node::rich_text_component(child);
+                let child = node::rich_text_component(child, "text");
                 node::resolve_text(child, text)
             });
         });

--- a/crates/zng-wgt-text/src/node.rs
+++ b/crates/zng-wgt-text/src/node.rs
@@ -47,7 +47,7 @@ pub struct RichCaretInfo {
     pub index: Option<WidgetId>,
     /// Widget that defines the selection second index.
     ///
-    /// Inside the widget the [`CaretInfo::selection_Index`] defines the actual index.
+    /// Inside the widget the [`CaretInfo::selection_index`] defines the actual index.
     pub selection_index: Option<WidgetId>,
 }
 

--- a/crates/zng-wgt-text/src/node.rs
+++ b/crates/zng-wgt-text/src/node.rs
@@ -280,6 +280,14 @@ impl TEXT {
         RwLockWriteGuardOwned::map(RICH_TEXT.write(), |ctx| &mut ctx.caret)
     }
 
+    /// Set the `caret_retained_x` value.
+    ///
+    /// Note that the value is already updated automatically on caret layout, this method is for rich text operations
+    /// to propagate the line position between widgets.
+    pub fn set_caret_retained_x(&self, x: Px) {
+        self.layout().caret_retained_x = x;
+    }
+
     pub(crate) fn resolve(&self) -> RwLockWriteGuardOwned<ResolvedText> {
         RESOLVED_TEXT.write()
     }

--- a/crates/zng-wgt-text/src/node.rs
+++ b/crates/zng-wgt-text/src/node.rs
@@ -441,12 +441,12 @@ impl LaidoutText {
     }
 }
 
-/// Represents the parent rich text context.
+/// Represents the rich text context.
 ///
 /// Use [`TEXT`] to get.
 pub struct RichText {
     /// Widget that defines the rich text context.
-    pub parent: WidgetId,
+    pub root_id: WidgetId,
 }
 impl RichText {
     fn no_context() -> Self {

--- a/crates/zng-wgt-text/src/node/layout.rs
+++ b/crates/zng-wgt-text/src/node/layout.rs
@@ -1035,7 +1035,7 @@ fn layout_text_edit_events(update: &EventUpdate, edit: &mut LayoutTextEdit) {
                     }
                 }
                 Key::ArrowUp => {
-                    if ACCEPTS_ENTER_VAR.get() || TEXT.laidout().shaped_text.lines_len() > 1 {
+                    if ACCEPTS_ENTER_VAR.get() || TEXT.laidout().shaped_text.lines_len() > 1 || TEXT.try_rich().is_some() {
                         let mut modifiers = args.modifiers;
                         let select = selectable && modifiers.take_shift();
                         if modifiers.is_empty() && (editable || select) {
@@ -1053,7 +1053,7 @@ fn layout_text_edit_events(update: &EventUpdate, edit: &mut LayoutTextEdit) {
                     }
                 }
                 Key::ArrowDown => {
-                    if ACCEPTS_ENTER_VAR.get() || TEXT.laidout().shaped_text.lines_len() > 1 {
+                    if ACCEPTS_ENTER_VAR.get() || TEXT.laidout().shaped_text.lines_len() > 1 || TEXT.try_rich().is_some() {
                         let mut modifiers = args.modifiers;
                         let select = selectable && modifiers.take_shift();
                         if modifiers.is_empty() && (editable || select) {
@@ -1071,7 +1071,7 @@ fn layout_text_edit_events(update: &EventUpdate, edit: &mut LayoutTextEdit) {
                     }
                 }
                 Key::PageUp => {
-                    if ACCEPTS_ENTER_VAR.get() || TEXT.laidout().shaped_text.lines_len() > 1 {
+                    if ACCEPTS_ENTER_VAR.get() || TEXT.laidout().shaped_text.lines_len() > 1 || TEXT.try_rich().is_some() {
                         let mut modifiers = args.modifiers;
                         let select = selectable && modifiers.take_shift();
                         if modifiers.is_empty() && (editable || select) {
@@ -1089,7 +1089,7 @@ fn layout_text_edit_events(update: &EventUpdate, edit: &mut LayoutTextEdit) {
                     }
                 }
                 Key::PageDown => {
-                    if ACCEPTS_ENTER_VAR.get() || TEXT.laidout().shaped_text.lines_len() > 1 {
+                    if ACCEPTS_ENTER_VAR.get() || TEXT.laidout().shaped_text.lines_len() > 1 || TEXT.try_rich().is_some() {
                         let mut modifiers = args.modifiers;
                         let select = selectable && modifiers.take_shift();
                         if modifiers.is_empty() && (editable || select) {

--- a/crates/zng-wgt-text/src/node/layout.rs
+++ b/crates/zng-wgt-text/src/node/layout.rs
@@ -1152,6 +1152,14 @@ fn layout_text_edit_events(update: &EventUpdate, edit: &mut LayoutTextEdit) {
                         .call();
                     }
                 }
+                Key::Escape => {
+                    if args.modifiers.is_empty() && (editable || selectable) {
+                        args.propagation().stop();
+                        TEXT.resolve().selection_by = SelectionBy::Keyboard;
+
+                        TextSelectOp::clear_selection().call();
+                    }
+                }
                 _ => {}
             }
         }

--- a/crates/zng-wgt-text/src/node/layout.rs
+++ b/crates/zng-wgt-text/src/node/layout.rs
@@ -1302,7 +1302,6 @@ fn layout_text_edit_events(update: &EventUpdate, edit: &mut LayoutTextEdit) {
         if let Some(args) = SELECT_CMD.scoped(widget.id()).on_unhandled(update) {
             if let Some(op) = args.param::<TextSelectOp>() {
                 args.propagation().stop();
-
                 op.clone().call();
             }
         } else if let Some(args) = SELECT_ALL_CMD.scoped(widget.id()).on_unhandled(update) {

--- a/crates/zng-wgt-text/src/node/layout.rs
+++ b/crates/zng-wgt-text/src/node/layout.rs
@@ -1239,7 +1239,11 @@ fn layout_text_edit_events(update: &EventUpdate, edit: &mut LayoutTextEdit) {
                     let id = widget.id();
                     edit.selection_move_handles.push(MOUSE_MOVE_EVENT.subscribe(id));
                     edit.selection_move_handles.push(POINTER_CAPTURE_EVENT.subscribe(id));
-                    POINTER_CAPTURE.capture_widget(id);
+                    if let Some(ctx) = TEXT.try_rich() {
+                        POINTER_CAPTURE.capture_subtree(ctx.root_id);
+                    } else {
+                        POINTER_CAPTURE.capture_widget(id);
+                    }
                 }
             }
         } else {

--- a/crates/zng-wgt-text/src/node/render.rs
+++ b/crates/zng-wgt-text/src/node/render.rs
@@ -177,7 +177,7 @@ pub fn render_selection(child: impl UiNode) -> impl UiNode {
         }
         UiNodeOp::Event { update } => {
             if let Some(args) = FOCUS_CHANGED_EVENT.on(update) {
-                let new_is_focused = args.is_focus_within(WIDGET.id());
+                let new_is_focused = args.is_focus_within(TEXT.try_rich().map(|r| r.root_id).unwrap_or_else(|| WIDGET.id()));
                 if is_focused != new_is_focused {
                     WIDGET.render();
                     is_focused = new_is_focused;

--- a/crates/zng-wgt-text/src/node/resolve.rs
+++ b/crates/zng-wgt-text/src/node/resolve.rs
@@ -33,7 +33,7 @@ use crate::{
     cmd::{EDIT_CMD, SELECT_ALL_CMD, SELECT_CMD, TextEditOp, TextSelectOp, UndoTextEditOp},
 };
 
-use super::{CaretInfo, ImePreview, PendingLayout, RESOLVED_TEXT, ResolvedText, SelectionBy, TEXT};
+use super::{CaretInfo, ImePreview, PendingLayout, RESOLVED_TEXT, ResolvedText, RichTextCopyParam, SelectionBy, TEXT};
 
 /// An UI node that resolves the text context vars, applies the text transform and white space correction and segments the `text`.
 ///
@@ -698,7 +698,12 @@ fn resolve_text_edit_or_select_events(update: &EventUpdate, _: &mut ResolveTextE
         let ctx = TEXT.resolved();
         if let Some(range) = ctx.caret.selection_char_range() {
             args.propagation().stop();
-            let _ = CLIPBOARD.set_text(Txt::from_str(&ctx.segmented_text.text()[range]));
+            let txt = Txt::from_str(&ctx.segmented_text.text()[range]);
+            if let Some(rt) = args.param::<RichTextCopyParam>() {
+                rt.set_text(txt);
+            } else {
+                let _ = CLIPBOARD.set_text(txt);
+            }
         }
     } else if let Some(args) = ACCESS_SELECTION_EVENT.on_unhandled(update) {
         if args.start.0 == widget_id && args.caret.0 == widget_id {

--- a/crates/zng-wgt-text/src/node/rich.rs
+++ b/crates/zng-wgt-text/src/node/rich.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 use zng_app::widget::node::Z_INDEX;
-use zng_ext_input::focus::{WidgetFocusInfo, WidgetInfoFocusExt, FOCUS_CHANGED_EVENT};
+use zng_ext_input::focus::{FOCUS_CHANGED_EVENT, WidgetFocusInfo, WidgetInfoFocusExt};
 use zng_ext_window::WINDOWS;
 use zng_wgt::prelude::*;
 
 use crate::RICH_TEXT_FOCUSED_Z_VAR;
 
-use super::{RichCaretInfo, RichText, RICH_TEXT, TEXT};
+use super::{RICH_TEXT, RichCaretInfo, RichText, TEXT};
 
 pub(crate) fn rich_text_node(child: impl UiNode, enabled: impl IntoVar<bool>) -> impl UiNode {
     let enabled = enabled.into_var();
@@ -299,7 +299,7 @@ fn rich_text_selection_static(wgt: &WidgetInfo, a: WidgetId, b: WidgetId) -> imp
     }
 
     let (skip, take) = if ai != usize::MAX && bi != usize::MAX {
-        (ai, bi - ai)
+        (ai, bi - ai + 1)
     } else {
         (0, 0)
     };
@@ -330,7 +330,7 @@ fn rich_text_selection_rev_static(wgt: &WidgetInfo, a: WidgetId, b: WidgetId) ->
     }
 
     let (skip, take) = if ai != usize::MAX && bi != usize::MAX {
-        (ai, bi - ai)
+        (ai, bi - ai + 1)
     } else {
         (0, 0)
     };

--- a/crates/zng-wgt-text/src/node/rich.rs
+++ b/crates/zng-wgt-text/src/node/rich.rs
@@ -2,23 +2,24 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 use zng_app::widget::node::Z_INDEX;
-use zng_ext_input::focus::FOCUS_CHANGED_EVENT;
+use zng_ext_input::focus::{FOCUS_CHANGED_EVENT, WidgetFocusInfo, WidgetInfoFocusExt};
+use zng_ext_window::WINDOWS;
 use zng_wgt::prelude::*;
 
 use crate::RICH_TEXT_FOCUSED_Z_VAR;
 
-use super::{RichText, RICH_TEXT, TEXT};
+use super::{RICH_TEXT, RichText, TEXT};
 
 pub(crate) fn rich_text_node(child: impl UiNode, enabled: impl IntoVar<bool>) -> impl UiNode {
     let enabled = enabled.into_var();
-    let child = rich_text_component(child);
+    let child = rich_text_component(child, "rich_text");
 
     let mut ctx = None;
     match_node(child, move |child, op| match op {
         UiNodeOp::Init => {
             WIDGET.sub_var(&enabled);
             if enabled.get() && TEXT.try_rich().is_none() {
-                ctx = Some(Arc::new(RwLock::new(RichText { parent: WIDGET.id() })));
+                ctx = Some(Arc::new(RwLock::new(RichText { root_id: WIDGET.id() })));
 
                 RICH_TEXT.with_context(&mut ctx, || child.init());
             }
@@ -48,7 +49,11 @@ pub(crate) fn rich_text_node(child: impl UiNode, enabled: impl IntoVar<bool>) ->
 ///
 /// This node is intrinsic to the `Text!` widget and is part of the `rich_text` property. Note that the
 /// actual rich text editing is implemented by the `resolve_text` and `layout_text` nodes that are intrinsic to `Text!`.
-pub fn rich_text_component(child: impl UiNode) -> impl UiNode {
+///
+/// The `kind` identifies what kind of component, the value `"rich_text"` is used by the `rich_text` property, the value `"text"`
+/// is used by the `Text!` widget, any other value defines a [`RichTextComponent::Leaf`] that is expected to be focusable, inlined
+/// and able to handle rich text composition requests.
+pub fn rich_text_component(child: impl UiNode, kind: &'static str) -> impl UiNode {
     let mut focus_within = false;
     let mut prev_index = ZIndex::DEFAULT;
     let mut index_update = None;
@@ -63,6 +68,21 @@ pub fn rich_text_component(child: impl UiNode) -> impl UiNode {
         }
         UiNodeOp::Deinit => {
             focus_within = false;
+        }
+        UiNodeOp::Info { info } => {
+            if let Some(r) = TEXT.try_rich() {
+                let c = match kind {
+                    "rich_text" => {
+                        if r.root_id == WIDGET.id() {
+                            RichTextComponent::Root
+                        } else {
+                            RichTextComponent::Branch
+                        }
+                    }
+                    kind => RichTextComponent::Leaf { kind },
+                };
+                info.set_meta(*RICH_TEXT_COMPONENT_ID, c);
+            }
         }
         UiNodeOp::Event { update } => {
             if let Some(args) = FOCUS_CHANGED_EVENT.on(update) {
@@ -98,4 +118,91 @@ pub fn rich_text_component(child: impl UiNode) -> impl UiNode {
         }
         _ => {}
     })
+}
+
+impl RichText {
+    /// Get root widget info.
+    ///
+    /// See also [`RichTextWidgetInfoExt`] to query the
+    pub fn root_info(&self) -> Option<WidgetInfo> {
+        WINDOWS.widget_info(self.root_id)
+    }
+}
+
+/// Extends [`WidgetInfo`] state to provide information about rich text.
+pub trait RichTextWidgetInfoExt {
+    /// Gets the outer most ancestor that defines the rich text root.
+    fn rich_text_root(&self) -> Option<WidgetInfo>;
+
+    /// Gets what kind of component of the rich text tree this widget is.
+    fn rich_text_component(&self) -> Option<RichTextComponent>;
+
+    /// Iterate over the text/leaf component descendants that can be interacted with.
+    fn rich_text_leafs(&self) -> impl Iterator<Item = WidgetFocusInfo>;
+    /// Iterate over the text/leaf component descendants that can be interacted with, in reverse.
+    fn rich_text_leafs_rev(&self) -> impl Iterator<Item = WidgetFocusInfo>;
+
+    /// Iterate over the prev text/leaf components before the current one.
+    fn rich_text_prev(&self) -> impl Iterator<Item = WidgetFocusInfo>;
+
+    /// Iterate over the next text/leaf components after the current one.
+    fn rich_text_next(&self) -> impl Iterator<Item = WidgetFocusInfo>;
+}
+impl RichTextWidgetInfoExt for WidgetInfo {
+    fn rich_text_root(&self) -> Option<WidgetInfo> {
+        self.self_and_ancestors()
+            .find(|w| matches!(w.rich_text_component(), Some(RichTextComponent::Root)))
+    }
+
+    fn rich_text_component(&self) -> Option<RichTextComponent> {
+        self.meta().copy(*RICH_TEXT_COMPONENT_ID)
+    }
+
+    fn rich_text_leafs(&self) -> impl Iterator<Item = WidgetFocusInfo> {
+        self.descendants()
+            .filter(|w| matches!(w.rich_text_component(), Some(RichTextComponent::Leaf { .. })))
+            .filter_map(|w| w.into_focusable(false, false))
+    }
+    fn rich_text_leafs_rev(&self) -> impl Iterator<Item = WidgetFocusInfo> {
+        self.descendants()
+            .tree_rev()
+            .filter(|w| matches!(w.rich_text_component(), Some(RichTextComponent::Leaf { .. })))
+            .filter_map(|w| w.into_focusable(false, false))
+    }
+
+    fn rich_text_prev(&self) -> impl Iterator<Item = WidgetFocusInfo> {
+        self.rich_text_root()
+            .into_iter()
+            .flat_map(|w| self.prev_siblings_in(&w))
+            .filter(|w| matches!(w.rich_text_component(), Some(RichTextComponent::Leaf { .. })))
+            .filter_map(|w| w.into_focusable(false, false))
+    }
+
+    fn rich_text_next(&self) -> impl Iterator<Item = WidgetFocusInfo> {
+        self.rich_text_root()
+            .into_iter()
+            .flat_map(|w| self.next_siblings_in(&w))
+            .filter(|w| matches!(w.rich_text_component(), Some(RichTextComponent::Leaf { .. })))
+            .filter_map(|w| w.into_focusable(false, false))
+    }
+}
+
+/// Represents what kind of component the widget is in a rich text tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RichTextComponent {
+    /// Outermost widget that is `rich_text` enabled.
+    Root,
+    /// Widget is `rich_text` enabled, but is inside another rich text tree.
+    Branch,
+    /// Widget is a text or custom component of the rich text.
+    Leaf {
+        /// Arbitrary identifier.
+        ///
+        /// Is `"text"` for `Text!` widgets.
+        kind: &'static str,
+    },
+}
+
+static_id! {
+    static ref RICH_TEXT_COMPONENT_ID: StateId<RichTextComponent>;
 }

--- a/crates/zng-wgt-text/src/node/rich.rs
+++ b/crates/zng-wgt-text/src/node/rich.rs
@@ -208,6 +208,9 @@ impl RichCaretInfo {
     /// # Panics
     ///
     /// Panics if `new_index` or `new_selection_index` is not inside the same rich text context.
+    ///
+    /// [`CaretInfo::index`]: crate::node::CaretInfo::index
+    /// [`CaretInfo::selection_index`]: crate::node::CaretInfo::selection_index
     pub fn update_selection(
         &mut self,
         new_index: &WidgetInfo,

--- a/crates/zng-wgt-text/src/node/rich.rs
+++ b/crates/zng-wgt-text/src/node/rich.rs
@@ -344,7 +344,8 @@ fn rich_text_selection_static(wgt: &WidgetInfo, a: WidgetId, b: WidgetId) -> imp
         let id = leaf.info().id();
         if id == a {
             ai = i;
-        } else if id == b {
+        }
+        if id == b {
             bi = i;
         }
         if ai != usize::MAX && bi != usize::MAX {

--- a/crates/zng-wgt-text/src/node/rich.rs
+++ b/crates/zng-wgt-text/src/node/rich.rs
@@ -169,6 +169,29 @@ impl RichText {
             known_len_iter: root.into_iter().flat_map(move |w| rich_text_selection_rev_static(&w, a, b)),
         }
     }
+
+    /// Gets the `caret.index` widget info if it is set and is a valid leaf.
+    pub fn caret_index_info(&self) -> Option<WidgetFocusInfo> {
+        self.leaf_info(self.caret.index?)
+    }
+
+    /// Gets the `caret.selection_index` widget info if it is set and is a valid leaf.
+    pub fn caret_selection_index_info(&self) -> Option<WidgetFocusInfo> {
+        self.leaf_info(self.caret.selection_index?)
+    }
+
+    /// Gets the `id` widget info if it is a valid leaf in the rich text context.
+    pub fn leaf_info(&self, id: WidgetId) -> Option<WidgetFocusInfo> {
+        let root = self.root_info()?;
+        let wgt = root.tree().get(id)?;
+        if !matches!(wgt.rich_text_component(), Some(RichTextComponent::Leaf { .. })) {
+            return None;
+        }
+        if !wgt.is_descendant(&root) {
+            return None;
+        }
+        wgt.into_focusable(false, false)
+    }
 }
 
 /// Extends [`WidgetInfo`] state to provide information about rich text.

--- a/crates/zng-wgt-text/src/node/rich.rs
+++ b/crates/zng-wgt-text/src/node/rich.rs
@@ -336,7 +336,12 @@ impl RichCaretInfo {
                         let is_new = inclusive_range_contains(new_a, new_b, wgt, &root);
 
                         match (is_old, is_new) {
-                            (true, true) => {}
+                            (true, true) => {
+                                if wgt == old_a || wgt == old_b {
+                                    // was endpoint now is full selection
+                                    SELECT_CMD.scoped(wgt.id()).notify_param(TextSelectOp::local_select_all())
+                                }
+                            }
                             (true, false) => {
                                 SELECT_CMD.scoped(wgt.id()).notify_param(TextSelectOp::local_clear_selection());
                             }

--- a/crates/zng-wgt-text/src/node/rich.rs
+++ b/crates/zng-wgt-text/src/node/rich.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use zng_app::widget::node::Z_INDEX;
+use zng_ext_input::focus::FOCUS_CHANGED_EVENT;
+use zng_wgt::prelude::*;
+
+use crate::RICH_TEXT_FOCUSED_Z_VAR;
+
+use super::{RichText, RICH_TEXT, TEXT};
+
+pub(crate) fn rich_text_node(child: impl UiNode, enabled: impl IntoVar<bool>) -> impl UiNode {
+    let enabled = enabled.into_var();
+    let child = rich_text_component(child);
+
+    let mut ctx = None;
+    match_node(child, move |child, op| match op {
+        UiNodeOp::Init => {
+            WIDGET.sub_var(&enabled);
+            if enabled.get() && TEXT.try_rich().is_none() {
+                ctx = Some(Arc::new(RwLock::new(RichText { parent: WIDGET.id() })));
+
+                RICH_TEXT.with_context(&mut ctx, || child.init());
+            }
+        }
+        UiNodeOp::Update { updates } => {
+            if enabled.is_new() {
+                WIDGET.reinit();
+            } else if ctx.is_some() {
+                RICH_TEXT.with_context(&mut ctx, || child.update(updates));
+            }
+        }
+        UiNodeOp::Deinit => {
+            if ctx.is_some() {
+                RICH_TEXT.with_context(&mut ctx, || child.deinit());
+                ctx = None;
+            }
+        }
+        op => {
+            if ctx.is_some() {
+                RICH_TEXT.with_context(&mut ctx, || child.op(op));
+            }
+        }
+    })
+}
+
+/// An UI node that implements some behavior for rich text composition.
+///
+/// This node is intrinsic to the `Text!` widget and is part of the `rich_text` property. Note that the
+/// actual rich text editing is implemented by the `resolve_text` and `layout_text` nodes that are intrinsic to `Text!`.
+pub fn rich_text_component(child: impl UiNode) -> impl UiNode {
+    let mut focus_within = false;
+    let mut prev_index = ZIndex::DEFAULT;
+    let mut index_update = None;
+    match_node(child, move |c, op| match op {
+        UiNodeOp::Init => {
+            c.init();
+
+            if TEXT.try_rich().is_some() {
+                WIDGET.sub_event(&FOCUS_CHANGED_EVENT).sub_var(&RICH_TEXT_FOCUSED_Z_VAR);
+                prev_index = Z_INDEX.get();
+            }
+        }
+        UiNodeOp::Deinit => {
+            focus_within = false;
+        }
+        UiNodeOp::Event { update } => {
+            if let Some(args) = FOCUS_CHANGED_EVENT.on(update) {
+                let new_is_focus_within = args.is_focus_within(WIDGET.id());
+                if focus_within != new_is_focus_within {
+                    focus_within = new_is_focus_within;
+
+                    if TEXT.try_rich().is_some() {
+                        index_update = Some(focus_within);
+                        WIDGET.update(); // Z_INDEX.set only works on update
+                    }
+                }
+            }
+        }
+        UiNodeOp::Update { updates } => {
+            c.update(updates);
+
+            if let Some(apply) = index_update.take() {
+                if apply {
+                    prev_index = Z_INDEX.get();
+                    if let Some(i) = RICH_TEXT_FOCUSED_Z_VAR.get() {
+                        Z_INDEX.set(i);
+                    }
+                } else if RICH_TEXT_FOCUSED_Z_VAR.get().is_some() {
+                    Z_INDEX.set(prev_index);
+                }
+            }
+            if let Some(idx) = RICH_TEXT_FOCUSED_Z_VAR.get_new() {
+                if focus_within {
+                    Z_INDEX.set(idx.unwrap_or(prev_index));
+                }
+            }
+        }
+        _ => {}
+    })
+}

--- a/crates/zng-wgt-text/src/node/rich.rs
+++ b/crates/zng-wgt-text/src/node/rich.rs
@@ -270,23 +270,26 @@ impl RichTextWidgetInfoExt for WidgetInfo {
         let (prev_min, prev_max) = match self.rich_text_prev().next() {
             Some(p) => {
                 let bounds = p.info().bounds_info();
+                let inner_bounds = bounds.inner_bounds();
                 if let Some(inline) = bounds.inline() {
-                    (inline.rows[0].min_y(), inline.rows[0].max_y())
+                    let mut last = inline.rows[inline.rows.len() - 1];
+                    last.origin += inner_bounds.origin.to_vector();
+                    (last.min_y(), last.max_y())
                 } else {
-                    let b = bounds.inner_bounds();
-                    (b.min_y(), b.max_y())
+                    (inner_bounds.min_y(), inner_bounds.max_y())
                 }
             }
             None => (Px::MIN, Px::MIN),
         };
 
         let bounds = self.bounds_info();
+        let inner_bounds = bounds.inner_bounds();
         let (min, max, wraps) = if let Some(inline) = bounds.inline() {
-            let last = &inline.rows[inline.rows.len() - 1];
-            (last.min_y(), last.max_y(), inline.rows.len() > 1)
+            let mut first = inline.rows[0];
+            first.origin += inner_bounds.origin.to_vector();
+            (first.min_y(), first.max_y(), inline.rows.len() > 1)
         } else {
-            let b = bounds.inner_bounds();
-            (b.min_y(), b.max_y(), false)
+            (inner_bounds.min_y(), inner_bounds.max_y(), false)
         };
 
         let starts = !lines_overlap_strict(prev_min, prev_max, min, max);

--- a/crates/zng-wgt-text/src/text_properties.rs
+++ b/crates/zng-wgt-text/src/text_properties.rs
@@ -1517,9 +1517,11 @@ pub fn change_stop_delay(child: impl UiNode, delay: impl IntoVar<Duration>) -> i
     with_context_var(child, CHANGE_STOP_DELAY_VAR, delay)
 }
 
-/// Auto-selection on focus when the text is selectable.
+/// Auto-selection on focus change when the text is selectable.
 ///
 /// If enabled on keyboard focus all text is selected and on blur any selection is cleared.
+///
+/// In rich text contexts applies to all sub-component texts.
 #[property(CONTEXT, default(AUTO_SELECTION_VAR), widget_impl(TextEditMix<P>))]
 pub fn auto_selection(child: impl UiNode, mode: impl IntoVar<AutoSelection>) -> impl UiNode {
     with_context_var(child, AUTO_SELECTION_VAR, mode)
@@ -1551,7 +1553,9 @@ pub fn obscure_txt(child: impl UiNode, enabled: impl IntoVar<bool>) -> impl UiNo
 }
 
 bitflags! {
-    /// Defines when text is auto-selected on focus.
+    /// Defines when text is auto-selected on focus change.
+    ///
+    /// In a rich text context applies across all sub component texts.
     #[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
     pub struct AutoSelection: u8 {
         /// No auto-selection.
@@ -1561,12 +1565,12 @@ bitflags! {
         /// This is the default behavior.
         const CLEAR_ON_BLUR = 0b0000_0001;
         /// Select all on keyboard initiated focus.
-        const ALL_ON_FOCUS_KEYBOARD = 0b0000_00010;
+        const ALL_ON_FOCUS_KEYBOARD = 0b0000_0010;
         /// Select all on pointer release if the pointer press event caused the focus to happen and it did not change
         /// the selection and there is no selection on release.
-        const ALL_ON_FOCUS_POINTER = 0b0000_00100;
+        const ALL_ON_FOCUS_POINTER = 0b0000_0100;
         /// All auto-selection features enabled.
-        const ENABLED = 0b1111_1111;
+        const ENABLED = 0b0000_0111;
     }
 }
 impl_from_and_into_var! {

--- a/crates/zng-wgt-text/src/text_properties.rs
+++ b/crates/zng-wgt-text/src/text_properties.rs
@@ -1934,7 +1934,7 @@ pub fn get_font_use(child: impl UiNode, font_use: impl IntoVar<Vec<(Font, std::o
 }
 
 /// Rich text properties.
-/// 
+///
 /// Note that these properties are usually set in parent panels of text widgets.
 #[widget_mixin]
 pub struct RichTextMix<P>(P);
@@ -1965,10 +1965,10 @@ pub fn rich_text(child: impl UiNode, enabled: impl IntoVar<bool>) -> impl UiNode
 }
 
 /// Defines the Z-index set on inner text (and nested rich text) widgets when focus is within.
-/// 
+///
 /// Is [`ZIndex::FRONT`] by default, so that the caret visual is not clipped when the insert point is at
-/// an edge between texts. Set to `None` to not change the Z-index on focus. 
-/// 
+/// an edge between texts. Set to `None` to not change the Z-index on focus.
+///
 /// Sets the [`RICH_TEXT_FOCUSED_Z_VAR`].
 #[property(CONTEXT, default(RICH_TEXT_FOCUSED_Z_VAR), widget_impl(RichTextMix<P>))]
 pub fn rich_text_focused_z(child: impl UiNode, z_index: impl IntoVar<Option<ZIndex>>) -> impl UiNode {

--- a/crates/zng-wgt-text/src/text_properties.rs
+++ b/crates/zng-wgt-text/src/text_properties.rs
@@ -1932,3 +1932,45 @@ pub fn get_font_use(child: impl UiNode, font_use: impl IntoVar<Vec<(Font, std::o
         }
     })
 }
+
+/// Rich text properties.
+/// 
+/// Note that these properties are usually set in parent panels of text widgets.
+#[widget_mixin]
+pub struct RichTextMix<P>(P);
+
+context_var! {
+    /// Selection toolbar function.
+    pub static RICH_TEXT_FOCUSED_Z_VAR: Option<ZIndex> = ZIndex::FRONT;
+}
+
+impl RichTextMix<()> {
+    /// Insert context variables used by properties in this mix-in.
+    pub fn context_vars_set(set: &mut ContextValueSet) {
+        set.insert(&RICH_TEXT_FOCUSED_Z_VAR);
+    }
+}
+
+/// Defines a *rich text* context.
+///
+/// When enabled text widget descendants of this widget edit the text across the widgets,
+/// for example, the caret position moves to the next text widget when it reaches the start/end of the first text widget.
+///
+/// Nested rich text contexts are allowed and are all part of the outermost context, enabling this property in all nested
+/// wrap panels is recommended as it enables some rich text behavior like bringing the focused widget to front to avoid
+/// clipping the caret.
+#[property(CONTEXT, default(false), widget_impl(RichTextMix<P>))]
+pub fn rich_text(child: impl UiNode, enabled: impl IntoVar<bool>) -> impl UiNode {
+    crate::node::rich_text_node(child, enabled)
+}
+
+/// Defines the Z-index set on inner text (and nested rich text) widgets when focus is within.
+/// 
+/// Is [`ZIndex::FRONT`] by default, so that the caret visual is not clipped when the insert point is at
+/// an edge between texts. Set to `None` to not change the Z-index on focus. 
+/// 
+/// Sets the [`RICH_TEXT_FOCUSED_Z_VAR`].
+#[property(CONTEXT, default(RICH_TEXT_FOCUSED_Z_VAR), widget_impl(RichTextMix<P>))]
+pub fn rich_text_focused_z(child: impl UiNode, z_index: impl IntoVar<Option<ZIndex>>) -> impl UiNode {
+    with_context_var(child, RICH_TEXT_FOCUSED_Z_VAR, z_index)
+}

--- a/crates/zng-wgt-wrap/src/lib.rs
+++ b/crates/zng-wgt-wrap/src/lib.rs
@@ -916,7 +916,8 @@ impl InlineLayout {
         #[cfg(debug_assertions)]
         for (i, row) in self.rows.iter().enumerate() {
             let width = row.size.width;
-            let sum_width = row.item_segs.iter().map(|s| Px(s.measure_width() as i32)).sum::<Px>();
+            let sum_width = row.item_segs.iter().map(|s| Px(s.measure_width() as i32)).sum::<Px>()
+                + spacing.column * Px(row.item_segs.len().saturating_sub(1) as _);
 
             if (sum_width - width) > Px(1) {
                 if metrics.inline_constraints().is_some() && (i == 0 || i == self.rows.len() - 1) {

--- a/crates/zng/src/text.rs
+++ b/crates/zng/src/text.rs
@@ -53,7 +53,41 @@
 //!
 //! # Rich Text
 //!
-//! !!: TODO
+//! Rich text is a sequence of `Text!` of different styles and other widgets such as `Image!` inside one or more layout panels,
+//! usually a `Wrap!` panel for paragraphs and a `Stack!` panel for the full text or page, if you only intent to present the text
+//! that is all you need, the inline layout will coordinate the flow of lines across multiple `Text!` widgets.
+//!
+//! To enable selection or editing in rich text you can enable the [`rich_text`] property on the panels. The outer panel will
+//! declare a rich text context that the inner `Text!` widgets will use to coordinate the caret position and selection across texts.
+//!
+//! ```
+//! use zng::prelude::*;
+//! # let _scope = APP.defaults();
+//! # let _ =
+//! Wrap! {
+//!     text::rich_text = true;
+//!     text::txt_selectable = true;
+//!     children = ui_vec![
+//!         Text! { txt = "red text"; font_color = colors::RED; },
+//!         Text! { txt = " green text"; font_color = colors::GREEN; },
+//!         Text! { txt = " blue text"; font_color = colors::BLUE; },
+//!     ];
+//! }
+//! # ;
+//! ```
+//!
+//! The example above declares a rich text with three different *text runs*, by enabling [`rich_text`] the wrap panel becomes
+//! a rich text context that all descendant texts will use to coordinate text operations. In this case the [`txt_selectable`]
+//! property enables text selection (and copy) for all descendants, without `rich_text` the descendant texts would allow
+//! selection only within each text.
+//!
+//! The [`rich_text`] property together with [`txt_editable`] is the base for rich text editor widgets, out of the box the descendant texts
+//! will coordinate the caret position and the focused text is edited by typing. A rich text editor needs to implement many other features,
+//! such as removing empty text widgets, inserting new styled texts, encoding all these texts into an unified representation for saving.
+//!
+//! To suppress the default behavior of component texts you can handle keyboard events in the preview track and stop propagation,
+//! same for mouse/touch events. The full text API crate provides the [`zng_wgt_text::cmd`] module that can be used to programmatically
+//! control the texts. The *active* component text is just the focused widget, that can be controlled using the [`zng::focus`] module.
 //!
 //! [`Text!`]: struct@Text
 //! [`SelectableText!`]: struct@crate::selectable::SelectableText
@@ -62,6 +96,9 @@
 //! [`Markdown!`]: struct@crate::markdown::Markdown
 //! [`AnsiText!`]: struct@crate::ansi_text::AnsiText
 //! [`wrap`]: crate::wrap
+//! [`rich_text`]: fn@rich_text
+//! [`txt_selectable`]: fn@txt_selectable
+//! [`txt_editable`]: fn@txt_editable
 //!
 //! # Full API
 //!

--- a/crates/zng/src/text.rs
+++ b/crates/zng/src/text.rs
@@ -83,5 +83,6 @@ pub use zng_wgt_text::{
     node::{TEXT, set_interactive_caret_spot},
     obscure_txt, obscuring_char, on_change_stop, overline, overline_color, paragraph_spacing, rich_text, selection_color,
     selection_toolbar, selection_toolbar_anchor, selection_toolbar_fn, strikethrough, strikethrough_color, tab_length, txt_align,
-    txt_editable, txt_overflow, txt_overflow_align, underline, underline_color, underline_skip, white_space, word_break, word_spacing,
+    txt_editable, txt_overflow, txt_overflow_align, txt_selectable, underline, underline_color, underline_skip, white_space, word_break,
+    word_spacing,
 };

--- a/crates/zng/src/text.rs
+++ b/crates/zng/src/text.rs
@@ -51,6 +51,10 @@
 //! font family value because of this, the [`font_size`](fn@font_size) on the other hand is set for
 //! each text widget and only affects that widget.
 //!
+//! # Rich Text
+//!
+//! !!: TODO
+//!
 //! [`Text!`]: struct@Text
 //! [`SelectableText!`]: struct@crate::selectable::SelectableText
 //! [`TextInput!`]: struct@crate::text_input::TextInput
@@ -77,7 +81,7 @@ pub use zng_wgt_text::{
     interactive_caret_visual, is_line_overflown, is_overflown, is_parse_pending, justify_mode, lang, letter_spacing, line_break,
     line_height, line_spacing, max_chars_count,
     node::{TEXT, set_interactive_caret_spot},
-    obscure_txt, obscuring_char, on_change_stop, overline, overline_color, paragraph_spacing, selection_color, selection_toolbar,
-    selection_toolbar_anchor, selection_toolbar_fn, strikethrough, strikethrough_color, tab_length, txt_align, txt_editable, txt_overflow,
-    txt_overflow_align, underline, underline_color, underline_skip, white_space, word_break, word_spacing,
+    obscure_txt, obscuring_char, on_change_stop, overline, overline_color, paragraph_spacing, rich_text, selection_color,
+    selection_toolbar, selection_toolbar_anchor, selection_toolbar_fn, strikethrough, strikethrough_color, tab_length, txt_align,
+    txt_editable, txt_overflow, txt_overflow_align, underline, underline_color, underline_skip, white_space, word_break, word_spacing,
 };

--- a/examples/focus/src/main.rs
+++ b/examples/focus/src/main.rs
@@ -29,20 +29,14 @@ fn main() {
         Window! {
             title = "Focus Example";
             enabled = window_enabled.clone();
-            widget::background = commands();
+            child_top = alt_scope(), 50;
             child = Stack! {
-                direction = StackDirection::top_to_bottom();
-                children = ui_vec![
-                    alt_scope(),
-                    Stack! {
-                        direction = StackDirection::left_to_right();
-                        margin = (50, 0, 0, 0);
-                        align = Align::CENTER;
-                        spacing = 10;
-                        children = ui_vec![tab_index_example(), functions(window_enabled), delayed_focus()]
-                    }
-                ];
+                direction = StackDirection::left_to_right();
+                align = Align::TOP;
+                spacing = 10;
+                children = ui_vec![tab_index_example(), functions(window_enabled), delayed_focus()]
             };
+            widget::background = commands();
             // zng::window::inspector::show_center_points = true;
             // zng::window::inspector::show_bounds = true;
             // zng::window::inspector::show_hit_test = true;

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -19,6 +19,7 @@ fn main() {
                 padding = 10;
                 child = Markdown! {
                     txt = std::fs::read_to_string(zng::env::res("sample.md")).unwrap_or_else(|e| e.to_string());
+                    txt_selectable = true;
 
                     // allow limited image download and read.
                     image::img_limits = ImageLimits::default()


### PR DESCRIPTION
Closes #60

This pull implements the `TEXT.rich` context and related API and implements it for most `TextSelectOp`. It also implement the `COPY_CMD` command. This enables copy in the Markdown control for example.