### PR TITLE
Add `txt_selectable_alt_only`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* `Markdown!` is not a rich text context, enable `txt_selectable` to provide simple selection and copy.
+* Add `zng::text::txt_selectable_alt_only` to coordinate click events with rich text selection gestures.
+  - `Button!` widgets enable this by default, any button or derived widget is now clickable inside rich texts.
 
 # 0.14.3
 

--- a/crates/zng-wgt-button/src/lib.rs
+++ b/crates/zng-wgt-button/src/lib.rs
@@ -29,7 +29,7 @@ use zng_wgt_input::{
     pointer_capture::{CaptureMode, capture_pointer},
 };
 use zng_wgt_style::{Style, StyleMix, impl_style_fn, style_fn};
-use zng_wgt_text::{FONT_COLOR_VAR, Text, font_color, underline};
+use zng_wgt_text::{FONT_COLOR_VAR, Text, font_color, txt_selectable_alt_only, underline};
 
 #[cfg(feature = "tooltip")]
 use zng_wgt_tooltip::{Tip, TooltipArgs, tooltip, tooltip_fn};
@@ -54,6 +54,7 @@ impl Button {
             style_base_fn = style_fn!(|_| DefaultStyle!());
             capture_pointer = true;
             labelled_by_child = true;
+            txt_selectable_alt_only = true;
         }
 
         self.widget_builder().push_build_action(|wgt| {

--- a/crates/zng-wgt-markdown/src/lib.rs
+++ b/crates/zng-wgt-markdown/src/lib.rs
@@ -58,6 +58,7 @@ impl Markdown {
             on_link = hn!(|args: &LinkArgs| {
                 try_default_link_action(args);
             });
+            zng_wgt_text::rich_text = true;
 
             when #txt_selectable {
                 cursor = CursorIcon::Text;

--- a/crates/zng-wgt-text/src/node.rs
+++ b/crates/zng-wgt-text/src/node.rs
@@ -295,6 +295,14 @@ impl TEXT {
     fn layout(&self) -> RwLockWriteGuardOwned<LaidoutText> {
         LAIDOUT_TEXT.write()
     }
+
+    pub(crate) fn take_rich_selection_started_by_alt(&self) -> bool {
+        std::mem::take(&mut *RICH_TEXT_SELECTION_STARTED_BY_ALT.write())
+    }
+
+    pub(crate) fn flag_rich_selection_started_by_alt(&self) {
+        *RICH_TEXT_SELECTION_STARTED_BY_ALT.write() = true;
+    }
 }
 
 /// Defines the source of the current selection.
@@ -505,6 +513,8 @@ context_local! {
     static LAIDOUT_TEXT: RwLock<LaidoutText> = RwLock::new(LaidoutText::no_context());
     /// Represents a list of events send from rich text leaves to other leaves.
     static RICH_TEXT_NOTIFY: RwLock<Vec<EventUpdate>> = RwLock::new(RichText::no_dispatch_context());
+    /// TODO refactor into RichCaretInfo private field next breaking change.
+    static RICH_TEXT_SELECTION_STARTED_BY_ALT: RwLock<bool> = RwLock::new(false);
 }
 
 impl RichText {

--- a/crates/zng-wgt-text/src/text_properties.rs
+++ b/crates/zng-wgt-text/src/text_properties.rs
@@ -1239,6 +1239,8 @@ context_var! {
 
     /// Text is selectable.
     pub static TEXT_SELECTABLE_VAR: bool = false;
+    /// Text only starts selection from mouse or touch if the Alt modifier is pressed.
+    pub static TEXT_SELECTABLE_ALT_ONLY_VAR: bool = false;
 
     /// Accepts `'\t'` input when editable.
     pub static ACCEPTS_TAB_VAR: bool = false;
@@ -1286,6 +1288,7 @@ impl TextEditMix<()> {
     pub fn context_vars_set(set: &mut ContextValueSet) {
         set.insert(&TEXT_EDITABLE_VAR);
         set.insert(&TEXT_SELECTABLE_VAR);
+        set.insert(&TEXT_SELECTABLE_ALT_ONLY_VAR);
         set.insert(&ACCEPTS_ENTER_VAR);
         set.insert(&CARET_COLOR_VAR);
         set.insert(&INTERACTIVE_CARET_VISUAL_VAR);
@@ -1371,10 +1374,30 @@ pub fn txt_editable(child: impl UiNode, enabled: impl IntoVar<bool>) -> impl UiN
 
 /// Enable text selection, copy and makes the widget focusable.
 ///
+/// Note that if the text widget subscribes to mouse or touch events the selection gestures will interfere with those events,
+/// you can enable [`txt_selectable_alt_only`] so that pointer selection gestures only start when the Alt keyboard modifier is pressed.
+///
 /// Sets the [`TEXT_SELECTABLE_VAR`].
+///
+/// [`txt_selectable_alt_only`]: fn@txt_selectable_alt_only
 #[property(CONTEXT, default(TEXT_SELECTABLE_VAR), widget_impl(TextEditMix<P>))]
 pub fn txt_selectable(child: impl UiNode, enabled: impl IntoVar<bool>) -> impl UiNode {
     with_context_var(child, TEXT_SELECTABLE_VAR, enabled)
+}
+
+/// Only start mouse and touch selections from this widget when the Alt keyboard modifier is pressed.
+///
+/// Note that this property does not enable text selection, [`txt_selectable`] must be enabled on the widget or parent.
+///
+/// This property is ignored if the text is also editable. Selections started from sibling widgets in rich text also expand
+/// inside this widget normally, this property only applies to selection started from this widget.
+///
+/// Sets the [`TEXT_SELECTABLE_ALT_ONLY_VAR`].
+///
+/// [`txt_selectable`]: fn@txt_selectable
+#[property(CONTEXT, default(TEXT_SELECTABLE_ALT_ONLY_VAR), widget_impl(TextEditMix<P>))]
+pub fn txt_selectable_alt_only(child: impl UiNode, enabled: impl IntoVar<bool>) -> impl UiNode {
+    with_context_var(child, TEXT_SELECTABLE_ALT_ONLY_VAR, enabled)
 }
 
 /// If the `'\t'` character is inserted when tab is pressed and the text is editable.

--- a/crates/zng/src/text.rs
+++ b/crates/zng/src/text.rs
@@ -120,6 +120,6 @@ pub use zng_wgt_text::{
     node::{TEXT, set_interactive_caret_spot},
     obscure_txt, obscuring_char, on_change_stop, overline, overline_color, paragraph_spacing, rich_text, selection_color,
     selection_toolbar, selection_toolbar_anchor, selection_toolbar_fn, strikethrough, strikethrough_color, tab_length, txt_align,
-    txt_editable, txt_overflow, txt_overflow_align, txt_selectable, underline, underline_color, underline_skip, white_space, word_break,
-    word_spacing,
+    txt_editable, txt_overflow, txt_overflow_align, txt_selectable, txt_selectable_alt_only, underline, underline_color, underline_skip,
+    white_space, word_break, word_spacing,
 };


### PR DESCRIPTION
Without this if a `Text!` handles `on_click` it will stop working when `txt_selectable` is enabled because the selection gesture stops propagation on mouse input.

Attempted to make this automatic, but there is no to know that a property subscribes to `CLICK_EVENT` only to receive context clicks for example, so it now is a `txt_selectable_alt_only` that anchor/link like styled Text widgets must enable.