### PR TITLE
Fix race condition in `zng::task::SignalOnce`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix race condition in `zng::task::SignalOnce`.
+
 * Event/command notify requested during a layout pass now all run before the next render pass.
     - After a layout pass the app does an updates pass (unchanged) and then does an app events pass (new).
     - See the `zng::app` module docs for more details.


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->