### PR TITLE
Add `read` associated function for configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add `read` associated function for `zng::config::{JsonConfig, RonConfig, TomlConfig, YamlConfig}`.
+    - This is a more efficient alternative to wrapping `sync` with `ReadOnlyConfig`.
 
 # 0.16.6
 

--- a/crates/zng-ext-config/src/lib.rs
+++ b/crates/zng-ext-config/src/lib.rs
@@ -260,6 +260,9 @@ fn get_impl<T: ConfigValue, C: AnyConfig>(source: &mut C, insert: bool, key: Con
 }
 
 /// Config wrapper that only provides read-only variables from the inner config.
+///
+/// Note that you can use [`SyncConfig::read`] to open a file read-only, that is more efficient than
+/// wrapping a [`SyncConfig::sync`] with this adapter.
 pub struct ReadOnlyConfig<C: Config> {
     cfg: C,
 }

--- a/examples/config/src/main.rs
+++ b/examples/config/src/main.rs
@@ -14,7 +14,7 @@ fn load_config() {
     // settings file for the app, keys with prefix "settings." are saved here.
     let user_settings = JsonConfig::sync(zng::env::config("example-config/settings.json"));
     // entries not found in `user_settings` bind to this file first before going to embedded fallback.
-    let default_settings = ReadOnlyConfig::new(JsonConfig::sync(zng::env::res("default-settings.json")));
+    let default_settings = JsonConfig::read(zng::env::res("default-settings.json"));
 
     let settings = FallbackConfig::new(user_settings, default_settings);
     // Clone a ref that can be used to reset specific entries.


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->