### PR TITLE
Better config for `ZOOM_TO_FIT_CMD`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
     - Before the size was sampled on render, now it is sampled before.
     - This change means any state hooked to the actual size will now update before the new size is visible on the next frame.
 
-* Add `zng::scroll::cmd::ZoomToFitRequest` for configuring the `ZOOM_TO_FIT_CMD`.
+* Improve scroll widget's `ZOOM_TO_FIT_CMD`.
+    - Add `zng::scroll::cmd::ZoomToFitRequest` for configuring if the scale change is animated.
+    - Add `Scroll::zoom_to_fit_mode` property for configuring if smaller content scales up to fit.
 
 * Add `zng::mouse::ctrl_scroll` contextual property.
     - Also strongly associated with `Scroll!` widget as `Scroll::ctrl_scroll`.

--- a/crates/zng-wgt-scroll/src/cmd.rs
+++ b/crates/zng-wgt-scroll/src/cmd.rs
@@ -264,14 +264,11 @@ command! {
 }
 
 /// Parameters for the [`ZOOM_TO_FIT_CMD`].
+///
+/// Also see the property [`zoom_to_fit_mode`].
 #[derive(Default, Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct ZoomToFitRequest {
-    /// If behaves like `ImageFit::ScaleDown` when the content is smaller them the viewport.
-    ///
-    /// By default behaves like `ImageFit::Contain` and scales up smaller contents, if this is enabled it will
-    /// only scale down larger content, smaller content scale is set to 100%.
-    pub scale_down: bool,
     /// Apply the change immediately, no easing/smooth animation.
     pub skip_animation: bool,
 }

--- a/crates/zng-wgt-scroll/src/scroll_properties.rs
+++ b/crates/zng-wgt-scroll/src/scroll_properties.rs
@@ -83,6 +83,9 @@ context_var! {
         margin: SideOffsets::new_all(0.dip()),
     };
 
+    /// Defines how the content is scaled to fit.
+    pub static ZOOM_TO_FIT_MODE_VAR: ZoomToFitMode = ZoomToFitMode::default();
+
     /// Extra space added to the viewport auto-hide rectangle.
     ///
     /// The scroll sets the viewport plus these offsets as the [`FrameBuilder::auto_hide_rect`], this value is used
@@ -351,6 +354,20 @@ pub fn smooth_scrolling(child: impl IntoUiNode, config: impl IntoVar<SmoothScrol
 #[property(CONTEXT, default(SCROLL_TO_FOCUSED_MODE_VAR), widget_impl(Scroll))]
 pub fn scroll_to_focused_mode(child: impl IntoUiNode, mode: impl IntoVar<Option<ScrollToMode>>) -> UiNode {
     with_context_var(child, SCROLL_TO_FOCUSED_MODE_VAR, mode)
+}
+
+/// Defines how the scale is changed to fit the content to the viewport.
+///
+/// The [`ZOOM_TO_FIT_CMD`] implementation uses this value to define the zoom scale needed to fit the content.
+/// By default it scales down and up to fit, setting this to `ScaleDown` will only scale down larger content and only
+/// scale up smaller content to 100%.
+///
+/// This property sets the [`ZOOM_TO_FIT_MODE_VAR`].
+///
+/// [`ZOOM_TO_FIT_CMD`]: crate::cmd::ZOOM_TO_FIT_CMD
+#[property(CONTEXT, default(ZOOM_TO_FIT_MODE_VAR), widget_impl(Scroll))]
+pub fn zoom_to_fit_mode(child: impl IntoUiNode, mode: impl IntoVar<ZoomToFitMode>) -> UiNode {
+    with_context_var(child, ZOOM_TO_FIT_MODE_VAR, mode)
 }
 
 /// Extra space added to the viewport auto-hide rectangle.

--- a/crates/zng-wgt-scroll/src/types.rs
+++ b/crates/zng-wgt-scroll/src/types.rs
@@ -1098,3 +1098,18 @@ impl_from_and_into_var! {
 #[derive(Debug, Default, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct AutoScrollArgs {}
+
+/// Defines how the scale is changed by the [`ZOOM_TO_FIT_CMD`].
+///
+/// See the [`zoom_to_fit_mode`] property for more details.
+///
+/// [`ZOOM_TO_FIT_CMD`]: crate::cmd::ZOOM_TO_FIT_CMD
+/// [`zoom_to_fit_mode`]: fn@crate::zoom_to_fit_mode
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ZoomToFitMode {
+    /// The content is scaled down or up to fit the viewport.
+    #[default]
+    Contain,
+    /// The content is only scaled down to fit the viewport. If the content is smaller them the viewport the scale is set to 100%.
+    ScaleDown,
+}

--- a/crates/zng/src/scroll.rs
+++ b/crates/zng/src/scroll.rs
@@ -63,10 +63,10 @@
 
 pub use zng_wgt_scroll::{
     LazyMode, SCROLL, Scroll, ScrollBarArgs, ScrollFrom, ScrollInfo, ScrollMode, ScrollUnitsMix, Scrollbar, ScrollbarFnMix,
-    SmoothScrolling, Thumb, WidgetInfoExt, alt_factor, auto_hide_extra, clip_to_viewport, define_viewport_unit, h_line_unit, h_page_unit,
-    h_scrollbar_fn, h_wheel_unit, lazy, line_units, max_zoom, min_zoom, mode, mouse_pan, overscroll_color, page_units,
+    SmoothScrolling, Thumb, WidgetInfoExt, ZoomToFitMode, alt_factor, auto_hide_extra, clip_to_viewport, define_viewport_unit, h_line_unit,
+    h_page_unit, h_scrollbar_fn, h_wheel_unit, lazy, line_units, max_zoom, min_zoom, mode, mouse_pan, overscroll_color, page_units,
     scroll_to_focused_mode, scrollbar_fn, scrollbar_joiner_fn, smooth_scrolling, v_line_unit, v_page_unit, v_scrollbar_fn, v_wheel_unit,
-    wheel_units, zoom_origin, zoom_size_only, zoom_touch_origin, zoom_wheel_origin, zoom_wheel_unit,
+    wheel_units, zoom_origin, zoom_size_only, zoom_to_fit_mode, zoom_touch_origin, zoom_wheel_origin, zoom_wheel_unit,
 };
 
 /// Scrollbar thumb widget.

--- a/examples/scroll/src/main.rs
+++ b/examples/scroll/src/main.rs
@@ -100,14 +100,7 @@ fn commands(mouse_pan: Var<bool>, smooth_scrolling: Var<bool>) -> UiNode {
                 ui_vec![
                     Button!(ZOOM_IN_CMD.scoped(scope)),
                     Button!(ZOOM_OUT_CMD.scoped(scope)),
-                    Button! {
-                        cmd = ZOOM_TO_FIT_CMD.scoped(scope);
-                        cmd_param = {
-                            let mut p = zng::scroll::cmd::ZoomToFitRequest::default();
-                            p.skip_animation = true;
-                            p
-                        };
-                    },
+                    Button!(ZOOM_TO_FIT_CMD.scoped(scope)),
                     Button!(ZOOM_RESET_CMD.scoped(scope)),
                     Hr!(),
                     scroll_to_zoom_btn(WidgetId::named("Lorem 2"), 200.pct()),


### PR DESCRIPTION
Configuring the fit mode using a property is more readable and fixes issue of the command not disabling when a `ScaleDown` fit was preferred and the scale was already at the fit value.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->