### PR TITLE
Fix `cargo zng fmt` wrap instability inside macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix buttons at the top-level of `Menu!` not returning focus on click.
 * View-process now tries to guess image format in case of header decode error for an extension or mime defined format.
+* Fix `cargo zng fmt` wrap instability inside macros.
 
 # 0.17.0
 


### PR DESCRIPTION
Missed some branches in the last pull

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->