### PR TITLE
Fix `mismatched_lifetime_syntaxes` lints

### DIFF
--- a/crates/cargo-zng/src/fmt.rs
+++ b/crates/cargo-zng/src/fmt.rs
@@ -330,7 +330,7 @@ fn try_fmt_macro(base_indent: usize, group_code: &str) -> Option<String> {
 // impl CargoZngFmt {
 //
 // ```
-fn replace_event_args(code: &str, reverse: bool) -> Cow<str> {
+fn replace_event_args(code: &str, reverse: bool) -> Cow<'_, str> {
     static RGX: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?m)^\s*(\.\.)\s*$").unwrap());
     static MARKER: &str = "// cargo-zng::fmt::dot_dot\n}\nimpl CargoZngFmt {\n";
     static RGX_REV: Lazy<Regex> =
@@ -350,7 +350,7 @@ fn replace_event_args(code: &str, reverse: bool) -> Cow<str> {
 }
 // replace `prop = 1, 2;` with `prop = (1, 2);`
 // AND replace `prop = { a: 1, b: 2, };` with `prop = __A_ { a: 1, b: 2, }`
-fn replace_widget_prop(code: &str, reverse: bool) -> Cow<str> {
+fn replace_widget_prop(code: &str, reverse: bool) -> Cow<'_, str> {
     static NAMED_RGX: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?m)\w+\s+=\s+(\{)").unwrap());
     static NAMED_MARKER: &str = "__A_ ";
 
@@ -418,7 +418,7 @@ fn replace_widget_prop(code: &str, reverse: bool) -> Cow<str> {
 }
 // replace `when <expr> { <properties> }` with `for cargo_zng_fmt_when in <expr> { <properties> }`
 // AND replace `#expr` with `__P_expr` AND `#{var}` with `__P_!{`
-fn replace_widget_when(code: &str, reverse: bool) -> Cow<str> {
+fn replace_widget_when(code: &str, reverse: bool) -> Cow<'_, str> {
     static RGX: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?s)\n\s*(when) .+?\{").unwrap());
     static MARKER: &str = "for cargo_zng_fmt_when in";
     static POUND_MARKER: &str = "__P_";
@@ -447,7 +447,7 @@ static POUND_REV_RGX: Lazy<Regex> = Lazy::new(|| Regex::new(r"__P_!?\s?").unwrap
 static POUND_VAR_MARKER: &str = "__P_!";
 
 // replace `#{` with `__P_!{`
-fn replace_expr_var(code: &str, reverse: bool) -> Cow<str> {
+fn replace_expr_var(code: &str, reverse: bool) -> Cow<'_, str> {
     if !reverse {
         POUND_RGX.replace(code, |caps: &regex::Captures| {
             let c = &caps[0][caps.get(1).unwrap().end() - caps.get(0).unwrap().start()..];

--- a/crates/zng-app-context/src/lib.rs
+++ b/crates/zng-app-context/src/lib.rs
@@ -1379,7 +1379,7 @@ impl<T> ReadOnlyRwLock<T> {
     /// Locks this `RwLock` with shared read access, blocking the current thread until it can be acquired.
     ///
     /// See `parking_lot::RwLock::read` for more details.
-    pub fn read(&self) -> parking_lot::RwLockReadGuard<T> {
+    pub fn read(&self) -> parking_lot::RwLockReadGuard<'_, T> {
         self.0.read()
     }
 
@@ -1389,21 +1389,21 @@ impl<T> ReadOnlyRwLock<T> {
     /// another read lock is held at the time of the call.
     ///
     /// See `parking_lot::RwLock::read_recursive` for more details.
-    pub fn read_recursive(&self) -> parking_lot::RwLockReadGuard<T> {
+    pub fn read_recursive(&self) -> parking_lot::RwLockReadGuard<'_, T> {
         self.0.read_recursive()
     }
 
     /// Attempts to acquire this `RwLock` with shared read access.
     ///
     /// See `parking_lot::RwLock::try_read` for more details.
-    pub fn try_read(&self) -> Option<parking_lot::RwLockReadGuard<T>> {
+    pub fn try_read(&self) -> Option<parking_lot::RwLockReadGuard<'_, T>> {
         self.0.try_read()
     }
 
     /// Attempts to acquire this `RwLock` with shared read access.
     ///
     /// See `parking_lot::RwLock::try_read_recursive` for more details.
-    pub fn try_read_recursive(&self) -> Option<parking_lot::RwLockReadGuard<T>> {
+    pub fn try_read_recursive(&self) -> Option<parking_lot::RwLockReadGuard<'_, T>> {
         self.0.try_read_recursive()
     }
 

--- a/crates/zng-app/src/event/channel.rs
+++ b/crates/zng-app/src/event/channel.rs
@@ -145,13 +145,13 @@ where
 
     /// Creates a blocking iterator over event updates, if there are no updates sent the iterator blocks,
     /// the iterator only finishes when the app shuts-down.
-    pub fn iter(&self) -> flume::Iter<A> {
+    pub fn iter(&self) -> flume::Iter<'_, A> {
         self.receiver.iter()
     }
 
     /// Create a non-blocking iterator over event updates, the iterator finishes if
     /// there are no more updates sent.
-    pub fn try_iter(&self) -> flume::TryIter<A> {
+    pub fn try_iter(&self) -> flume::TryIter<'_, A> {
         self.receiver.try_iter()
     }
 

--- a/crates/zng-app/src/lib.rs
+++ b/crates/zng-app/src/lib.rs
@@ -841,7 +841,7 @@ pub trait AppEventObserver {
     /// Cast to dynamically dispatched observer, this can help avoid code bloat.
     ///
     /// The app methods that accept observers automatically use this method if the feature `"dyn_app_extension"` is active.
-    fn as_dyn(&mut self) -> DynAppEventObserver
+    fn as_dyn(&mut self) -> DynAppEventObserver<'_>
     where
         Self: Sized,
     {
@@ -948,7 +948,7 @@ impl AppEventObserver for DynAppEventObserver<'_> {
         self.0.render_dyn(render_widgets, render_update_widgets)
     }
 
-    fn as_dyn(&mut self) -> DynAppEventObserver {
+    fn as_dyn(&mut self) -> DynAppEventObserver<'_> {
         DynAppEventObserver(self.0)
     }
 }

--- a/crates/zng-app/src/render.rs
+++ b/crates/zng-app/src/render.rs
@@ -1139,7 +1139,7 @@ impl FrameBuilder {
     ///
     /// Note that all hit-test is clipped by the inner-bounds, the shapes pushed with this builder
     /// only refine the widget inner-bounds, shapes out-of-bounds are clipped.
-    pub fn hit_test(&mut self) -> HitTestBuilder {
+    pub fn hit_test(&mut self) -> HitTestBuilder<'_> {
         expect_inner!(self.hit_test);
 
         HitTestBuilder {

--- a/crates/zng-app/src/view_process.rs
+++ b/crates/zng-app/src/view_process.rs
@@ -79,15 +79,15 @@ impl VIEW_PROCESS {
         APP.is_running() && VIEW_PROCESS_SV.read().is_some()
     }
 
-    fn read(&self) -> MappedRwLockReadGuard<ViewProcessService> {
+    fn read(&self) -> MappedRwLockReadGuard<'_, ViewProcessService> {
         VIEW_PROCESS_SV.read_map(|e| e.as_ref().expect("VIEW_PROCESS not available"))
     }
 
-    fn write(&self) -> MappedRwLockWriteGuard<ViewProcessService> {
+    fn write(&self) -> MappedRwLockWriteGuard<'_, ViewProcessService> {
         VIEW_PROCESS_SV.write_map(|e| e.as_mut().expect("VIEW_PROCESS not available"))
     }
 
-    fn try_write(&self) -> Result<MappedRwLockWriteGuard<ViewProcessService>> {
+    fn try_write(&self) -> Result<MappedRwLockWriteGuard<'_, ViewProcessService>> {
         let vp = VIEW_PROCESS_SV.write();
         if let Some(w) = &*vp {
             if w.process.is_connected() {
@@ -104,7 +104,7 @@ impl VIEW_PROCESS {
         }
     }
 
-    fn handle_write(&self, id: AppId) -> MappedRwLockWriteGuard<ViewProcessService> {
+    fn handle_write(&self, id: AppId) -> MappedRwLockWriteGuard<'_, ViewProcessService> {
         self.check_app(id);
         self.write()
     }

--- a/crates/zng-app/src/widget/builder.rs
+++ b/crates/zng-app/src/widget/builder.rs
@@ -2199,7 +2199,7 @@ impl WidgetBuilding {
     ///
     /// Note that captured properties are not instantiated in the final build, but they also are not removed like *unset*.
     /// A property can be "captured" more then once, and if the `"inspector"` feature is enabled they can be inspected.
-    pub fn capture_property(&mut self, property_id: PropertyId) -> Option<BuilderPropertyRef> {
+    pub fn capture_property(&mut self, property_id: PropertyId) -> Option<BuilderPropertyRef<'_>> {
         self.capture_property_impl(property_id)
     }
 
@@ -2719,7 +2719,7 @@ pub struct WidgetBuilderProperties {
 }
 impl WidgetBuilderProperties {
     /// Reference the property, if it is present.
-    pub fn property(&self, property_id: PropertyId) -> Option<BuilderPropertyRef> {
+    pub fn property(&self, property_id: PropertyId) -> Option<BuilderPropertyRef<'_>> {
         match self.property_index(property_id) {
             Some(i) => match &self.items[i].item {
                 WidgetItem::Property {
@@ -2739,7 +2739,7 @@ impl WidgetBuilderProperties {
     }
 
     /// Modify the property, if it is present.
-    pub fn property_mut(&mut self, property_id: PropertyId) -> Option<BuilderPropertyMut> {
+    pub fn property_mut(&mut self, property_id: PropertyId) -> Option<BuilderPropertyMut<'_>> {
         match self.property_index(property_id) {
             Some(i) => match &mut self.items[i] {
                 WidgetItemPositioned {
@@ -2766,7 +2766,7 @@ impl WidgetBuilderProperties {
     /// Iterate over the current properties.
     ///
     /// The properties may not be sorted in the correct order if the builder has never built.
-    pub fn properties(&self) -> impl Iterator<Item = BuilderPropertyRef> {
+    pub fn properties(&self) -> impl Iterator<Item = BuilderPropertyRef<'_>> {
         self.items.iter().filter_map(|it| match &it.item {
             WidgetItem::Intrinsic { .. } => None,
             WidgetItem::Property {
@@ -2783,7 +2783,7 @@ impl WidgetBuilderProperties {
     }
 
     /// iterate over mutable references to the current properties.
-    pub fn properties_mut(&mut self) -> impl Iterator<Item = BuilderPropertyMut> {
+    pub fn properties_mut(&mut self) -> impl Iterator<Item = BuilderPropertyMut<'_>> {
         self.items.iter_mut().filter_map(|it| match &mut it.item {
             WidgetItem::Intrinsic { .. } => None,
             WidgetItem::Property {
@@ -2834,7 +2834,7 @@ impl WidgetBuilderProperties {
         self.capture_value_or_else(property_id, T::default)
     }
 
-    fn capture_property_impl(&mut self, property_id: PropertyId) -> Option<BuilderPropertyRef> {
+    fn capture_property_impl(&mut self, property_id: PropertyId) -> Option<BuilderPropertyRef<'_>> {
         if let Some(i) = self.property_index(property_id) {
             match &mut self.items[i] {
                 WidgetItemPositioned {

--- a/crates/zng-app/src/widget/info.rs
+++ b/crates/zng-app/src/widget/info.rs
@@ -186,7 +186,7 @@ impl WidgetInfoTree {
     /// Custom metadata associated with the tree during info build.
     ///
     /// Any widget (that was not reused) can have inserted metadata.
-    pub fn build_meta(&self) -> StateMapRef<WidgetInfoMeta> {
+    pub fn build_meta(&self) -> StateMapRef<'_, WidgetInfoMeta> {
         self.0.build_meta.borrow()
     }
 
@@ -569,7 +569,7 @@ impl WidgetBoundsInfo {
     /// Exclusive read the latest inline layout info.
     ///
     /// Returns `None` if the latest widget layout was not in an inlining context.
-    pub fn inline(&self) -> Option<MappedMutexGuard<WidgetInlineInfo>> {
+    pub fn inline(&self) -> Option<MappedMutexGuard<'_, WidgetInlineInfo>> {
         let me = self.0.lock();
         if me.inline.is_some() {
             Some(MutexGuard::map(me, |m| m.inline.as_mut().unwrap()))
@@ -1057,7 +1057,7 @@ impl WidgetInfo {
         Self { tree, node_id }
     }
 
-    fn node(&self) -> tree::NodeRef<WidgetInfoData> {
+    fn node(&self) -> tree::NodeRef<'_, WidgetInfoData> {
         self.tree.0.tree.index(self.node_id)
     }
 
@@ -1408,7 +1408,7 @@ impl WidgetInfo {
     }
 
     /// Custom metadata associated with the widget during info build.
-    pub fn meta(&self) -> StateMapRef<WidgetInfoMeta> {
+    pub fn meta(&self) -> StateMapRef<'_, WidgetInfoMeta> {
         self.info().meta.borrow()
     }
 

--- a/crates/zng-app/src/widget/info/access.rs
+++ b/crates/zng-app/src/widget/info/access.rs
@@ -22,7 +22,7 @@ impl WidgetInfoBuilder {
     /// Accessibility metadata builder.
     ///
     /// Only available if accessibility info is required for the window.
-    pub fn access(&mut self) -> Option<WidgetAccessInfoBuilder> {
+    pub fn access(&mut self) -> Option<WidgetAccessInfoBuilder<'_>> {
         if self.access_enabled.is_enabled() {
             Some(WidgetAccessInfoBuilder { builder: self })
         } else {

--- a/crates/zng-app/src/widget/info/builder.rs
+++ b/crates/zng-app/src/widget/info/builder.rs
@@ -90,7 +90,7 @@ impl WidgetInfoBuilder {
         builder
     }
 
-    fn node(&mut self, id: tree::NodeId) -> tree::NodeMut<WidgetInfoData> {
+    fn node(&mut self, id: tree::NodeId) -> tree::NodeMut<'_, WidgetInfoData> {
         self.tree.index_mut(id)
     }
 

--- a/crates/zng-app/src/widget/info/path.rs
+++ b/crates/zng-app/src/widget/info/path.rs
@@ -85,7 +85,7 @@ impl WidgetPath {
     }
 
     /// Make a path to an ancestor id that is contained in the current path.
-    pub fn ancestor_path(&self, ancestor_id: WidgetId) -> Option<Cow<WidgetPath>> {
+    pub fn ancestor_path(&self, ancestor_id: WidgetId) -> Option<Cow<'_, WidgetPath>> {
         self.path.iter().position(|&id| id == ancestor_id).map(|i| {
             if i == self.path.len() - 1 {
                 Cow::Borrowed(self)
@@ -122,7 +122,7 @@ impl WidgetPath {
     }
 
     /// Gets a path to the root widget of this path.
-    pub fn root_path(&self) -> Cow<WidgetPath> {
+    pub fn root_path(&self) -> Cow<'_, WidgetPath> {
         if self.path.len() == 1 {
             Cow::Borrowed(self)
         } else {
@@ -134,7 +134,7 @@ impl WidgetPath {
     }
 
     /// Gets a path to the `widget_id` of this path.
-    pub fn sub_path(&self, widget_id: WidgetId) -> Option<Cow<WidgetPath>> {
+    pub fn sub_path(&self, widget_id: WidgetId) -> Option<Cow<'_, WidgetPath>> {
         if self.widget_id() == widget_id {
             Some(Cow::Borrowed(self))
         } else {
@@ -379,7 +379,7 @@ impl InteractionPath {
     }
 
     /// Make a path to an ancestor id that is contained in the current path.
-    pub fn ancestor_path(&self, ancestor_id: WidgetId) -> Option<Cow<InteractionPath>> {
+    pub fn ancestor_path(&self, ancestor_id: WidgetId) -> Option<Cow<'_, InteractionPath>> {
         self.widgets_path().iter().position(|&id| id == ancestor_id).map(|i| {
             if i == self.path.path.len() - 1 {
                 Cow::Borrowed(self)
@@ -424,7 +424,7 @@ impl InteractionPath {
     }
 
     /// Gets a path to the root widget of this path.
-    pub fn root_path(&self) -> Cow<InteractionPath> {
+    pub fn root_path(&self) -> Cow<'_, InteractionPath> {
         if self.path.path.len() == 1 {
             Cow::Borrowed(self)
         } else {
@@ -440,7 +440,7 @@ impl InteractionPath {
     }
 
     /// Gets a sub-path up to `widget_id` (inclusive), or `None` if the widget is not in the path.
-    pub fn sub_path(&self, widget_id: WidgetId) -> Option<Cow<InteractionPath>> {
+    pub fn sub_path(&self, widget_id: WidgetId) -> Option<Cow<'_, InteractionPath>> {
         if widget_id == self.widget_id() {
             Some(Cow::Borrowed(self))
         } else {

--- a/crates/zng-app/src/widget/info/tree.rs
+++ b/crates/zng-app/src/widget/info/tree.rs
@@ -44,23 +44,23 @@ impl<T> Tree<T> {
         Tree { nodes }
     }
 
-    pub fn index(&self, id: NodeId) -> NodeRef<T> {
+    pub fn index(&self, id: NodeId) -> NodeRef<'_, T> {
         #[cfg(debug_assertions)]
         let _ = self.nodes[id.get()];
         NodeRef { tree: self, id }
     }
 
-    pub fn index_mut(&mut self, id: NodeId) -> NodeMut<T> {
+    pub fn index_mut(&mut self, id: NodeId) -> NodeMut<'_, T> {
         #[cfg(debug_assertions)]
         let _ = self.nodes[id.get()];
         NodeMut { tree: self, id }
     }
 
-    pub fn root(&self) -> NodeRef<T> {
+    pub fn root(&self) -> NodeRef<'_, T> {
         self.index(NodeId::new(0))
     }
 
-    pub fn root_mut(&mut self) -> NodeMut<T> {
+    pub fn root_mut(&mut self) -> NodeMut<'_, T> {
         self.index_mut(NodeId::new(0))
     }
 
@@ -200,7 +200,7 @@ impl<T> NodeMut<'_, T> {
         self.id
     }
 
-    pub fn push_child(&mut self, value: T) -> NodeMut<T> {
+    pub fn push_child(&mut self, value: T) -> NodeMut<'_, T> {
         let len = self.tree.nodes.len();
         let new_id = NodeId::new(len);
 
@@ -246,7 +246,7 @@ impl<T> NodeMut<'_, T> {
         clone.close();
     }
 
-    fn first_child(&mut self) -> Option<NodeMut<T>> {
+    fn first_child(&mut self) -> Option<NodeMut<'_, T>> {
         self.tree.nodes[self.id.get()].last_child.map(|_| NodeMut {
             tree: self.tree,
             id: self.id.next(), // if we have a last child, we have a first one, just after `self`

--- a/crates/zng-app/src/widget/node/match_node.rs
+++ b/crates/zng-app/src/widget/node/match_node.rs
@@ -176,7 +176,7 @@ pub enum UiNodeOp<'a> {
         update: &'a mut FrameUpdate,
     },
 }
-impl UiNodeOp<'_> {
+impl<'a> UiNodeOp<'a> {
     /// Gets the operation without the associated data.
     pub fn mtd(&self) -> UiNodeOpMethod {
         match self {
@@ -193,7 +193,7 @@ impl UiNodeOp<'_> {
     }
 
     /// Reborrow the op.
-    pub fn reborrow(&mut self) -> UiNodeOp {
+    pub fn reborrow(&mut self) -> UiNodeOp<'_> {
         match self {
             UiNodeOp::Init => UiNodeOp::Init,
             UiNodeOp::Deinit => UiNodeOp::Deinit,

--- a/crates/zng-ext-config/src/settings.rs
+++ b/crates/zng-ext-config/src/settings.rs
@@ -270,7 +270,7 @@ impl Category {
     }
 
     /// Custom category metadata.
-    pub fn meta(&self) -> StateMapRef<Category> {
+    pub fn meta(&self) -> StateMapRef<'_, Category> {
         self.meta.borrow()
     }
 
@@ -355,7 +355,7 @@ impl Setting {
     }
 
     /// Custom setting metadata.
-    pub fn meta(&self) -> StateMapRef<Setting> {
+    pub fn meta(&self) -> StateMapRef<'_, Setting> {
         self.meta.borrow()
     }
 
@@ -471,7 +471,7 @@ impl SettingsBuilder<'_> {
         }
         self
     }
-    fn entry_impl(&mut self, config_key: ConfigKey, category_id: CategoryId) -> Option<SettingBuilder> {
+    fn entry_impl(&mut self, config_key: ConfigKey, category_id: CategoryId) -> Option<SettingBuilder<'_>> {
         if (self.filter)(&config_key, &category_id) {
             if let Some(i) = self.settings.iter().position(|s| s.key == config_key) {
                 let existing = self.settings.swap_remove(i);
@@ -560,7 +560,7 @@ impl SettingBuilder<'_> {
     }
 
     /// Custom setting metadata.
-    pub fn meta(&mut self) -> StateMapMut<Setting> {
+    pub fn meta(&mut self) -> StateMapMut<'_, Setting> {
         self.meta.borrow_mut()
     }
 
@@ -642,7 +642,7 @@ impl CategoriesBuilder<'_> {
         }
         self
     }
-    fn entry_impl(&mut self, category_id: CategoryId) -> Option<CategoryBuilder> {
+    fn entry_impl(&mut self, category_id: CategoryId) -> Option<CategoryBuilder<'_>> {
         if (self.filter)(&category_id) {
             if let Some(i) = self.categories.iter().position(|s| s.id == category_id) {
                 let existing = self.categories.swap_remove(i);
@@ -709,7 +709,7 @@ impl CategoryBuilder<'_> {
     }
 
     /// Custom category metadata.
-    pub fn meta(&mut self) -> StateMapMut<Category> {
+    pub fn meta(&mut self) -> StateMapMut<'_, Category> {
         self.meta.borrow_mut()
     }
 }

--- a/crates/zng-ext-font/src/emoji_util.rs
+++ b/crates/zng-ext-font/src/emoji_util.rs
@@ -169,13 +169,13 @@ impl ColorPalettes {
     }
 
     /// Gets the requested palette or the first if it is not found.
-    pub fn palette(&self, p: impl Into<FontColorPalette>) -> Option<ColorPalette> {
+    pub fn palette(&self, p: impl Into<FontColorPalette>) -> Option<ColorPalette<'_>> {
         let i = self.palette_i(p.into());
         self.palette_get(i.unwrap_or(0))
     }
 
     /// Gets the requested palette.
-    pub fn palette_exact(&self, p: impl Into<FontColorPalette>) -> Option<ColorPalette> {
+    pub fn palette_exact(&self, p: impl Into<FontColorPalette>) -> Option<ColorPalette<'_>> {
         let i = self.palette_i(p.into())?;
         self.palette_get(i)
     }
@@ -200,7 +200,7 @@ impl ColorPalettes {
         }
     }
 
-    fn palette_get(&self, i: usize) -> Option<ColorPalette> {
+    fn palette_get(&self, i: usize) -> Option<ColorPalette<'_>> {
         let len = self.num_palette_entries as usize;
         let s = len * i;
         let e = s + len;
@@ -212,7 +212,7 @@ impl ColorPalettes {
     }
 
     /// Iterate over color palettes.
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = ColorPalette> {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = ColorPalette<'_>> {
         self.colors
             .chunks_exact(self.num_palette_entries as _)
             .enumerate()
@@ -347,7 +347,7 @@ impl ColorGlyphs {
     /// `None` if the base text color must be used.
     ///
     /// Yields the `base_glyph` with no palette color if the font does not provide colored replacements for it.
-    pub fn glyph(&self, base_glyph: GlyphIndex) -> Option<ColorGlyph> {
+    pub fn glyph(&self, base_glyph: GlyphIndex) -> Option<ColorGlyph<'_>> {
         match self.base_glyph_records.binary_search_by_key(&(base_glyph as u16), |e| e.glyph_id) {
             Ok(i) => {
                 let rec = &self.base_glyph_records[i];

--- a/crates/zng-ext-font/src/font_features.rs
+++ b/crates/zng-ext-font/src/font_features.rs
@@ -105,7 +105,7 @@ impl FontFeatures {
     }
 
     /// Access to the named feature.
-    pub fn feature(&mut self, name: FontFeatureName) -> FontFeature {
+    pub fn feature(&mut self, name: FontFeatureName) -> FontFeature<'_> {
         FontFeature(self.0.entry(name))
     }
 
@@ -114,7 +114,7 @@ impl FontFeatures {
     /// # Panics
     ///
     /// If `names` has less than 2 names.
-    pub fn feature_set(&mut self, names: &'static [FontFeatureName]) -> FontFeatureSet {
+    pub fn feature_set(&mut self, names: &'static [FontFeatureName]) -> FontFeatureSet<'_> {
         assert!(names.len() >= 2);
         FontFeatureSet {
             features: &mut self.0,
@@ -127,7 +127,7 @@ impl FontFeatures {
     /// # Panics
     ///
     /// If `S::names()` has less than 2 names.
-    pub fn feature_exclusive_set<S: FontFeatureExclusiveSetState>(&mut self) -> FontFeatureExclusiveSet<S> {
+    pub fn feature_exclusive_set<S: FontFeatureExclusiveSetState>(&mut self) -> FontFeatureExclusiveSet<'_, S> {
         assert!(S::names().len() >= 2);
         FontFeatureExclusiveSet {
             features: &mut self.0,
@@ -141,7 +141,7 @@ impl FontFeatures {
     /// # Panics
     ///
     /// If `S::names()` has less than 2 entries.
-    pub fn feature_exclusive_sets<S: FontFeatureExclusiveSetsState>(&mut self) -> FontFeatureExclusiveSets<S> {
+    pub fn feature_exclusive_sets<S: FontFeatureExclusiveSetsState>(&mut self) -> FontFeatureExclusiveSets<'_, S> {
         assert!(S::names().len() >= 2);
         FontFeatureExclusiveSets {
             features: &mut self.0,
@@ -244,7 +244,7 @@ macro_rules! font_features {
     (feature $(#[$docs:meta])* fn $name:ident($feat0:tt, $feat1:tt); ) => {
         $(#[$docs])*
 
-        pub fn $name(&mut self) -> FontFeatureSet {
+        pub fn $name(&mut self) -> FontFeatureSet<'_> {
             static FEATS: [FontFeatureName; 2] = [FontFeatureName(*$feat0), FontFeatureName(*$feat1)];
             self.feature_set(&FEATS)
         }
@@ -254,7 +254,7 @@ macro_rules! font_features {
     (feature $(#[$docs:meta])* fn $name:ident($feat0:tt);) => {
         $(#[$docs])*
 
-        pub fn $name(&mut self) -> FontFeature {
+        pub fn $name(&mut self) -> FontFeature<'_> {
             self.feature(FontFeatureName(*$feat0))
         }
 
@@ -263,7 +263,7 @@ macro_rules! font_features {
     (feature $(#[$docs:meta])* fn $name:ident($Enum:ident) -> $Helper:ident;) => {
         $(#[$docs])*
 
-        pub fn $name(&mut self) -> $Helper<$Enum> {
+        pub fn $name(&mut self) -> $Helper<'_, $Enum> {
             $Helper { features: &mut self.0, _t: PhantomData }
         }
 

--- a/crates/zng-ext-font/src/lib.rs
+++ b/crates/zng-ext-font/src/lib.rs
@@ -1212,7 +1212,7 @@ impl FontFace {
     ///
     /// [`is_empty`]: Self::is_empty
     /// [`bytes`]: Self::bytes
-    pub fn harfbuzz(&self) -> Option<rustybuzz::Face> {
+    pub fn harfbuzz(&self) -> Option<rustybuzz::Face<'_>> {
         if self.is_empty() {
             None
         } else {
@@ -1228,7 +1228,7 @@ impl FontFace {
     ///
     /// [`is_empty`]: Self::is_empty
     /// [`bytes`]: Self::bytes
-    pub fn ttf(&self) -> Option<ttf_parser::Face> {
+    pub fn ttf(&self) -> Option<ttf_parser::Face<'_>> {
         if self.is_empty() {
             None
         } else {
@@ -1464,7 +1464,7 @@ impl Font {
     }
 
     /// Gets the sized harfbuzz font.
-    pub fn harfbuzz(&self) -> Option<rustybuzz::Face> {
+    pub fn harfbuzz(&self) -> Option<rustybuzz::Face<'_>> {
         let ppem = self.0.size.0 as u16;
 
         let mut font = self.0.face.harfbuzz()?;
@@ -1612,7 +1612,7 @@ impl FontFaceList {
     }
 
     /// Iterate over font faces, more specific first.
-    pub fn iter(&self) -> std::slice::Iter<FontFace> {
+    pub fn iter(&self) -> std::slice::Iter<'_, FontFace> {
         self.fonts.iter()
     }
 
@@ -1720,7 +1720,7 @@ impl FontList {
     }
 
     /// Iterate over font faces, more specific first.
-    pub fn iter(&self) -> std::slice::Iter<Font> {
+    pub fn iter(&self) -> std::slice::Iter<'_, Font> {
         self.fonts.iter()
     }
 
@@ -3156,7 +3156,7 @@ impl WhiteSpace {
     /// Transform the white space of the text.
     ///
     /// Returns [`Cow::Owned`] if the text was changed.
-    pub fn transform(self, text: &Txt) -> Cow<Txt> {
+    pub fn transform(self, text: &Txt) -> Cow<'_, Txt> {
         match self {
             WhiteSpace::Preserve => Cow::Borrowed(text),
             WhiteSpace::Merge => {

--- a/crates/zng-ext-font/src/segmenting.rs
+++ b/crates/zng-ext-font/src/segmenting.rs
@@ -252,7 +252,7 @@ impl SegmentedText {
     ///     println!("s: {sub_str:?} is a `{:?}`", seg.kind);
     /// }
     /// ```
-    pub fn iter(&self) -> SegmentedTextIter {
+    pub fn iter(&self) -> SegmentedTextIter<'_> {
         SegmentedTextIter {
             text: &self.text,
             start: 0,

--- a/crates/zng-ext-font/src/shaping.rs
+++ b/crates/zng-ext-font/src/shaping.rs
@@ -435,7 +435,7 @@ impl ShapedText {
     }
 
     /// Glyphs by font and palette color.
-    pub fn colored_glyphs(&self) -> impl Iterator<Item = (&Font, ShapedColoredGlyphs)> {
+    pub fn colored_glyphs(&self) -> impl Iterator<Item = (&Font, ShapedColoredGlyphs<'_>)> {
         ColoredGlyphsIter {
             glyphs: self.glyphs(),
             maybe_colored: None,
@@ -443,7 +443,7 @@ impl ShapedText {
     }
 
     /// Glyphs in a range by font and palette color.
-    pub fn colored_glyphs_slice(&self, range: impl ops::RangeBounds<usize>) -> impl Iterator<Item = (&Font, ShapedColoredGlyphs)> {
+    pub fn colored_glyphs_slice(&self, range: impl ops::RangeBounds<usize>) -> impl Iterator<Item = (&Font, ShapedColoredGlyphs<'_>)> {
         ColoredGlyphsIter {
             glyphs: self.glyphs_slice_impl(IndexRange::from_bounds(range)),
             maybe_colored: None,
@@ -451,7 +451,7 @@ impl ShapedText {
     }
 
     /// Glyphs by font and associated image.
-    pub fn image_glyphs(&self) -> impl Iterator<Item = (&Font, ShapedImageGlyphs)> {
+    pub fn image_glyphs(&self) -> impl Iterator<Item = (&Font, ShapedImageGlyphs<'_>)> {
         ImageGlyphsIter {
             glyphs: self.glyphs(),
             glyphs_i: 0,
@@ -461,7 +461,7 @@ impl ShapedText {
     }
 
     /// Glyphs in a range by font and associated image.
-    pub fn image_glyphs_slice(&self, range: impl ops::RangeBounds<usize>) -> impl Iterator<Item = (&Font, ShapedImageGlyphs)> {
+    pub fn image_glyphs_slice(&self, range: impl ops::RangeBounds<usize>) -> impl Iterator<Item = (&Font, ShapedImageGlyphs<'_>)> {
         let range = IndexRange::from_bounds(range);
         ImageGlyphsIter {
             glyphs_i: range.start() as _,
@@ -586,7 +586,7 @@ impl ShapedText {
 
     /// Gets the first line that overflows the `max_height`. A line overflows when the line `PxRect::max_y`
     /// is greater than `max_height`.
-    pub fn overflow_line(&self, max_height: Px) -> Option<ShapedLine> {
+    pub fn overflow_line(&self, max_height: Px) -> Option<ShapedLine<'_>> {
         let mut y = self.first_line.max_y();
         if y > max_height {
             self.line(0)
@@ -1317,7 +1317,7 @@ impl ShapedText {
     /// Iterate over [`ShapedLine`] selections split by [`LineBreak`] or wrap.
     ///
     /// [`LineBreak`]: TextSegmentKind::LineBreak
-    pub fn lines(&self) -> impl Iterator<Item = ShapedLine> {
+    pub fn lines(&self) -> impl Iterator<Item = ShapedLine<'_>> {
         let just_width = self.justify_mode().map(|_| self.align_size.width);
         self.lines.iter_segs().enumerate().map(move |(i, (w, r))| ShapedLine {
             text: self,
@@ -1338,7 +1338,7 @@ impl ShapedText {
     }
 
     /// Gets the line by index.
-    pub fn line(&self, line_idx: usize) -> Option<ShapedLine> {
+    pub fn line(&self, line_idx: usize) -> Option<ShapedLine<'_>> {
         if line_idx >= self.lines.0.len() {
             None
         } else {
@@ -1628,7 +1628,7 @@ impl ShapedText {
     }
 
     /// Gets the line that contains the `y` offset or is nearest to it.
-    pub fn nearest_line(&self, y: Px) -> Option<ShapedLine> {
+    pub fn nearest_line(&self, y: Px) -> Option<ShapedLine<'_>> {
         let first_line_max_y = self.first_line.max_y();
         if first_line_max_y >= y {
             self.line(0)
@@ -3400,7 +3400,7 @@ impl<'a> ShapedLine<'a> {
     /// Get the segment by index.
     ///
     /// The first segment of the line is `0`.
-    pub fn seg(&self, seg_idx: usize) -> Option<ShapedSegment> {
+    pub fn seg(&self, seg_idx: usize) -> Option<ShapedSegment<'_>> {
         if self.seg_range.len() > seg_idx {
             Some(ShapedSegment {
                 text: self.text,

--- a/crates/zng-ext-l10n/src/sources/tar.rs
+++ b/crates/zng-ext-l10n/src/sources/tar.rs
@@ -236,7 +236,7 @@ impl L10nTarData {
     }
 
     /// Decompress bytes.
-    pub fn decode_bytes(&self) -> std::io::Result<Cow<[u8]>> {
+    pub fn decode_bytes(&self) -> std::io::Result<Cow<'_, [u8]>> {
         if self.is_gz() {
             let bytes = self.bytes();
             let mut data = vec![];

--- a/crates/zng-ext-l10n/src/types.rs
+++ b/crates/zng-ext-l10n/src/types.rs
@@ -250,7 +250,7 @@ impl_from_and_into_var_number! {
 }
 impl L10nArgument {
     /// Borrow argument as a fluent value.
-    pub fn fluent_value(&self) -> fluent::FluentValue {
+    pub fn fluent_value(&self) -> fluent::FluentValue<'_> {
         match self {
             L10nArgument::Txt(t) => fluent::FluentValue::String(Cow::Borrowed(t.as_str())),
             L10nArgument::Number(n) => fluent::FluentValue::Number(n.clone()),

--- a/crates/zng-ext-undo/src/lib.rs
+++ b/crates/zng-ext-undo/src/lib.rs
@@ -531,7 +531,7 @@ pub trait UndoInfo: Send + Sync + Any {
     /// edit action for example, or an icon.
     ///
     /// Is empty by default.
-    fn meta(&self) -> StateMapRef<UNDO> {
+    fn meta(&self) -> StateMapRef<'_, UNDO> {
         StateMapRef::empty()
     }
 
@@ -563,7 +563,7 @@ impl UndoInfo for Arc<dyn UndoInfo> {
         self.as_ref().description()
     }
 
-    fn meta(&self) -> StateMapRef<UNDO> {
+    fn meta(&self) -> StateMapRef<'_, UNDO> {
         self.as_ref().meta()
     }
 

--- a/crates/zng-state-map/src/lib.rs
+++ b/crates/zng-state-map/src/lib.rs
@@ -212,7 +212,7 @@ impl<'a, U> StateMapMut<'a, U> {
     }
 
     /// Gets the given ID's corresponding entry in the map for in-place manipulation.
-    pub fn entry<T: StateValue>(&mut self, id: impl Into<StateId<T>>) -> state_map::StateMapEntry<T> {
+    pub fn entry<T: StateValue>(&mut self, id: impl Into<StateId<T>>) -> state_map::StateMapEntry<'_, T> {
         self.0.entry(id.into())
     }
 
@@ -229,12 +229,12 @@ impl<'a, U> StateMapMut<'a, U> {
     }
 
     /// Reborrow the mutable reference.
-    pub fn reborrow(&mut self) -> StateMapMut<U> {
+    pub fn reborrow(&mut self) -> StateMapMut<'_, U> {
         StateMapMut(self.0, PhantomData)
     }
 
     /// Reborrow the reference as read-only.
-    pub fn as_ref(&self) -> StateMapRef<U> {
+    pub fn as_ref(&self) -> StateMapRef<'_, U> {
         StateMapRef(self.0, PhantomData)
     }
 }
@@ -279,12 +279,12 @@ impl<U> OwnedStateMap<U> {
     }
 
     /// Create tagged read-only reference to the map.
-    pub fn borrow(&self) -> StateMapRef<U> {
+    pub fn borrow(&self) -> StateMapRef<'_, U> {
         StateMapRef(&self.0, PhantomData)
     }
 
     /// Crate tagged mutable reference to the map.
-    pub fn borrow_mut(&mut self) -> StateMapMut<U> {
+    pub fn borrow_mut(&mut self) -> StateMapMut<'_, U> {
         StateMapMut(&mut self.0, PhantomData)
     }
 }
@@ -343,7 +343,7 @@ pub mod state_map {
             self.get_mut(id).unwrap_or_else(move || panic!("expected `{id:?}` in state map"))
         }
 
-        pub fn entry<T: StateValue>(&mut self, id: StateId<T>) -> StateMapEntry<T> {
+        pub fn entry<T: StateValue>(&mut self, id: StateId<T>) -> StateMapEntry<'_, T> {
             match self.map.entry(id.get()) {
                 IdEntry::Occupied(e) => StateMapEntry::Occupied(OccupiedStateMapEntry {
                     _type: PhantomData,

--- a/crates/zng-task/src/channel.rs
+++ b/crates/zng-task/src/channel.rs
@@ -242,7 +242,7 @@ impl<T> Receiver<T> {
     }
 
     /// Takes all sitting in the channel.
-    pub fn drain(&self) -> flume::Drain<T> {
+    pub fn drain(&self) -> flume::Drain<'_, T> {
         self.0.drain()
     }
 }

--- a/crates/zng-var/src/arc.rs
+++ b/crates/zng-var/src/arc.rs
@@ -127,7 +127,7 @@ impl<T: VarValue> AnyVar for ArcVar<T> {
         self.0.modify_importance()
     }
 
-    fn var_ptr(&self) -> VarPtr {
+    fn var_ptr(&self) -> VarPtr<'_> {
         VarPtr::new_arc(&self.0)
     }
 

--- a/crates/zng-var/src/boxed.rs
+++ b/crates/zng-var/src/boxed.rs
@@ -115,7 +115,7 @@ impl AnyVar for Box<dyn AnyVar> {
         (**self).downgrade_any()
     }
 
-    fn var_ptr(&self) -> VarPtr {
+    fn var_ptr(&self) -> VarPtr<'_> {
         (**self).var_ptr()
     }
 
@@ -307,7 +307,7 @@ impl<T: VarValue> AnyVar for BoxedVar<T> {
         (**self).modify_importance()
     }
 
-    fn var_ptr(&self) -> VarPtr {
+    fn var_ptr(&self) -> VarPtr<'_> {
         (**self).var_ptr()
     }
 

--- a/crates/zng-var/src/context.rs
+++ b/crates/zng-var/src/context.rs
@@ -199,7 +199,7 @@ impl<T: VarValue> AnyVar for ContextVar<T> {
         self.0.get().modify_importance()
     }
 
-    fn var_ptr(&self) -> VarPtr {
+    fn var_ptr(&self) -> VarPtr<'_> {
         VarPtr::new_ctx_local(self.0)
     }
 

--- a/crates/zng-var/src/contextualized.rs
+++ b/crates/zng-var/src/contextualized.rs
@@ -145,7 +145,7 @@ impl<T: VarValue> ContextualizedVar<T> {
     }
 
     /// Borrow/initialize the actual var.
-    pub fn borrow_init(&self) -> parking_lot::MappedRwLockReadGuard<BoxedVar<T>> {
+    pub fn borrow_init(&self) -> parking_lot::MappedRwLockReadGuard<'_, BoxedVar<T>> {
         #[cfg(feature = "dyn_closure")]
         {
             parking_lot::MappedRwLockReadGuard::map(
@@ -325,7 +325,7 @@ impl<T: VarValue> AnyVar for ContextualizedVar<T> {
         self.borrow_init().modify_importance()
     }
 
-    fn var_ptr(&self) -> VarPtr {
+    fn var_ptr(&self) -> VarPtr<'_> {
         VarPtr::new_arc(&self.init)
     }
 

--- a/crates/zng-var/src/cow.rs
+++ b/crates/zng-var/src/cow.rs
@@ -257,7 +257,7 @@ impl<T: VarValue, S: Var<T>> AnyVar for ArcCowVar<T, S> {
         }
     }
 
-    fn var_ptr(&self) -> VarPtr {
+    fn var_ptr(&self) -> VarPtr<'_> {
         VarPtr::new_arc(&self.0)
     }
 

--- a/crates/zng-var/src/flat_map.rs
+++ b/crates/zng-var/src/flat_map.rs
@@ -204,7 +204,7 @@ where
         self.0.read().var.modify_importance()
     }
 
-    fn var_ptr(&self) -> VarPtr {
+    fn var_ptr(&self) -> VarPtr<'_> {
         VarPtr::new_arc(&self.0)
     }
 

--- a/crates/zng-var/src/lib.rs
+++ b/crates/zng-var/src/lib.rs
@@ -628,7 +628,7 @@ pub trait AnyVar: Any + Send + Sync + crate::private::Sealed {
     ///
     /// If two of these values are equal, both variables point to the same *rc* or *context* at the moment of comparison.
     /// Note that this is only for comparison, trying to access the variable internals is never safe.
-    fn var_ptr(&self) -> VarPtr;
+    fn var_ptr(&self) -> VarPtr<'_>;
 
     /// Get the value as a debug [`Txt`].
     ///
@@ -994,7 +994,7 @@ impl<'a> AnyVarHookArgs<'a> {
     }
 
     /// Try cast to strongly typed args.
-    pub fn as_strong<T: VarValue>(&self) -> Option<VarHookArgs<T>> {
+    pub fn as_strong<T: VarValue>(&self) -> Option<VarHookArgs<'_, T>> {
         if TypeId::of::<T>() == self.value_type() {
             Some(VarHookArgs {
                 any: self,
@@ -1969,7 +1969,7 @@ pub trait Var<T: VarValue>: IntoVar<T, Var = Self> + AnyVar + Clone {
         S: Fn(&animation::Transition<T>, EasingStep) -> T + Send + Sync + 'static;
 
     /// Returns a wrapper that implements [`fmt::Debug`] to write the var value.
-    fn debug(&self) -> types::VarDebug<T, Self> {
+    fn debug(&self) -> types::VarDebug<'_, T, Self> {
         types::VarDebug {
             var: self,
             _t: PhantomData,
@@ -1977,7 +1977,7 @@ pub trait Var<T: VarValue>: IntoVar<T, Var = Self> + AnyVar + Clone {
     }
 
     /// Returns a wrapper that implements [`fmt::Display`] to write the var value.
-    fn display(&self) -> types::VarDisplay<T, Self>
+    fn display(&self) -> types::VarDisplay<'_, T, Self>
     where
         T: fmt::Display,
     {

--- a/crates/zng-var/src/local.rs
+++ b/crates/zng-var/src/local.rs
@@ -96,7 +96,7 @@ impl<T: VarValue> AnyVar for LocalVar<T> {
         0
     }
 
-    fn var_ptr(&self) -> VarPtr {
+    fn var_ptr(&self) -> VarPtr<'_> {
         VarPtr::new_never_eq(self)
     }
 

--- a/crates/zng-var/src/map_ref.rs
+++ b/crates/zng-var/src/map_ref.rs
@@ -130,7 +130,7 @@ impl<I: VarValue, O: VarValue, S: Var<I>> AnyVar for MapRef<I, O, S> {
         self.source.modify_importance()
     }
 
-    fn var_ptr(&self) -> VarPtr {
+    fn var_ptr(&self) -> VarPtr<'_> {
         self.source.var_ptr()
     }
 
@@ -460,7 +460,7 @@ impl<I: VarValue, O: VarValue, S: Var<I>> AnyVar for MapRefBidi<I, O, S> {
         self.source.modify_importance()
     }
 
-    fn var_ptr(&self) -> VarPtr {
+    fn var_ptr(&self) -> VarPtr<'_> {
         self.source.var_ptr()
     }
 

--- a/crates/zng-var/src/merge.rs
+++ b/crates/zng-var/src/merge.rs
@@ -271,7 +271,7 @@ impl<T: VarValue> AnyVar for ArcMergeVar<T> {
         self.0.value.modify_importance()
     }
 
-    fn var_ptr(&self) -> VarPtr {
+    fn var_ptr(&self) -> VarPtr<'_> {
         VarPtr::new_arc(&self.0)
     }
 

--- a/crates/zng-var/src/read_only.rs
+++ b/crates/zng-var/src/read_only.rs
@@ -113,7 +113,7 @@ impl<T: VarValue, V: Var<T>> AnyVar for ReadOnlyVar<T, V> {
         self.1.modify_importance()
     }
 
-    fn var_ptr(&self) -> VarPtr {
+    fn var_ptr(&self) -> VarPtr<'_> {
         self.1.var_ptr()
     }
 

--- a/crates/zng-var/src/util.rs
+++ b/crates/zng-var/src/util.rs
@@ -332,7 +332,7 @@ impl VarData {
         *self.0.into_inner().value.into_any().downcast::<T>().unwrap()
     }
 
-    fn read<T: VarValue>(&self) -> parking_lot::MappedRwLockReadGuard<T> {
+    fn read<T: VarValue>(&self) -> parking_lot::MappedRwLockReadGuard<'_, T> {
         let read = self.0.read();
         parking_lot::RwLockReadGuard::map(read, |r| r.value.as_any().downcast_ref::<T>().unwrap())
     }

--- a/crates/zng-var/src/when.rs
+++ b/crates/zng-var/src/when.rs
@@ -551,7 +551,7 @@ impl<T: VarValue> AnyVar for ArcWhenVar<T> {
         self.active().modify_importance()
     }
 
-    fn var_ptr(&self) -> VarPtr {
+    fn var_ptr(&self) -> VarPtr<'_> {
         VarPtr::new_arc(&self.0)
     }
 

--- a/crates/zng-view-api/src/access.rs
+++ b/crates/zng-view-api/src/access.rs
@@ -817,7 +817,7 @@ impl ops::Deref for AccessTreeBuilder {
 pub struct AccessTree(Vec<AccessNode>);
 impl AccessTree {
     /// Root node.
-    pub fn root(&self) -> AccessNodeRef {
+    pub fn root(&self) -> AccessNodeRef<'_> {
         AccessNodeRef { tree: self, index: 0 }
     }
 }
@@ -850,21 +850,21 @@ pub struct AccessNodeRef<'a> {
 }
 impl AccessNodeRef<'_> {
     /// Iterate over `self` and all descendant nodes.
-    pub fn self_and_descendants(&self) -> impl ExactSizeIterator<Item = AccessNodeRef> {
+    pub fn self_and_descendants(&self) -> impl ExactSizeIterator<Item = AccessNodeRef<'_>> {
         let range = self.index..(self.index + self.descendants_len as usize);
         let tree = self.tree;
         range.map(move |i| AccessNodeRef { tree, index: i })
     }
 
     /// Iterate over all descendant nodes.
-    pub fn descendants(&self) -> impl ExactSizeIterator<Item = AccessNodeRef> {
+    pub fn descendants(&self) -> impl ExactSizeIterator<Item = AccessNodeRef<'_>> {
         let mut d = self.self_and_descendants();
         d.next();
         d
     }
 
     /// Iterate over children nodes.
-    pub fn children(&self) -> impl ExactSizeIterator<Item = AccessNodeRef> {
+    pub fn children(&self) -> impl ExactSizeIterator<Item = AccessNodeRef<'_>> {
         struct ChildrenIter<'a> {
             tree: &'a AccessTree,
             count: usize,

--- a/crates/zng-view/src/image_cache.rs
+++ b/crates/zng-view/src/image_cache.rs
@@ -1180,7 +1180,7 @@ mod external {
         }
     }
     impl ExternalImageHandler for WrImageCache {
-        fn lock(&mut self, key: ExternalImageId, _channel_index: u8) -> ExternalImage {
+        fn lock(&mut self, key: ExternalImageId, _channel_index: u8) -> ExternalImage<'_> {
             // SAFETY: this is safe because the Arc is kept alive in `ImageUseMap`.
             let img = unsafe {
                 let ptr = key.0 as *const ImageData;

--- a/crates/zng-wgt-wrap/src/crate_util.rs
+++ b/crates/zng-wgt-wrap/src/crate_util.rs
@@ -44,7 +44,7 @@ impl<T: Recycle> RecycleVec<T> {
         self.push(item);
     }
 
-    pub fn iter_mut(&mut self) -> std::slice::IterMut<T> {
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, T> {
         self.vec[..self.fresh_len].iter_mut()
     }
 }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->