### PR TITLE
Fix release builds with default features

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,6 +410,10 @@ jobs:
         uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
         with:
           run: cargo do test --render
+      - run: cargo do clean
+        if: ${{ github.event.inputs.skip_checks != 'true' }}
+      - run: cargo do build -e focus --release
+        if: ${{ github.event.inputs.skip_checks != 'true' }}
       - run: cargo clean
         if: ${{ github.event.inputs.skip_tests != 'true' }}
   
@@ -451,6 +455,10 @@ jobs:
         if: ${{ github.event.inputs.skip_tests != 'true' }}
       - run: cargo do test --render
         if: ${{ github.event.inputs.skip_tests != 'true' }}
+      - run: cargo do clean
+        if: ${{ github.event.inputs.skip_checks != 'true' }}
+      - run: cargo do build -e focus --release
+        if: ${{ github.event.inputs.skip_checks != 'true' }}
       - run: cargo clean
         if: ${{ github.event.inputs.skip_tests != 'true' }}
   test-macos:
@@ -496,6 +504,10 @@ jobs:
         if: ${{ github.event.inputs.skip_tests != 'true' }}
       - run: cargo do test --render
         if: ${{ github.event.inputs.skip_tests != 'true' }}
+      - run: cargo do clean
+        if: ${{ github.event.inputs.skip_checks != 'true' }}
+      - run: cargo do build -e focus --release
+        if: ${{ github.event.inputs.skip_checks != 'true' }}
       - run: cargo clean
         if: ${{ github.event.inputs.skip_tests != 'true' }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix release builds with default features.
 
 # 0.15.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Unreleased
 
-* Add `"dyn_node"` to `zng` default features to avoid linking issues in release builds.
+* Add `"dyn_node"` to `zng` default features to avoid build issues in release builds.
   - GitHub workflow runners can't handle building with all the generics inlining that happens without this feature.
   - This is a better default for test release builds, the performance hit is negligible.
   - Production builds should disable default features and configure depending on need, see [`docs/optimize-release.md`] for details.
 * Fix release builds with default features.
 * Fix `zng-wgt-inspector` builds without `"live"` feature.
+
+[`docs/optimize-release.md`]: ./docs/optimize-release.md
 
 # 0.15.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Unreleased
 
+* Add `"dyn_node"` to `zng` default features to avoid linking issues in release builds.
+  - GitHub workflow runners can't handle building with all the generics inlining that happens without this feature.
+  - This is a better default for test release builds, the performance hit is negligible.
+  - Production builds should disable default features and configure depending on need, see [`docs/optimize-release.md`] for details.
 * Fix release builds with default features.
+* Fix `zng-wgt-inspector` builds without `"live"` feature.
 
 # 0.15.6
 

--- a/crates/zng-wgt-inspector/src/lib.rs
+++ b/crates/zng-wgt-inspector/src/lib.rs
@@ -18,7 +18,8 @@ pub mod debug;
 
 mod live;
 
-pub use live::data_model::{INSPECTOR, InspectedInfo, InspectedTree, InspectedWidget, InspectorWatcherBuilder, WeakInspectedTree};
+#[cfg(feature = "live")]
+pub use crate::live::data_model::{INSPECTOR, InspectedInfo, InspectedTree, InspectedWidget, InspectorWatcherBuilder, WeakInspectedTree};
 
 command! {
     /// Represent the window **inspect** action.

--- a/crates/zng/Cargo.toml
+++ b/crates/zng/Cargo.toml
@@ -48,6 +48,7 @@ default = [
     "image_all",
     "button",
     "ansi_text",
+    "dyn_node",
 ]
 
 # Include the default view-process implementation.

--- a/crates/zng/Cargo.toml
+++ b/crates/zng/Cargo.toml
@@ -70,7 +70,7 @@ http = [
 # Enable the `"dyn_*"`, `"inspector"` and `"trace_recorder"` features in debug builds.
 debug_default = [
     "zng-app/debug_default",
-    "zng-wgt-inspector/debug_default",
+    "zng-wgt-inspector?/debug_default",
     "zng-wgt-scroll/debug_default",
     "zng-wgt-window/debug_default",
 ]


### PR DESCRIPTION
Fix issue identified in https://github.com/zng-ui/zng/issues/674#issuecomment-3045673571

It was two issues:

1 - `zng-wgt-inspector` was reexporting some types that are `cfg(feature = "live")` without the conditional.
2 - `zng` default feature `"debug_default"` referenced `"zng-wgt-inspector/debug_default"`, that crate is optional but because of this reference it was always included on the build.

I also did some experiments to see the time impact of adding a release build test on CI and identified another issue:

* `"dyn_node"` was not default in `zng` causing massive generics code bloat on release builds, that actually caused the build to fail on the limited runner machine Github provides.

Added `"dyn_node"` to defaults now, the CI impact is still a lot, will add a test build only on the publish workflow. A [manual test build](https://github.com/zng-ui/zng/actions/runs/16125176653/job/45500260139) of `focus` worked with these changes.