### PR TITLE
Remove warnings about `touch_config` not being implemented in Desktop OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Remove warnings about `touch_config` not being implemented in Linux, macOS and Windows.
 * Fix localization resources fallback going to different file name (take 2).
 
 # 0.15.8

--- a/crates/zng-view/src/config/gsettings.rs
+++ b/crates/zng-view/src/config/gsettings.rs
@@ -51,7 +51,8 @@ pub fn key_repeat_config() -> KeyRepeatConfig {
 }
 
 pub fn touch_config() -> TouchConfig {
-    super::other::touch_config()
+    // Gnome does not provide touch config
+    TouchConfig::default()
 }
 
 pub fn colors_config() -> ColorsConfig {

--- a/crates/zng-view/src/config/macos.rs
+++ b/crates/zng-view/src/config/macos.rs
@@ -27,7 +27,8 @@ pub fn key_repeat_config() -> KeyRepeatConfig {
 }
 
 pub fn touch_config() -> TouchConfig {
-    super::other::touch_config()
+    // macOS does not provide touch config
+    TouchConfig::default()
 }
 
 pub fn colors_config() -> ColorsConfig {

--- a/crates/zng-view/src/config/windows.rs
+++ b/crates/zng-view/src/config/windows.rs
@@ -298,7 +298,8 @@ pub fn key_repeat_config() -> KeyRepeatConfig {
 }
 
 pub fn touch_config() -> TouchConfig {
-    super::other::touch_config()
+    // Windows does not provide touch config
+    TouchConfig::default()
 }
 
 pub fn chrome_config() -> ChromeConfig {


### PR DESCRIPTION
…macOS and Windows

These OS do not provide system wide touch settings.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->