### PR TITLE
Rich text copy now includes all visible line breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Rich text copy now includes all visible line breaks, in a future release wrap breaks will be ignored, but for now this is better then no breaks.
 
 # 0.15.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Enable rich text selection in debug crash dialog, removed "plain" stdio panels.
 * Rich text copy now includes all visible line breaks, in a future release wrap breaks will be ignored, but for now this is better then no breaks.
 
 # 0.15.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Enable rich text selection in default third-party licenses screen. 
 * Enable rich text selection in debug crash dialog, removed "plain" stdio panels.
 * Rich text copy now includes all visible line breaks, in a future release wrap breaks will be ignored, but for now this is better then no breaks.
 

--- a/crates/zng-wgt-inspector/l10n/en-US/crash-handler.ftl
+++ b/crates/zng-wgt-inspector/l10n/en-US/crash-handler.ftl
@@ -24,11 +24,9 @@ panic =
 
 stderr =
     .title = Stderr
-    .title-plain = Stderr (plain)
 
 stdout =
     .title = Stdout
-    .title-plain = Stdout (plain)
 
 summary =
     .text = Timestamp: {$timestamp}

--- a/crates/zng-wgt-inspector/l10n/pt-BR/crash-handler.ftl
+++ b/crates/zng-wgt-inspector/l10n/pt-BR/crash-handler.ftl
@@ -24,11 +24,9 @@ panic =
 
 stderr =
     .title = Stderr
-    .title-plain = Stderr (plain)
 
 stdout =
     .title = Stdout
-    .title-plain = Stdout (plain)
 
 summary =
     .text = Timestamp: {$timestamp}

--- a/crates/zng-wgt-inspector/l10n/template/crash-handler.ftl
+++ b/crates/zng-wgt-inspector/l10n/template/crash-handler.ftl
@@ -24,11 +24,9 @@ panic =
 
 stderr =
     .title = Stderr
-    .title-plain = Stderr (plain)
 
 stdout =
     .title = Stdout
-    .title-plain = Stdout (plain)
 
 summary =
     .text = Timestamp: {$timestamp}

--- a/crates/zng-wgt-inspector/src/crash_handler.rs
+++ b/crates/zng-wgt-inspector/src/crash_handler.rs
@@ -68,21 +68,13 @@ fn panels(error: &CrashError) -> impl UiNode {
     let mut active = ErrorPanel::Summary;
 
     if !error.stdout.is_empty() {
-        options.push(ErrorPanel::StdoutPlain);
-        active = ErrorPanel::StdoutPlain;
-        if !error.is_stdout_plain() {
-            options.push(ErrorPanel::Stdout);
-            active = ErrorPanel::Stdout;
-        }
+        options.push(ErrorPanel::Stdout);
+        active = ErrorPanel::Stdout;
     }
 
     if !error.stderr.is_empty() {
-        options.push(ErrorPanel::StderrPlain);
-        active = ErrorPanel::StderrPlain;
-        if error.is_stderr_plain() {
-            options.push(ErrorPanel::Stderr);
-            active = ErrorPanel::Stderr;
-        }
+        options.push(ErrorPanel::Stderr);
+        active = ErrorPanel::Stderr;
     }
 
     if error.has_panic() {
@@ -123,8 +115,6 @@ enum ErrorPanel {
     Summary,
     Stdout,
     Stderr,
-    StdoutPlain,
-    StderrPlain,
     Panic,
     Widget,
     Minidump,
@@ -135,8 +125,6 @@ impl ErrorPanel {
             ErrorPanel::Summary => l10n!("crash-handler/summary.title", "Summary").get(),
             ErrorPanel::Stdout => l10n!("crash-handler/stdout.title", "Stdout").get(),
             ErrorPanel::Stderr => l10n!("crash-handler/stderr.title", "Stderr").get(),
-            ErrorPanel::StdoutPlain => l10n!("crash-handler/stdout.title-plain", "Stdout (plain)").get(),
-            ErrorPanel::StderrPlain => l10n!("crash-handler/stderr.title-plain", "Stderr (plain)").get(),
             ErrorPanel::Panic => l10n!("crash-handler/panic.title", "Panic").get(),
             ErrorPanel::Widget => l10n!("crash-handler/widget.title", "Widget").get(),
             ErrorPanel::Minidump => l10n!("crash-handler/minidump.title", "Minidump").get(),
@@ -148,8 +136,6 @@ impl ErrorPanel {
             ErrorPanel::Summary => summary_panel(error).boxed(),
             ErrorPanel::Stdout => std_panel(error.stdout.clone(), "stdout").boxed(),
             ErrorPanel::Stderr => std_panel(error.stderr.clone(), "stderr").boxed(),
-            ErrorPanel::StdoutPlain => std_plain_panel(error.stdout_plain(), "stdout").boxed(),
-            ErrorPanel::StderrPlain => std_plain_panel(error.stderr_plain(), "stderr").boxed(),
             ErrorPanel::Panic => panic_panel(error.find_panic().unwrap()).boxed(),
             ErrorPanel::Widget => widget_panel(error.find_panic().unwrap().widget_path).boxed(),
             ErrorPanel::Minidump => minidump_panel(error.minidump.clone().unwrap()).boxed(),
@@ -206,12 +192,10 @@ fn std_panel(std: Txt, config_key: &'static str) -> impl UiNode {
         vertical_offset = CONFIG.get(formatx!("{config_key}.scroll.v"), 0.fct());
         child = AnsiText! {
             txt = std;
+            txt_selectable = true;
             font_size = 0.9.em();
         }
     }
-}
-fn std_plain_panel(std: Txt, config_key: &'static str) -> impl UiNode {
-    plain_panel(std, config_key)
 }
 fn panic_panel(panic: CrashPanic) -> impl UiNode {
     plain_panel(panic.to_txt(), "panic")

--- a/crates/zng-wgt-text/src/node/rich.rs
+++ b/crates/zng-wgt-text/src/node/rich.rs
@@ -130,6 +130,14 @@ fn rich_text_cmds(child: impl UiNode) -> impl UiNode {
                             child.event(&update);
 
                             if let Some(t_frag) = rich_copy.into_text() {
+                                let line_info = leaf.rich_text_line_info();
+                                if line_info.starts_new_line && !txt.is_empty() {
+                                    // TODO, ignore wrap new lines
+                                    // * Some widgets line `AnsiText!` remove text line breaks and use a `Stack!` of lines.
+                                    // * `Wrap!` can wrap two `Text!` widgets such that the second one starts on a new line, without any actual break.
+                                    txt.push('\n');
+                                }
+
                                 txt.push_str(&t_frag);
                             }
                         }

--- a/crates/zng/src/third_party.rs
+++ b/crates/zng/src/third_party.rs
@@ -247,7 +247,10 @@ pub(crate) fn setup_default_view() {
                 mode = zng::scroll::ScrollMode::VERTICAL;
                 child_align = Align::TOP_START;
                 padding = 10;
-                child = zng::markdown::Markdown!(selected.map(default_markdown));
+                child = zng::markdown::Markdown! {
+                    txt = selected.map(default_markdown);
+                    txt_selectable = true;
+                };
             };
         }
     }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->