### PR TITLE
Upgrade dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,11 @@
 * Fix `PxConstraints::with_more` not saturating on overflow.
 * Fix `Transitionable::lerp` implementation for `Align`. 
 * Fix `Align` equality not considering the `x_rtl_aware` field.
-
 * Implement `PartialOrd` for `PreMulRgba`, `Hsla`, `Hsva`, `Rgba`, `InlineSegmentPos`, `Ppi`, `Ppm`, `AngleRadian`, `AngleGradian`, `AngleDegree`, `AngleTurn`.
 * Implement `Ord` for `FontStretch`, `FontWeight`, `Factor`, `PreMulRgba`, `Hsla`, `Hsva`, `Rgba`, `InlineSegmentPos`, `Ppi`, `Ppm`, `AngleRadian`, `AngleGradian`, `AngleDegree`, `AngleTurn`.
   - *Deprecated* custom `max`, `min` and `clamp` methods of `Factor`,  `Ppi`, `Ppm`, use the Ord equivalent. 
 * Implement `Eq` for `Factor`, `FactorPercent`, `Align`, `ColorMatrix`, `PreMulAlpha`, `Hsla`, `Hsva`, `FontStretch`, `FontWeight`, `Ppi`, `Ppm`, `AngleRadian`, `AngleGradian`, `AngleDegree`, `AngleTurn`, `Rgba`, `AngleGradian`.
 * Implement `Hash` for `AngleRadian`, `AngleGradian`, `AngleDegree`, `AngleTurn`, `Align`, `Ppm`.
-
 * Fix hash equality for `f32` based unit types.
   - Refactor `zng_layout::unit::about_eq` to compare finite values by *bucket granularity*.
   - Refactor `about_eq_hash` to hash the same *bucket*.
@@ -24,7 +22,6 @@
   - In practice direct equality comparisons between two values has no significant change, the previous *epsilon distance* based
     equality was correct, it just was not compatible with hashing.
   - Refactor `about_eq_ord` to enforce `-inf < finite < inf < NaN` using the new equality *bucket* value for the finite values.
-
 * Fix `TimeUnits::ms` impl for `f32`.
 * Fix `Txt::split_off` when the `Txt` is backed by `&'static str`. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Add support for `CLIPBOARD.file_list` in Linux and macOS.
 * `LocalContext::with_context_blend` now also overrides the tracing dispatcher if it captures a dispatcher.
 * Better error handling in `zng::env::migrate_config`.
 * Fix `zng::env::init_cache` setting the config path instead cache.

--- a/crates/cargo-zng/Cargo.toml
+++ b/crates/cargo-zng/Cargo.toml
@@ -40,7 +40,7 @@ anyhow = "1.0"
 dunce = "1.0"
 zng-env = { path = "../zng-env", version = "0.5.1" }
 directories = "6.0"
-quick-xml = { version = "0.37", features = ["serialize"] }
+quick-xml = { version = "0.38", features = ["serialize"] }
 
 # fmt
 regex = "1.10"

--- a/crates/zng-view/Cargo.toml
+++ b/crates/zng-view/Cargo.toml
@@ -173,7 +173,7 @@ features = ["Foundation_Collections", "System_UserProfile", "UI_ViewManagement",
 clipboard-win = { version = "5.0", features = ["std"] }
 
 [target.'cfg(not(any(windows, target_os = "android")))'.dependencies]
-arboard = "3.3"
+arboard = "3.6"
 [target.'cfg(not(windows))'.dependencies]
 sys-locale = "0.3"
 

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -2179,7 +2179,8 @@ impl Api for App {
             }
             clipboard::ClipboardType::FileList => self
                 .arboard()?
-                .get_file_list()
+                .get()
+                .file_list()
                 .map_err(util::arboard_to_clip)
                 .map(|l| clipboard::ClipboardData::FileList(l)),
             clipboard::ClipboardType::Extension(_) => Err(clipboard::ClipboardError::NotSupported),

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -2182,7 +2182,7 @@ impl Api for App {
                 .get()
                 .file_list()
                 .map_err(util::arboard_to_clip)
-                .map(|l| clipboard::ClipboardData::FileList(l)),
+                .map(clipboard::ClipboardData::FileList),
             clipboard::ClipboardType::Extension(_) => Err(clipboard::ClipboardError::NotSupported),
             _ => Err(clipboard::ClipboardError::NotSupported),
         }

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -2177,7 +2177,11 @@ impl Api for App {
                 ));
                 Ok(clipboard::ClipboardData::Image(id))
             }
-            clipboard::ClipboardType::FileList => Err(clipboard::ClipboardError::NotSupported),
+            clipboard::ClipboardType::FileList => self
+                .arboard()?
+                .get_file_list()
+                .map_err(util::arboard_to_clip)
+                .map(|l| clipboard::ClipboardData::FileList(l)),
             clipboard::ClipboardType::Extension(_) => Err(clipboard::ClipboardError::NotSupported),
             _ => Err(clipboard::ClipboardError::NotSupported),
         }


### PR DESCRIPTION
In particular `arboard` enables `CLIPBOARD.file_list` in Linux and macOS.