### PR TITLE
Handle text commands scoped to rich text context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Rich text contexts now handle scoped `SELECT_CMD` and `SELECT_ALL_CMD`.
 
 # 0.14.4
 

--- a/crates/zng-app/src/event/command.rs
+++ b/crates/zng-app/src/event/command.rs
@@ -558,6 +558,11 @@ impl Command {
         ))
     }
 
+    /// Create an event update for this command without custom `param`.
+    pub fn new_update(&self) -> EventUpdate {
+        self.event.new_update(CommandArgs::now(None, self.scope, self.is_enabled_value()))
+    }
+
     /// Create an event update for this command with custom `param`.
     pub fn new_update_param(&self, param: impl Any + Send + Sync) -> EventUpdate {
         self.event


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->