### PR TITLE
Use windows-2025 in CI to avoid bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - run: cargo do fmt --check
       - run: cargo do check
   check-windows:
-    runs-on: windows-latest
+    runs-on: windows-2025
     env:
       CC: 'clang-cl'
       CXX: 'clang-cl'
@@ -90,7 +90,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo do build-apk multi
   check-android-windows:
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: [check-windows]
     steps:
       - uses: actions/checkout@v4
@@ -162,7 +162,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - run: cargo do test --nextest
   test-windows:
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: [check-windows]
     env:
       ZNG_TP_LICENSES: true
@@ -236,7 +236,7 @@ jobs:
         with:
           run: cargo do test --render --no-prebuilt
   test-render-windows:
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: [check-windows]
     env:
       ZNG_TP_LICENSES: true

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         feature: ['--all-features', '']
         profile: ['--release', '']
-    runs-on: windows-latest
+    runs-on: windows-2025
     env:
       CC: 'clang-cl'
       CXX: 'clang-cl'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - run: cargo clean
         if: ${{ github.event.inputs.skip_checks != 'true' }}
   check-windows:
-    runs-on: windows-latest
+    runs-on: windows-2025
     env:
       CC: 'clang-cl'
       CXX: 'clang-cl'
@@ -107,7 +107,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-          - os: windows-latest
+          - os: windows-2025
           - os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -202,7 +202,7 @@ jobs:
           - target: x86_64-pc-windows-msvc
             features: --features image_avif
           - target: aarch64-pc-windows-msvc
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: [check-windows]
     env:
       ZNG_TP_LICENSES: true
@@ -414,7 +414,7 @@ jobs:
         if: ${{ github.event.inputs.skip_tests != 'true' }}
   
   test-windows:
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: [prebuild-windows]
     env:
       CC: 'clang-cl'


### PR DESCRIPTION
windows-latest (that is actually windows-2022) has updated VS but not LVVM leading to a mismatch on the clang-cl version. In the windows-2025 image both are updated correctly.