### PR TITLE
Enable rich text selection in inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Inspector properties panel is now a selectable rich text.
 * Rich text selection operations that apply to lines now ignore wrap line breaks.
 * Add `zng::window::inspector::INSPECTOR` and associated types for configuring the live inspector (ctrl+shift+i).
   - In this release: custom watchers and the internal data model is made public, root type `InspectedTree`.

--- a/crates/zng-wgt-inspector/src/live/inspector_window.rs
+++ b/crates/zng-wgt-inspector/src/live/inspector_window.rs
@@ -411,6 +411,9 @@ fn selected_view(wgt: Option<InspectedWidget>) -> impl UiNode {
             child = Stack! {
                 direction = StackDirection::top_to_bottom();
                 font_family = ["JetBrains Mono", "Consolas", "monospace"];
+                zng_wgt_text::rich_text = true;
+                zng_wgt_text::txt_selectable = true;
+                zng_wgt_input::cursor = zng_wgt_input::CursorIcon::Text;
                 children = ui_vec![
                     Wrap! {
                         children = ui_vec![


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->