### PR TITLE
Fix `VarCapability::is_const` for contextual read-only variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `VarCapability::is_const` for contextual read-only variables.
 * Fix `IMAGES.reload` panic on error.
 * Add `IMAGES.watch` for auto reloading image that is modified.
     - Implemented in `zng::fs_watcher::IMAGES_Ext` and imported in the prelude.

--- a/crates/zng-ext-window/src/service.rs
+++ b/crates/zng-ext-window/src/service.rs
@@ -725,7 +725,8 @@ impl WINDOWS {
     /// Register the closure `extender` to be called with the root of every new window starting on the next update.
     ///
     /// The closure returns the new root node that will be passed to any other root extender until
-    /// the actual final root node is created.
+    /// the actual final root node is created. The closure is called in the [`WINDOW`] context of the new window,
+    /// so it can be used to modify the window context too.
     ///
     /// This is an advanced API that enables app wide features, like themes, to inject context in every new window. The
     /// extender is called in the context of the window, after the window creation future has completed.

--- a/crates/zng-var/src/var_impl.rs
+++ b/crates/zng-var/src/var_impl.rs
@@ -233,7 +233,7 @@ bitflags! {
 impl VarCapability {
     /// If cannot `NEW` and is not `MODIFY_CHANGES`.
     pub fn is_const(self) -> bool {
-        !self.contains(Self::NEW) && !self.contains(Self::MODIFY_CHANGES)
+        self.is_empty()
     }
 
     /// If does not have `MODIFY` capability and is not `MODIFY_CHANGES`.

--- a/crates/zng-var/src/var_impl/contextual_var.rs
+++ b/crates/zng-var/src/var_impl/contextual_var.rs
@@ -132,6 +132,9 @@ impl ContextualVar {
             let mut ctx = self.0.ctx.write();
             if ctx.1 != id {
                 ctx.0 = self.0.init.lock().init();
+                if ctx.0.capabilities().is_contextual() {
+                    ctx.0 = ctx.0.current_context();
+                }
                 ctx.1 = id;
             }
             let ctx = parking_lot::RwLockWriteGuard::downgrade(ctx);


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->