### PR TITLE
Remove `fxhash` dependency

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,10 @@
 [advisories]
 ignore = [
+    # `fxhash` is unmaintained
+    #
+    # need to patch 'zng-wr-glyph-rasterizer' and `zng-webrender` first
+    "RUSTSEC-2025-0057",
+
     # `paste` is unmaintained
     #
     # already replaced in project crates, `image` dependency still use it:

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches: [ "main" ]
   workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # daily
 jobs:
   security_audit:
     runs-on: ubuntu-latest

--- a/crates/zng-view-prebuilt/Cargo.toml
+++ b/crates/zng-view-prebuilt/Cargo.toml
@@ -25,8 +25,7 @@ dunce = { version = "1.0", default-features = false }
 parking_lot = { version = "0.12", default-features = false }
 
 [build-dependencies]
-hashers = { version = "1.0", default-features = false }
-base64 = { version = "0.22", default-features = false, features = ["std"] }
+sha2 = { version = "0.10", features = ["std"], default-features = false }
 home = { version = "0.5", default-features = false }
 dunce = { version = "1.0", default-features = false }
 

--- a/crates/zng-view-prebuilt/build.rs
+++ b/crates/zng-view-prebuilt/build.rs
@@ -1,11 +1,9 @@
 use std::{
     env,
-    hash::Hasher,
     path::{Path, PathBuf},
 };
 
-use base64::Engine;
-use hashers::jenkins::spooky_hash::SpookyHasher;
+use sha2::Digest;
 
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(zng_lib_embedded)");
@@ -110,17 +108,10 @@ fn main() {
         let lib_bytes = std::fs::read(lib).unwrap();
 
         // just to identify build.
-        let mut hasher = SpookyHasher::new(u64::from_le_bytes(*b"prebuild"), u64::from_le_bytes(*b"view-lib"));
-        hasher.write(&lib_bytes);
-        let (a, b) = hasher.finish128();
-        let mut hash = [0; 16];
-        hash[..8].copy_from_slice(&a.to_le_bytes());
-        hash[8..].copy_from_slice(&b.to_le_bytes());
-
-        println!(
-            "cargo:rustc-env=ZNG_VIEW_LIB_HASH={}",
-            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(hash)
-        );
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(&lib_bytes);
+        let hash = hasher.finalize();
+        println!("cargo:rustc-env=ZNG_VIEW_LIB_HASH={hash:x}",);
     } else if is_docs_rs || PathBuf::from("../../tools/cargo-do").exists() {
         println!("cargo:warning=view prebuilt not embedded, missing '{file}', call `do prebuild`");
     } else {


### PR DESCRIPTION
`zng-webrender` still depends on it, need to patch that.

Added the advisory to ignore list, not even Mozilla is rushing to fix this, there is no actual vulnerability.