### PR TITLE
Upgrade `subscribe_when`  to use the full `VarHookArgs`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* **Breaking** Variable `subscribe_when` and related methods now have access to the full `VarHookArgs`.
+
 * Refactor `Img`, it is now a normal value.
     - Fixes `ImageVar` sometimes not updating correctly in complex bindings.
     - **Breaking** Replaced advanced `ViewImage` with `ViewImageHandle`.


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->