### PR TITLE
Improve `command_property!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@
     - Modify methods `Var::{set, update, modify}` now simply DEBUG log if the variable is read-only, 
       use `try_set, try_update, try_modify` to get the error.
 
+* **Breaking** `zng::command_property::command_property!` now also generates contextual property and var that enable/disable the handlers.
+    - Adds `zng::clipboard::{can_cut, can_copy, can_paste}`.
+    - Adds `zng::config::settings::can_settings`.
+    - Adds `zng::app::{can_new, can_open, can_save, can_save_as}`.
+    - Will not generate this if `enabled:` is set.
+
 * **Breaking** Refactor `MONITORS` state reporting to use variables.
 
 * Fix deserialization of `PxConstraints` failing when the `max` field is not set and format is "human readable".

--- a/crates/zng-view-api/src/types.rs
+++ b/crates/zng-view-api/src/types.rs
@@ -1065,7 +1065,6 @@ pub struct DeviceEventsFilter {
     /// Note that although the view-process will filter input device events using these flags setting
     /// just one of them may cause a general native listener to init.
     pub input: InputDeviceCapability,
-    // TODO(breaking): add audio.
 }
 impl DeviceEventsFilter {
     /// Default value, no device events are needed.

--- a/crates/zng-wgt-text/src/node.rs
+++ b/crates/zng-wgt-text/src/node.rs
@@ -300,11 +300,11 @@ impl TEXT {
     }
 
     pub(crate) fn take_rich_selection_started_by_alt(&self) -> bool {
-        std::mem::take(&mut *RICH_TEXT_SELECTION_STARTED_BY_ALT.write())
+        std::mem::take(&mut RICH_TEXT.write().selection_started_by_alt)
     }
 
     pub(crate) fn flag_rich_selection_started_by_alt(&self) {
-        *RICH_TEXT_SELECTION_STARTED_BY_ALT.write() = true;
+        RICH_TEXT.write().selection_started_by_alt = true;
     }
 }
 
@@ -501,6 +501,8 @@ pub struct RichText {
 
     /// Widgets that define the caret and selection indexes.
     pub caret: RichCaretInfo,
+
+    selection_started_by_alt: bool,
 }
 impl RichText {
     fn no_context() -> Self {
@@ -520,8 +522,6 @@ context_local! {
     static LAIDOUT_TEXT: RwLock<LaidoutText> = RwLock::new(LaidoutText::no_context());
     /// Represents a list of events send from rich text leaves to other leaves.
     static RICH_TEXT_NOTIFY: RwLock<Vec<EventUpdate>> = RwLock::new(RichText::no_dispatch_context());
-    /// TODO(breaking) refactor into RichCaretInfo private field.
-    static RICH_TEXT_SELECTION_STARTED_BY_ALT: RwLock<bool> = RwLock::new(false);
 }
 
 impl RichText {

--- a/crates/zng-wgt-text/src/node/rich.rs
+++ b/crates/zng-wgt-text/src/node/rich.rs
@@ -33,6 +33,7 @@ pub(crate) fn rich_text_node(child: impl IntoUiNode, enabled: impl IntoVar<bool>
                         index: None,
                         selection_index: None,
                     },
+                    selection_started_by_alt: false,
                 })));
                 dispatch = Some(Arc::new(RwLock::new(vec![])));
 

--- a/crates/zng-wgt-toggle/src/lib.rs
+++ b/crates/zng-wgt-toggle/src/lib.rs
@@ -437,7 +437,6 @@ fn value_impl(child: impl IntoUiNode, value: AnyVar) -> UiNode {
             if let Some(Some(true)) = checked.get_new()
                 && SCROLL_ON_SELECT_VAR.get()
             {
-                // TODO(breaking) - only scroll if parent selector scope is in view?
                 use zng_wgt_scroll::cmd::*;
                 scroll_to(WIDGET.id(), ScrollToMode::minimal(10));
             }

--- a/crates/zng/src/app.rs
+++ b/crates/zng/src/app.rs
@@ -412,7 +412,8 @@ pub use zng_app_context::{
     MappedRwLockWriteGuardOwned, ReadOnlyRwLock, RunOnDrop, RwLockReadGuardOwned, RwLockWriteGuardOwned, app_local, context_local,
 };
 pub use zng_wgt_input::cmd::{
-    NEW_CMD, OPEN_CMD, SAVE_AS_CMD, SAVE_CMD, on_new, on_open, on_pre_new, on_pre_open, on_pre_save, on_pre_save_as, on_save, on_save_as,
+    NEW_CMD, OPEN_CMD, SAVE_AS_CMD, SAVE_CMD, can_new, can_open, can_save, can_save_as, on_new, on_open, on_pre_new, on_pre_open,
+    on_pre_save, on_pre_save_as, on_save, on_save_as,
 };
 
 pub use zng_app::view_process::raw_events::{LOW_MEMORY_EVENT, LowMemoryArgs};

--- a/crates/zng/src/clipboard.rs
+++ b/crates/zng/src/clipboard.rs
@@ -108,4 +108,4 @@
 //! See [`zng_ext_clipboard`] for the full clipboard API.
 
 pub use zng_ext_clipboard::{CLIPBOARD, COPY_CMD, CUT_CMD, ClipboardError, PASTE_CMD};
-pub use zng_wgt_input::cmd::{on_copy, on_cut, on_paste, on_pre_copy, on_pre_cut, on_pre_paste};
+pub use zng_wgt_input::cmd::{can_copy, can_cut, can_paste, on_copy, on_cut, on_paste, on_pre_copy, on_pre_cut, on_pre_paste};

--- a/crates/zng/src/config.rs
+++ b/crates/zng/src/config.rs
@@ -116,7 +116,7 @@ pub mod settings {
     pub use zng_ext_config::settings::{
         CategoriesBuilder, Category, CategoryBuilder, CategoryId, SETTINGS, Setting, SettingBuilder, SettingsBuilder,
     };
-    pub use zng_wgt_input::cmd::{SETTINGS_CMD, on_pre_settings, on_settings};
+    pub use zng_wgt_input::cmd::{SETTINGS_CMD, can_settings, on_pre_settings, on_settings};
 
     /// Settings editor widget.
     ///

--- a/crates/zng/src/event.rs
+++ b/crates/zng/src/event.rs
@@ -248,7 +248,7 @@
 //! # }
 //! ```
 //!
-//! The example above declares `FOO_CMD`, `on_pre_foo` and `on_foo`. The example then declares
+//! The example above declares `FOO_CMD`, `on_pre_foo`, `on_foo`, `can_foo` and `CAN_FOO_VAR`. The example then declares
 //! a widget that sends the `FOO_CMD` to itself on init and receives it using the event properties.
 //!
 //! ## Metadata


### PR DESCRIPTION
Now generates contextual property for enabling/disabling. This is something that is almost always needed and the reason the default file commands are not being used in projects.

Also cleanup the rest of TODO(breaking)