### PR TITLE
Fix rich selection not highlighting all text components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+* Fix rich selection not highlighting all text components with focused style.
+* Add `EventUpdate::custom` to create a custom event delivery from an existing one.
+  - Somewhat equivalent to `Event<A>::new_update_custom`, but without needing to know the event type. 
+* Fix panic on explicit disabled `rich_text`.
 * Enable rich text selection in default third-party licenses screen. 
 * Enable rich text selection in debug crash dialog, removed "plain" stdio panels.
 * Rich text copy now includes all visible line breaks, in a future release wrap breaks will be ignored, but for now this is better then no breaks.

--- a/crates/zng-app/src/update.rs
+++ b/crates/zng-app/src/update.rs
@@ -327,6 +327,19 @@ impl EventUpdate {
         }
     }
 
+    /// Create an event update for the same event and args, but with a custom `delivery_list`.
+    ///
+    /// Note that the returned instance can only be used to notify app extensions or nodes that the caller can reference.
+    pub fn custom(&self, delivery_list: UpdateDeliveryList) -> Self {
+        Self {
+            event: self.event,
+            args: self.args.clone_any(),
+            delivery_list,
+            pre_actions: Mutex::new(vec![]),
+            pos_actions: Mutex::new(vec![]),
+        }
+    }
+
     pub(crate) fn push_once_action(&mut self, action: Box<dyn FnOnce(&EventUpdate) + Send>, is_preview: bool) {
         if is_preview {
             self.pre_actions.get_mut().push(action);

--- a/crates/zng-wgt-text/src/cmd.rs
+++ b/crates/zng-wgt-text/src/cmd.rs
@@ -2073,7 +2073,7 @@ fn rich_line_start_end(clear_selection: bool, is_end: bool) -> TextSelectOp {
                         let mut prev_id = c.id();
                         for c in c.rich_text_next() {
                             let line_info = c.rich_text_line_info();
-                            if line_info.starts_new_line {
+                            if line_info.starts_new_line && !line_info.is_wrap_start {
                                 return (prev_id, Some(from_id));
                             } else if line_info.ends_in_new_line {
                                 return (c.id(), Some(from_id));
@@ -2093,7 +2093,7 @@ fn rich_line_start_end(clear_selection: bool, is_end: bool) -> TextSelectOp {
                         let mut last_id = c.id();
                         for c in c.rich_text_prev() {
                             let line_info = c.rich_text_line_info();
-                            if line_info.starts_new_line || line_info.ends_in_new_line {
+                            if (line_info.starts_new_line && !line_info.is_wrap_start) || line_info.ends_in_new_line {
                                 return (c.id(), Some(from_id));
                             }
                             last_id = c.id();
@@ -2426,7 +2426,7 @@ fn rich_nearest_line_to(replace_selection: bool, window_point: DipPoint) -> Text
                         let mut end = nearest_leaf.clone();
                         for next in nearest_leaf.rich_text_next() {
                             let line_info = next.rich_text_line_info();
-                            if line_info.starts_new_line {
+                            if line_info.starts_new_line && !line_info.is_wrap_start {
                                 return (
                                     end.id(),
                                     Some(end.bounds_info().inline().map(|i| i.rows.len().saturating_sub(1)).unwrap_or(0)),
@@ -2467,7 +2467,7 @@ fn rich_nearest_line_to(replace_selection: bool, window_point: DipPoint) -> Text
                     for prev in line_start.rich_text_prev() {
                         let line_info = prev.rich_text_line_info();
                         line_start = prev;
-                        if line_info.starts_new_line || line_info.ends_in_new_line {
+                        if (line_info.starts_new_line && !line_info.is_wrap_start) || line_info.ends_in_new_line {
                             break;
                         }
                     }

--- a/crates/zng-wgt-text/src/node/render.rs
+++ b/crates/zng-wgt-text/src/node/render.rs
@@ -177,6 +177,7 @@ pub fn render_selection(child: impl UiNode) -> impl UiNode {
         }
         UiNodeOp::Event { update } => {
             if let Some(args) = FOCUS_CHANGED_EVENT.on(update) {
+                // rich context also sends this event to all selected
                 let new_is_focused = args.is_focus_within(TEXT.try_rich().map(|r| r.root_id).unwrap_or_else(|| WIDGET.id()));
                 if is_focused != new_is_focused {
                     WIDGET.render();

--- a/crates/zng-wgt-text/src/text_properties.rs
+++ b/crates/zng-wgt-text/src/text_properties.rs
@@ -2092,6 +2092,8 @@ impl RichTextMix<()> {
 /// Nested rich text contexts are allowed and are all part of the outermost context, enabling this property in all nested
 /// wrap panels is recommended as it enables some rich text behavior like bringing the focused widget to front to avoid
 /// clipping the caret.
+///
+/// When enabled and not nested the widget will handle text commands, it also broadcasts focus change events to all text descendants.
 #[property(CONTEXT, default(false), widget_impl(RichTextMix<P>))]
 pub fn rich_text(child: impl UiNode, enabled: impl IntoVar<bool>) -> impl UiNode {
     crate::node::rich_text_node(child, enabled)


### PR DESCRIPTION
Also implement a convenient way to modify delivery list mid event update.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->