### PR TITLE
Add view-process audio API stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@
 * Fix `Slider!` not reacting to value changes.
 * Fix inherited widget properties not showing in documentation.
 
+* **Breaking** Add unimplemented audio decoding and playback to the view-process API in preparation of a future release.
+
 # 0.15.11
 
 * Fix `DIALOG.confirm` always cancelling.

--- a/crates/zng-var/Cargo.toml
+++ b/crates/zng-var/Cargo.toml
@@ -23,7 +23,7 @@ type_names = []
 # Box closures at opportune places, such as `Var::map`, reducing the number of monomorphised types.
 #
 # This speeds-up compilation time at the cost of runtime.
-dyn_closure = [] # TODO(breaking) review this, not used after rewrite
+dyn_closure = []
 
 [dependencies]
 zng-var-proc-macros = { path = "../zng-var-proc-macros", version = "0.3.0" }

--- a/crates/zng-view-api/src/audio.rs
+++ b/crates/zng-view-api/src/audio.rs
@@ -15,6 +15,16 @@ crate::declare_id! {
     ///
     /// The View Process defines the ID.
     pub struct AudioDeviceId(_);
+
+    /// Id of a decoded audio in the cache.
+    ///
+    /// The View Process defines the ID.
+    pub struct AudioId(_);
+
+    /// Audio playback ID.
+    ///
+    /// The View Process defines the ID.
+    pub struct PlaybackId(_);
 }
 
 /// Info about an input or output device.
@@ -78,4 +88,39 @@ pub enum BufferSize {
     },
     /// Platform cannot describe buffer size for this device.
     Unknown,
+}
+
+/// Represent an audio load/decode request.
+///
+/// # Unimplemented
+///
+/// This type is a stub for a future API, it is not implemented by app-process nor the default view-process.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AudioRequest<D> {
+    /// Audio data.
+    pub data: D,
+}
+
+/// Represents an audio playback request.
+///
+/// # Unimplemented
+///
+/// This type is a stub for a future API, it is not implemented by app-process nor the default view-process.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PlaybackRequest {
+    // app-process will define a timeline of AudioId clips, with effects and such
+    // this will allow the view-process to synchronize stuff
+}
+
+/// Represents an audio playback update request.
+///
+/// # Unimplemented
+///
+/// This type is a stub for a future API, it is not implemented by app-process nor the default view-process.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PlaybackUpdateRequest {
+    // pause, stop
 }

--- a/crates/zng-view-api/src/lib.rs
+++ b/crates/zng-view-api/src/lib.rs
@@ -437,6 +437,54 @@ declare_api! {
     /// [`image_encoders`]: Api::image_encoders
     pub fn encode_image(&mut self, id: ImageId, format: Txt);
 
+    /// Cache an audio resource.
+    ///
+    /// # Unimplemented
+    ///
+    /// This method is a stub for a future API, it is not implemented by app-process nor the default view-process.
+    pub fn add_audio(&mut self, request: audio::AudioRequest<IpcBytes>) -> audio::AudioId;
+
+    /// Cache an streaming audio resource.
+    ///
+    /// The audio is decoded as bytes are buffered in.
+    ///
+    /// # Unimplemented
+    ///
+    /// This method is a stub for a future API, it is not implemented by app-process nor the default view-process.
+    pub fn add_audio_pro(&mut self, request: audio::AudioRequest<IpcBytesReceiver>) -> audio::AudioId;
+
+    /// Remove an audio from cache.
+    ///
+    /// Note that if the audio is in use by a playback it will remain in memory until the playback ends.
+    ///
+    /// # Unimplemented
+    ///
+    /// This method is a stub for a future API, it is not implemented by app-process nor the default view-process.
+    pub fn forget_audio(&mut self, id: audio::AudioId);
+
+    /// Returns a list of image decoders supported by this implementation.
+    ///
+    /// Each text is the lower-case file extension, without the dot.
+    ///
+    /// # Unimplemented
+    ///
+    /// This method is a stub for a future API, it is not implemented by app-process nor the default view-process.
+    pub fn audio_decoders(&mut self) -> Vec<Txt>;
+
+    /// Start playing audio.
+    ///
+    /// # Unimplemented
+    ///
+    /// This method is a stub for a future API, it is not implemented by app-process nor the default view-process.
+    pub fn playback(&mut self, request: audio::PlaybackRequest) -> audio::PlaybackId;
+
+    /// Update an existing playback.
+    ///
+    /// # Unimplemented
+    ///
+    /// This method is a stub for a future API, it is not implemented by app-process nor the default view-process.
+    pub fn playback_update(&mut self, id: audio::PlaybackId, request: audio::PlaybackUpdateRequest);
+
     /// Add a raw font resource to the window renderer.
     ///
     /// Returns the new font key.

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -2108,6 +2108,30 @@ impl Api for App {
         with_window_or_surface!(self, id, |w| w.delete_image(texture_id), || ())
     }
 
+    fn add_audio(&mut self, _request: audio::AudioRequest<IpcBytes>) -> audio::AudioId {
+        unimplemented!()
+    }
+
+    fn add_audio_pro(&mut self, _request: audio::AudioRequest<IpcBytesReceiver>) -> audio::AudioId {
+        unimplemented!()
+    }
+
+    fn audio_decoders(&mut self) -> Vec<Txt> {
+        unimplemented!()
+    }
+
+    fn forget_audio(&mut self, _id: audio::AudioId) {
+        unimplemented!()
+    }
+
+    fn playback(&mut self, _request: audio::PlaybackRequest) -> audio::PlaybackId {
+        unimplemented!()
+    }
+
+    fn playback_update(&mut self, _id: audio::PlaybackId, _request: audio::PlaybackUpdateRequest) {
+        unimplemented!()
+    }
+
     fn add_font_face(&mut self, id: WindowId, bytes: IpcBytes, index: u32) -> FontFaceId {
         with_window_or_surface!(self, id, |w| w.add_font_face(bytes.to_vec(), index), || FontFaceId::INVALID)
     }


### PR DESCRIPTION
Adding methods to the view-process `Api` trait is technically a breaking change so we are skipping ahead here to allow implementing audio in a future non breaking 0.16.* release.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->