### PR TITLE
Contextual named styles + minor changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add `"deadlock_detection"` to default `"dev"` feature.
+* Style more widgets inside `Menu!` root.
 
 # 0.17.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+* **Experiment** Refactor named styles to be contextual like the default style.
+    - **Deprecated** `toggle::ComboStyle`. Now style with `toggle::COMBO_STYLE_FN_VAR`.
+    - Added `toggle::{combo_style_fn, DefaultComboStyle}` for theming combo-boxes.
+    - !!: Experiment, will be removed or completed before next release.
+
 * Add `"deadlock_detection"` to default `"dev"` feature.
 * Style more widgets inside `Menu!` root.
 

--- a/crates/zng-app/src/shortcut.rs
+++ b/crates/zng-app/src/shortcut.rs
@@ -588,7 +588,7 @@ bitflags! {
         /// Any "logo" key.
         ///
         /// This is the "windows" key on PC and "command" key on Mac.
-        const LOGO = 0b1100_0000;
+        const LOGO = 0b1100_0000; // TODO(breaking) rename to SUPER
     }
 }
 impl ModifiersState {

--- a/crates/zng-wgt-menu/src/lib.rs
+++ b/crates/zng-wgt-menu/src/lib.rs
@@ -94,8 +94,6 @@ pub fn has_open(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNode {
 
 /// Default [`Menu!`] style.
 ///
-/// Gives the button a *menu-item* look.
-///
 /// [`Menu!`]: struct@Menu
 #[widget($crate::DefaultStyle)]
 pub struct DefaultStyle(Style);

--- a/crates/zng-wgt-settings/src/view_fn.rs
+++ b/crates/zng-wgt-settings/src/view_fn.rs
@@ -167,7 +167,7 @@ pub fn default_categories_list_mobile_fn(args: CategoriesListArgs) -> UiNode {
     let items = ArcNode::new(args.items);
     Toggle! {
         zng_wgt::margin = 4;
-        style_fn = zng_wgt_toggle::ComboStyle!();
+        style_fn = zng_wgt_toggle::COMBO_STYLE_FN_VAR;
         child = Text! {
             txt =
                 SETTINGS

--- a/crates/zng/Cargo.toml
+++ b/crates/zng/Cargo.toml
@@ -82,6 +82,7 @@ dev = [
     "trace_widget",
     "trace_recorder",
     "var_type_names",
+    "deadlock_detection",
 ]
 
 # Include the default view-process implementation.

--- a/crates/zng/src/lib.rs
+++ b/crates/zng/src/lib.rs
@@ -1001,6 +1001,9 @@ mod defaults {
                     #[cfg(feature = "inspector")]
                     let child = zng_wgt_inspector::inspector(child, zng_wgt_inspector::live_inspector(true));
 
+                    #[cfg(feature = "menu")]
+                    let child = zng_wgt_menu::style_fn(child, crate::style::style_fn!(|_| crate::menu::DefaultStyle!()));
+
                     child
                 });
                 tracing::debug!("defaults init, root_extender set");

--- a/crates/zng/src/menu.rs
+++ b/crates/zng/src/menu.rs
@@ -93,7 +93,10 @@ pub use zng_wgt_menu::{
     ButtonStyle, IconButtonStyle, Menu, ToggleStyle, icon, icon_fn, panel_fn, shortcut_spacing, shortcut_txt, style_fn,
 };
 
-use crate::{widget::{widget, widget_set}, style::style_fn};
+use crate::{
+    style::style_fn,
+    widget::{widget, widget_set},
+};
 
 /// Default [`Menu!`] style.
 ///
@@ -114,7 +117,7 @@ impl DefaultStyle {
 }
 
 /// Style applied to all [`TextInput!`] widgets inside [`Menu!`] root.
-/// 
+///
 /// Gives the input a *toolbar-item* look.
 ///
 /// [`TextInput!`]: struct@crate::text_input::TextInput

--- a/crates/zng/src/menu.rs
+++ b/crates/zng/src/menu.rs
@@ -90,8 +90,47 @@
 //! See [`zng_wgt_menu`] for the full widget API.
 
 pub use zng_wgt_menu::{
-    ButtonStyle, DefaultStyle, IconButtonStyle, Menu, ToggleStyle, icon, icon_fn, panel_fn, shortcut_spacing, shortcut_txt, style_fn,
+    ButtonStyle, IconButtonStyle, Menu, ToggleStyle, icon, icon_fn, panel_fn, shortcut_spacing, shortcut_txt, style_fn,
 };
+
+use crate::{widget::{widget, widget_set}, style::style_fn};
+
+/// Default [`Menu!`] style.
+///
+/// Extends [`zng_wgt_menu::DefaultStyle!`] to cover more widgets. This is set as default in the `APP.default` using a window root extender.
+///
+/// [`Menu!`]: struct@Menu
+/// [`zng_wgt_menu::DefaultStyle!`]: struct@zng_wgt_menu::DefaultStyle
+#[widget($crate::menu::DefaultStyle)]
+pub struct DefaultStyle(zng_wgt_menu::DefaultStyle);
+impl DefaultStyle {
+    fn widget_intrinsic(&mut self) {
+        widget_set! {
+            self;
+            #[cfg(feature = "text_input")]
+            crate::text_input::style_fn = style_fn!(|_| TextInputStyle!());
+        }
+    }
+}
+
+/// Style applied to all [`TextInput!`] widgets inside [`Menu!`] root.
+/// 
+/// Gives the input a *toolbar-item* look.
+///
+/// [`TextInput!`]: struct@crate::text_input::TextInput
+/// [`Menu!`]: struct@Menu
+#[cfg(feature = "text_input")]
+#[widget($crate::menu::TextInputStyle)]
+pub struct TextInputStyle(crate::text_input::DefaultStyle);
+impl TextInputStyle {
+    fn widget_intrinsic(&mut self) {
+        widget_set! {
+            self;
+            zng::layout::padding = 2;
+            // !!: TODO return focus on enter
+        }
+    }
+}
 
 /// Submenu widget and properties.
 ///

--- a/crates/zng/src/toggle.rs
+++ b/crates/zng/src/toggle.rs
@@ -141,14 +141,14 @@
 //!
 //! ## Combo
 //!
-//! The [`ComboStyle!`](struct@ComboStyle) together with the [`checked_popup`](struct@Toggle#method.checked_popup) property can be used
+//! The [`COMBO_STYLE_FN_VAR`] together with the [`checked_popup`](struct@Toggle#method.checked_popup) property can be used
 //! to declare a combo box, that is a toggle for a drop down that contains another toggle selector context that selects a value.
 //!
 //! Note that the `checked_popup` setups the `checked` state, you cannot set one of the other checked properties in the same
 //! widget.
 //!
 //! The example below declares a combo box with a `TextInput!` content, users can type a custom option or open the popup and pick
-//! an option. Note that the `ComboStyle!` also restyles `Toggle!` inside the popup to look like a menu item.
+//! an option. Note that this also restyles `Toggle!` inside the popup to look like a menu item.
 //!
 //! ```
 //! use zng::prelude::*;
@@ -162,7 +162,7 @@
 //!         txt = txt.clone();
 //!         gesture::on_click = hn!(|a: &gesture::ClickArgs| a.propagation().stop());
 //!     };
-//!     style_fn = toggle::ComboStyle!();
+//!     style_fn = toggle::COMBO_STYLE_FN_VAR;
 //!
 //!     checked_popup = wgt_fn!(|_| popup::Popup! {
 //!         id = "popup";
@@ -186,10 +186,13 @@
 //! See [`zng_wgt_toggle`] for the full widget API.
 
 pub use zng_wgt_toggle::{
-    CheckStyle, ComboStyle, DefaultStyle, IS_CHECKED_VAR, LightStyle, RadioStyle, Selector, SelectorError, SelectorImpl, SwitchStyle,
-    Toggle, check_spacing, combo_spacing, deselect_on_deinit, deselect_on_new, is_checked, radio_spacing, scroll_on_select, select_on_init,
-    select_on_new, selector, style_fn, switch_spacing, tristate,
+    COMBO_STYLE_FN_VAR, CheckStyle, DefaultComboStyle, DefaultStyle, IS_CHECKED_VAR, LightStyle, RadioStyle, Selector, SelectorError,
+    SelectorImpl, SwitchStyle, Toggle, check_spacing, combo_spacing, combo_style_fn, deselect_on_deinit, deselect_on_new, is_checked,
+    radio_spacing, scroll_on_select, select_on_init, select_on_new, selector, style_fn, switch_spacing, tristate,
 };
+
+#[allow(deprecated)] // TODO(breaking)
+pub use zng_wgt_toggle::ComboStyle;
 
 /// Toggle commands.
 pub mod cmd {

--- a/crates/zng/src/undo.rs
+++ b/crates/zng/src/undo.rs
@@ -19,7 +19,7 @@
 //!     let cmd = op.cmd().undo_scoped();
 //!
 //!     Toggle! {
-//!         style_fn = toggle::ComboStyle!();
+//!         style_fn = toggle::COMBO_STYLE_FN_VAR;
 //!
 //!         widget::enabled = cmd.flat_map(|c| c.is_enabled());
 //!

--- a/examples/button/src/main.rs
+++ b/examples/button/src/main.rs
@@ -141,7 +141,7 @@ fn split_button() -> UiNode {
     let split_count = var(0u32);
 
     Toggle! {
-        style_fn = toggle::ComboStyle!();
+        style_fn = toggle::COMBO_STYLE_FN_VAR;
 
         on_click = hn!(split_count, |_| {
             tracing::info!("Clicked split part");
@@ -240,7 +240,7 @@ fn combo_box() -> UiNode {
             txt = txt.clone();
             gesture::on_click = hn!(|a: &ClickArgs| a.propagation().stop());
         };
-        style_fn = toggle::ComboStyle!();
+        style_fn = toggle::COMBO_STYLE_FN_VAR;
 
         checked_popup = wgt_fn!(|_| popup::Popup! {
             id = "popup";

--- a/examples/text/src/editor.rs
+++ b/examples/text/src/editor.rs
@@ -136,7 +136,7 @@ fn text_editor_menu(editor: Arc<TextEditor>) -> UiNode {
         let cmd = op.cmd().undo_scoped();
 
         Toggle! {
-            style_fn = toggle::ComboStyle!();
+            style_fn = toggle::COMBO_STYLE_FN_VAR;
 
             widget::enabled = cmd.flat_map(|c| c.is_enabled());
 

--- a/examples/window/src/main.rs
+++ b/examples/window/src/main.rs
@@ -321,7 +321,7 @@ fn state() -> UiNode {
 
 fn exclusive_mode() -> UiNode {
     Toggle! {
-        style_fn = toggle::ComboStyle!();
+        style_fn = toggle::COMBO_STYLE_FN_VAR;
         corner_radius = (0, 0, 4, 4);
 
         tooltip = Tip!(Text!("Exclusive video mode"));


### PR DESCRIPTION
* Style `TextInput!` inside `Menu!`.
* Add `"deadlock_detection"` to default (`"dev"`) features. This has minimal perf impact in debug builds.
* Try new way of declaring named styles. 