### PR TITLE
Rename `Img` to `ImageEntry`

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -13,4 +13,7 @@ ignore = [
     #
     # remove this ignore when all dependencies are fixes
     "RUSTSEC-2024-0436",
+
+    # See https://github.com/zng-ui/zng/pull/885
+    "RUSTSEC-2025-0141",
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* **Breaking** Rename `Img` to `ImageEntry`.
+
 * **Breaking** Variable `subscribe_when` and related methods now have access to the full `VarHookArgs`.
 
 * Refactor `Img`, it is now a normal value.

--- a/crates/zng-ext-clipboard/src/lib.rs
+++ b/crates/zng-ext-clipboard/src/lib.rs
@@ -19,7 +19,7 @@ use zng_app::{
     view_process::{VIEW_PROCESS, ViewClipboard, ViewImageHandle},
 };
 use zng_app_context::app_local;
-use zng_ext_image::{IMAGES, ImageVar, ImageEntry};
+use zng_ext_image::{IMAGES, ImageEntry, ImageVar};
 use zng_task::channel::{ChannelError, IpcBytes};
 use zng_txt::{ToTxt, Txt};
 use zng_var::{ResponderVar, ResponseVar, response_var};

--- a/crates/zng-ext-clipboard/src/lib.rs
+++ b/crates/zng-ext-clipboard/src/lib.rs
@@ -19,7 +19,7 @@ use zng_app::{
     view_process::{VIEW_PROCESS, ViewClipboard, ViewImageHandle},
 };
 use zng_app_context::app_local;
-use zng_ext_image::{IMAGES, ImageVar, Img};
+use zng_ext_image::{IMAGES, ImageVar, ImageEntry};
 use zng_task::channel::{ChannelError, IpcBytes};
 use zng_txt::{ToTxt, Txt};
 use zng_var::{ResponderVar, ResponseVar, response_var};
@@ -77,7 +77,7 @@ app_local! {
 #[derive(Default)]
 struct ClipboardService {
     text: ClipboardData<Txt, Txt>,
-    image: ClipboardData<ImageVar, Img>,
+    image: ClipboardData<ImageVar, ImageEntry>,
     paths: ClipboardData<Vec<PathBuf>, Vec<PathBuf>>,
     ext: ClipboardData<IpcBytes, (Txt, IpcBytes)>,
 }
@@ -256,7 +256,7 @@ impl CLIPBOARD {
     ///
     /// Returns a response var that updates to `Ok(true)` is the text is put on the clipboard,
     /// `Ok(false)` if another request made on the same update pass replaces this one or `Err(ClipboardError)`.
-    pub fn set_image(&self, img: Img) -> ResponseVar<Result<bool, ClipboardError>> {
+    pub fn set_image(&self, img: ImageEntry) -> ResponseVar<Result<bool, ClipboardError>> {
         CLIPBOARD_SV.write().image.request(img)
     }
 

--- a/crates/zng-ext-image/src/lib.rs
+++ b/crates/zng-ext-image/src/lib.rs
@@ -88,7 +88,7 @@ impl IMAGES {
 
     /// Returns a dummy image that reports it is loaded or an error.
     pub fn dummy(&self, error: Option<Txt>) -> ImageVar {
-        var(Img::new_empty(error.unwrap_or_default())).read_only()
+        var(ImageEntry::new_empty(error.unwrap_or_default())).read_only()
     }
 
     /// Cache or load an image file from a file system `path`.
@@ -173,7 +173,7 @@ impl IMAGES {
         options: ImageOptions,
         limits: Option<ImageLimits>,
     ) -> ImageVar {
-        let img = var(Img::new_empty(Txt::from_static("")));
+        let img = var(ImageEntry::new_empty(Txt::from_static("")));
         task::spawn(async_clmv!(img, {
             let source = source.await;
             let actual_img = service::image(source, options, limits);
@@ -221,7 +221,7 @@ impl IMAGES {
     }
 
     /// Gets the cache key of an image.
-    pub fn cache_key(&self, image: &Img) -> Option<ImageHash> {
+    pub fn cache_key(&self, image: &ImageEntry) -> Option<ImageHash> {
         if let Some(key) = &image.cache_key
             && service::contains_key(key)
         {
@@ -231,7 +231,7 @@ impl IMAGES {
     }
 
     /// If the image is cached.
-    pub fn is_cached(&self, image: &Img) -> bool {
+    pub fn is_cached(&self, image: &ImageEntry) -> bool {
         image.cache_key.as_ref().map(service::contains_key).unwrap_or(false)
     }
 

--- a/crates/zng-ext-image/src/lib.rs
+++ b/crates/zng-ext-image/src/lib.rs
@@ -10,39 +10,25 @@
 #![warn(missing_docs)]
 
 use std::{
-    env, mem,
     path::{Path, PathBuf},
     pin::Pin,
-    sync::atomic::{AtomicBool, Ordering},
 };
 
-use parking_lot::Mutex;
-use task::io::AsyncReadExt;
-use zng_app::{
-    APP, AppExtension,
-    update::EventUpdate,
-    view_process::{
-        VIEW_PROCESS, VIEW_PROCESS_INITED_EVENT, ViewImageHandle,
-        raw_events::{LOW_MEMORY_EVENT, RAW_IMAGE_DECODE_ERROR_EVENT, RAW_IMAGE_DECODED_EVENT, RAW_IMAGE_METADATA_DECODED_EVENT},
-    },
-    widget::UiTaskWidget,
-};
-use zng_app_context::app_local;
-use zng_clone_move::{async_clmv, clmv};
+use zng_app::{AppExtension, update::EventUpdate, view_process::ViewImageHandle};
+use zng_clone_move::async_clmv;
 use zng_task as task;
+use zng_task::channel::IpcBytes;
+use zng_txt::{ToTxt, Txt};
+use zng_var::{Var, var};
+use zng_view_api::image::ImageDecoded;
+
+mod service;
 
 mod types;
 pub use types::*;
 
-mod render;
 #[doc(inline)]
-pub use render::{IMAGE_RENDER, IMAGES_WINDOW, ImageRenderWindowRoot, ImageRenderWindowsService, render_retain};
-use zng_layout::unit::{ByteLength, ByteUnits, Px, PxSize};
-use zng_task::{UiTask, channel::IpcBytes};
-use zng_txt::{ToTxt, Txt, formatx};
-use zng_unique_id::{IdEntry, IdMap};
-use zng_var::{Var, WeakVar, const_var, var};
-use zng_view_api::image::{ImageDecoded, ImageEntryMetadata, ImageId, ImageMetadata, ImageRequest};
+pub use service::render::{IMAGE_RENDER, IMAGES_WINDOW, ImageRenderWindowRoot, ImageRenderWindowsService, render_retain};
 
 /// Application extension that provides an image cache.
 ///
@@ -56,820 +42,15 @@ use zng_view_api::image::{ImageDecoded, ImageEntryMetadata, ImageId, ImageMetada
 pub struct ImageManager {}
 impl AppExtension for ImageManager {
     fn event_preview(&mut self, update: &mut EventUpdate) {
-        let mut img = None;
-        // handle any ok decode
-        if let Some(args) = RAW_IMAGE_METADATA_DECODED_EVENT.on(update) {
-            img = Some((args.handle.clone(), ImageDecoded::new(args.meta.clone(), IpcBytes::default(), true)));
-        } else if let Some(args) = RAW_IMAGE_DECODED_EVENT.on(update) {
-            img = Some((args.handle.clone(), args.image.clone()));
-        }
-
-        if let Some((handle, data)) = img {
-            let images = IMAGES_SV.read();
-
-            if let Some(var) = images.find_decoding(handle.image_id()) {
-                // image is registered already, or is entry of registered
-                var.modify(move |i| i.set_data(data));
-            } else if let Some(p) = &data.meta.parent
-                && let Some(var) = images.find_decoding(p.parent)
-            {
-                // image is not registered, but is entry of image that is, insert it
-                let entry = Img::new(handle, data);
-                var.modify(move |i| {
-                    i.insert_entry(entry);
-                });
-            }
-        } else if let Some(args) = RAW_IMAGE_DECODE_ERROR_EVENT.on(update) {
-            let images = IMAGES_SV.read();
-
-            if let Some(var) = images.find_decoding(args.handle.image_id()) {
-                // image registered, update to error.
-
-                let error = args.error.clone();
-                var.modify(move |i| i.set_error(error));
-
-                if let Some(key) = var.with(|i| i.cache_key)
-                    && let Some(entry) = images.cache.get(&key)
-                {
-                    entry.error.store(true, Ordering::Relaxed);
-                }
-                // else is loading will flag on the pos update pass
-            }
-        }
-
-        if let Some(args) = VIEW_PROCESS_INITED_EVENT.on(update) {
-            let mut images = IMAGES_SV.write();
-            let images = &mut *images;
-            images.cleanup_not_cached(true);
-            images.download_accept.clear();
-
-            let mut decoding_interrupted = mem::take(&mut images.decoding);
-            for (img_var, max_decoded_len, downscale, mask, entries) in images
-                .cache
-                .values()
-                .map(|e| (e.image.clone(), e.max_decoded_len, &e.downscale, e.mask, e.entries))
-                .chain(
-                    images
-                        .not_cached
-                        .iter()
-                        .filter_map(|e| e.image.upgrade().map(|v| (v, e.max_decoded_len, &e.downscale, e.mask, e.entries))),
-                )
-            {
-                let img = img_var.get();
-                let old_handle = img.view_handle();
-
-                if !old_handle.is_dummy() {
-                    if old_handle.view_process_gen() == args.generation {
-                        continue; // already recovered, can this happen?
-                    }
-                    if let Some(e) = img.error() {
-                        // respawned, but image was an error.
-                        img_var.set(Img::new_empty(e));
-                    } else if let Some(task_i) = decoding_interrupted
-                        .iter()
-                        .position(|e| e.image.with(|img| img.view_handle() == old_handle))
-                    {
-                        let task = decoding_interrupted.swap_remove(task_i);
-                        // respawned, but image was decoding, need to restart decode.
-                        let mut request = ImageRequest::new(
-                            task.format.clone(),
-                            task.data.clone(),
-                            max_decoded_len.0 as u64,
-                            downscale.clone(),
-                            mask,
-                        );
-                        request.entries = entries;
-                        match VIEW_PROCESS.add_image(request) {
-                            Ok(img) => {
-                                img_var.set(Img::new_loading(img));
-                            }
-                            Err(_) => { /*will receive another event.*/ }
-                        }
-                        images.decoding.push(ImageDecodingTask {
-                            format: task.format.clone(),
-                            data: task.data.clone(),
-                            image: img_var,
-                        });
-                    } else {
-                        // respawned and image was loaded.
-
-                        let img_format = if img.is_mask() {
-                            ImageDataFormat::A8 { size: img.size() }
-                        } else {
-                            ImageDataFormat::Bgra8 {
-                                size: img.size(),
-                                density: img.density(),
-                                original_color_type: img.original_color_type(),
-                            }
-                        };
-
-                        let entries = img.entries();
-
-                        let data = img.pixels().unwrap();
-                        let request = ImageRequest::new(img_format.clone(), data.clone(), max_decoded_len.0 as u64, None, mask);
-                        let img = match VIEW_PROCESS.add_image(request) {
-                            Ok(img) => img,
-                            Err(_) => return, // we will receive another event.
-                        };
-                        let mut img = Img::new_loading(img);
-
-                        fn add_entries(max_decoded_len: ByteLength, mask: Option<ImageMaskMode>, entries: Vec<ImageVar>, img: &mut Img) {
-                            for (i, entry) in entries.into_iter().enumerate() {
-                                let entry = entry.get();
-                                let entry_handle = entry.view_handle();
-                                if !entry_handle.is_dummy() {
-                                    if entry.is_loaded() {
-                                        let img_format = if img.is_mask() {
-                                            ImageDataFormat::A8 { size: entry.size() }
-                                        } else {
-                                            ImageDataFormat::Bgra8 {
-                                                size: entry.size(),
-                                                density: entry.density(),
-                                                original_color_type: entry.original_color_type(),
-                                            }
-                                        };
-                                        let data = entry.pixels().unwrap();
-                                        let mut request =
-                                            ImageRequest::new(img_format.clone(), data.clone(), max_decoded_len.0 as u64, None, mask);
-                                        request.parent = Some(ImageEntryMetadata::new(img.view_handle().image_id(), i, entry.entry_kind()));
-                                        let entry_img = match VIEW_PROCESS.add_image(request) {
-                                            Ok(img) => img,
-                                            Err(_) => return, // we will receive another event.
-                                        };
-                                        let entry_img = img.insert_entry(Img::new_loading(entry_img));
-
-                                        add_entries(max_decoded_len, mask, entry.entries(), &mut entry_img.get());
-                                        continue;
-                                    } else if entry.is_error() {
-                                        img.insert_entry(entry);
-                                        continue;
-                                    }
-                                }
-                                tracing::warn!("respawn not implemented for multi entry image partially decoded on crash");
-                            }
-                        }
-                        add_entries(max_decoded_len, mask, entries, &mut img);
-
-                        img_var.set(img);
-
-                        images.decoding.push(ImageDecodingTask {
-                            format: img_format,
-                            data,
-                            image: img_var,
-                        });
-                    }
-                } else if let Some(task_i) = decoding_interrupted.iter().position(|e| e.image.var_eq(&img_var)) {
-                    // respawned, but image had not started decoding, start it now.
-                    let task = decoding_interrupted.swap_remove(task_i);
-                    let mut request = ImageRequest::new(
-                        task.format.clone(),
-                        task.data.clone(),
-                        max_decoded_len.0 as u64,
-                        downscale.clone(),
-                        mask,
-                    );
-                    request.entries = entries;
-                    match VIEW_PROCESS.add_image(request) {
-                        Ok(img) => {
-                            img_var.set(Img::new_loading(img));
-                        }
-                        Err(_) => { /*will receive another event.*/ }
-                    }
-                    images.decoding.push(ImageDecodingTask {
-                        format: task.format.clone(),
-                        data: task.data.clone(),
-                        image: img_var,
-                    });
-                }
-                // else { *is loading, will continue normally in self.update_preview()* }
-            }
-        } else if LOW_MEMORY_EVENT.on(update).is_some() {
-            IMAGES.clean_all();
-        } else {
-            IMAGES_SV.write().event_preview_render(update);
-        }
+        service::on_app_event_preview(update);
     }
 
     fn update_preview(&mut self) {
-        // update loading tasks:
-
-        let mut images = IMAGES_SV.write();
-        let mut loading = Vec::with_capacity(images.loading.len());
-        let loading_tasks = mem::take(&mut images.loading);
-        let mut extensions = mem::take(&mut images.extensions);
-        drop(images); // extensions can use IMAGES
-
-        'loading_tasks: for mut t in loading_tasks {
-            t.task.get_mut().update();
-            match t.task.into_inner().into_result() {
-                Ok(d) => {
-                    match d.r {
-                        Ok(data) => {
-                            for ext in &mut extensions {
-                                if let Some(img) = ext.image_data(t.max_decoded_len, &t.key, &data, &d.format, &t.options) {
-                                    img.set_bind(&t.image).perm();
-                                    t.image.hold(img).perm();
-                                    continue 'loading_tasks;
-                                }
-                            }
-
-                            if VIEW_PROCESS.is_available() {
-                                // success and we have a view-process.
-                                let mut request = ImageRequest::new(
-                                    d.format.clone(),
-                                    data.clone(),
-                                    t.max_decoded_len.0 as u64,
-                                    t.options.downscale.clone(),
-                                    t.options.mask,
-                                );
-                                request.entries = t.options.entries;
-                                match VIEW_PROCESS.add_image(request) {
-                                    Ok(img) => {
-                                        // request sent, add to `decoding` will receive
-                                        // image decoded events
-                                        t.image.modify(move |v| {
-                                            v.set_handle(img);
-                                        });
-                                    }
-                                    Err(_) => {
-                                        // will recover in VIEW_PROCESS_INITED_EVENT
-                                    }
-                                }
-                                IMAGES_SV.write().decoding.push(ImageDecodingTask {
-                                    format: d.format,
-                                    data,
-                                    image: t.image,
-                                });
-                            } else {
-                                // success, but we are only doing `load_in_headless` validation.
-                                t.image.modify(move |v| {
-                                    let data = ImageDecoded::new(
-                                        ImageMetadata::new(ImageId::INVALID, PxSize::splat(Px(1)), false, ColorType::BGRA8),
-                                        IpcBytes::from_vec_blocking(vec![0, 0, 0, 0]).unwrap(),
-                                        false,
-                                    );
-                                    v.set_data(data);
-                                });
-                            }
-                        }
-                        Err(e) => {
-                            tracing::error!("load error: {e:?}");
-                            // load error.
-                            t.image.modify(move |v| {
-                                v.set_error(e);
-                            });
-
-                            // flag error for user retry
-                            if let Some(k) = &t.image.with(|img| img.cache_key)
-                                && let Some(e) = IMAGES_SV.read().cache.get(k)
-                            {
-                                e.error.store(true, Ordering::Relaxed);
-                            }
-                        }
-                    }
-                }
-                Err(task) => {
-                    loading.push(ImageLoadingTask {
-                        task: Mutex::new(task),
-                        image: t.image,
-                        max_decoded_len: t.max_decoded_len,
-                        key: t.key,
-                        options: t.options,
-                    });
-                }
-            }
-        }
-        let mut images = IMAGES_SV.write();
-        images.loading = loading;
-        images.extensions = extensions;
+        service::on_app_update_preview();
     }
 
     fn update(&mut self) {
-        let mut images = IMAGES_SV.write();
-        let images = &mut *images;
-
-        images.decoding.retain(|t| {
-            t.image.with(|i| {
-                let retain = i.is_loading() || i.has_loading_entries();
-
-                if !retain
-                    && i.is_error()
-                    && let Some(key) = i.cache_key
-                    && let Some(entry) = images.cache.get_mut(&key)
-                {
-                    *entry.error.get_mut() = true;
-                }
-
-                retain
-            })
-        });
-
-        images.update_render();
-    }
-}
-
-app_local! {
-    static IMAGES_SV: ImagesService = {
-        APP.extensions().require::<ImageManager>();
-        ImagesService::new()
-    };
-}
-
-struct ImageLoadingTask {
-    task: Mutex<UiTask<ImageData>>,
-    image: Var<Img>,
-    max_decoded_len: ByteLength,
-    key: ImageHash,
-    options: ImageOptions,
-}
-
-struct ImageDecodingTask {
-    format: ImageDataFormat,
-    data: IpcBytes,
-    image: Var<Img>,
-}
-
-struct CacheEntry {
-    image: Var<Img>,
-    error: AtomicBool,
-    max_decoded_len: ByteLength,
-    downscale: Option<ImageDownscaleMode>,
-    mask: Option<ImageMaskMode>,
-    entries: ImageEntriesMode,
-}
-
-struct NotCachedEntry {
-    image: WeakVar<Img>,
-    max_decoded_len: ByteLength,
-    downscale: Option<ImageDownscaleMode>,
-    mask: Option<ImageMaskMode>,
-    entries: ImageEntriesMode,
-}
-
-struct ImagesService {
-    load_in_headless: Var<bool>,
-    limits: Var<ImageLimits>,
-
-    download_accept: Txt,
-    extensions: Vec<Box<dyn ImagesExtension>>,
-
-    loading: Vec<ImageLoadingTask>,
-    decoding: Vec<ImageDecodingTask>,
-    cache: IdMap<ImageHash, CacheEntry>,
-    not_cached: Vec<NotCachedEntry>,
-
-    render: render::ImagesRender,
-}
-impl ImagesService {
-    fn new() -> Self {
-        Self {
-            load_in_headless: var(false),
-            limits: var(ImageLimits::default()),
-            extensions: vec![],
-            loading: vec![],
-            decoding: vec![],
-            download_accept: Txt::from_static(""),
-            cache: IdMap::new(),
-            not_cached: vec![],
-            render: render::ImagesRender::default(),
-        }
-    }
-
-    /// Associate the `handle` with the `key` or return it with the already existing image if the `key` already has an entry.
-    #[allow(clippy::result_large_err)]
-    fn register(
-        &mut self,
-        key: Option<ImageHash>,
-        image: (ViewImageHandle, ImageDecoded),
-        error: Txt,
-    ) -> std::result::Result<ImageVar, ((ViewImageHandle, ImageDecoded), ImageVar)> {
-        let limits = self.limits.get();
-        let limits = ImageLimits {
-            max_encoded_len: limits.max_encoded_len,
-            max_decoded_len: limits.max_decoded_len.max(image.1.pixels.len().bytes()),
-            allow_path: PathFilter::BlockAll,
-            #[cfg(feature = "http")]
-            allow_uri: UriFilter::BlockAll,
-        };
-
-        let (handle, image) = image;
-        let is_error = !error.is_empty();
-        let is_loading = !is_error && (image.partial.is_some() || image.pixels.is_empty());
-
-        if let Some(key) = key {
-            match self.cache.entry(key) {
-                IdEntry::Occupied(e) => Err(((handle, image), e.get().image.read_only())),
-                IdEntry::Vacant(e) => {
-                    let is_mask = image.meta.is_mask;
-                    let format = if is_mask {
-                        ImageDataFormat::A8 { size: image.meta.size }
-                    } else {
-                        ImageDataFormat::Bgra8 {
-                            size: image.meta.size,
-                            density: image.meta.density,
-                            original_color_type: image.meta.original_color_type.clone(),
-                        }
-                    };
-                    let img_var = var(Img::new(handle, image));
-                    if is_loading {
-                        self.decoding.push(ImageDecodingTask {
-                            format,
-                            data: IpcBytes::default(),
-                            image: img_var.clone(),
-                        });
-                    }
-
-                    Ok(e.insert(CacheEntry {
-                        error: AtomicBool::new(is_error),
-                        image: img_var,
-                        max_decoded_len: limits.max_decoded_len,
-                        downscale: None,
-                        mask: if is_mask { Some(ImageMaskMode::A) } else { None },
-                        entries: ImageEntriesMode::PRIMARY,
-                    })
-                    .image
-                    .read_only())
-                }
-            }
-        } else if is_loading {
-            let is_mask = image.meta.is_mask;
-            let image = var(Img::new(handle, image));
-            self.not_cached.push(NotCachedEntry {
-                image: image.downgrade(),
-                max_decoded_len: limits.max_decoded_len,
-                downscale: None,
-                mask: if is_mask { Some(ImageMaskMode::A) } else { None },
-                entries: ImageEntriesMode::PRIMARY,
-            });
-            todo!()
-        } else {
-            // not cached and already loaded
-            Ok(const_var(Img::new(handle, image)))
-        }
-    }
-
-    fn detach(&mut self, image: ImageVar) -> ImageVar {
-        if let Some(key) = &image.with(|i| i.cache_key) {
-            let decoded_size = image.with(|img| img.pixels().map(|b| b.len()).unwrap_or(0).bytes());
-            let mut max_decoded_len = self.limits.with(|l| l.max_decoded_len.max(decoded_size));
-            let mut downscale = None;
-            let mut mask = None;
-            let mut entries = ImageEntriesMode::PRIMARY;
-
-            if let Some(e) = self.cache.get(key) {
-                max_decoded_len = e.max_decoded_len;
-                downscale = e.downscale.clone();
-                mask = e.mask;
-                entries = e.entries;
-
-                // is cached, `clean` if is only external reference.
-                if image.strong_count() == 2 {
-                    self.cache.remove(key);
-                }
-            }
-
-            // remove `cache_key` from image, this clones the `Img` only-if is still in cache.
-            let mut img = image.get();
-            img.cache_key = None;
-            let img = var(img);
-            self.not_cached.push(NotCachedEntry {
-                image: img.downgrade(),
-                max_decoded_len,
-                downscale,
-                mask,
-                entries,
-            });
-            img.read_only()
-        } else {
-            // already not cached
-            image
-        }
-    }
-
-    fn restore_extensions(&mut self, mut extensions: Vec<Box<dyn ImagesExtension>>) {
-        extensions.append(&mut self.extensions);
-        self.extensions = extensions;
-    }
-
-    fn remove(mut extensions: Vec<Box<dyn ImagesExtension>>, mut key: ImageHash, mut purge: bool) -> bool {
-        for ext in &mut extensions {
-            if !ext.remove(&mut key, &mut purge) {
-                IMAGES_SV.write().restore_extensions(extensions);
-                return false;
-            }
-        }
-        let mut sv = IMAGES_SV.write();
-        sv.restore_extensions(extensions);
-        sv.remove_impl(key, purge)
-    }
-    fn remove_impl(&mut self, key: ImageHash, purge: bool) -> bool {
-        if purge || self.cache.get(&key).map(|v| v.image.strong_count() > 1).unwrap_or(false) {
-            self.cache.remove(&key).is_some()
-        } else {
-            false
-        }
-    }
-
-    fn image(
-        mut extensions: Vec<Box<dyn ImagesExtension>>,
-        mut source: ImageSource,
-        mut options: ImageOptions,
-        limits: ImageLimits,
-    ) -> ImageVar {
-        for ext in &mut extensions {
-            ext.image(&limits, &mut source, &mut options);
-        }
-
-        let source = match source {
-            ImageSource::Read(path) => {
-                // check limits
-                let path = crate::absolute_path(&path, || env::current_dir().expect("could not access current dir"), true);
-                if !limits.allow_path.allows(&path) {
-                    let error = formatx!("limits filter blocked `{}`", path.display());
-                    tracing::error!("{error}");
-                    IMAGES_SV.write().restore_extensions(extensions);
-                    return var(Img::new_empty(error)).read_only();
-                }
-                ImageSource::Read(path)
-            }
-            #[cfg(feature = "http")]
-            // check limits
-            ImageSource::Download(uri, accepts) => {
-                if !limits.allow_uri.allows(&uri) {
-                    let error = formatx!("limits filter blocked `{uri}`");
-                    tracing::error!("{error}");
-                    IMAGES_SV.write().restore_extensions(extensions);
-                    return var(Img::new_empty(error)).read_only();
-                }
-                ImageSource::Download(uri, accepts)
-            }
-            // Image is supposed to return directly
-            ImageSource::Image(r) => {
-                IMAGES_SV.write().restore_extensions(extensions);
-                return r;
-            }
-            source => source,
-        };
-
-        // continue to loading, ext.image_data gain, decoding
-        let mut sv = IMAGES_SV.write();
-        sv.restore_extensions(extensions);
-
-        sv.image_impl(source, limits, options)
-    }
-    #[allow(clippy::too_many_arguments)]
-    fn image_impl(&mut self, source: ImageSource, limits: ImageLimits, opt: ImageOptions) -> ImageVar {
-        let key = source.hash128(&opt).unwrap();
-
-        match opt.cache_mode {
-            ImageCacheMode::Cache => {
-                if let Some(v) = self.cache.get(&key) {
-                    return v.image.read_only();
-                }
-            }
-            ImageCacheMode::Retry => {
-                if let Some(e) = self.cache.get(&key)
-                    && !e.error.load(Ordering::Relaxed)
-                {
-                    return e.image.read_only();
-                }
-            }
-            ImageCacheMode::Ignore | ImageCacheMode::Reload => {}
-        }
-
-        if !VIEW_PROCESS.is_available() && !self.load_in_headless.get() {
-            tracing::warn!("loading dummy image, set `load_in_headless=true` to actually load without renderer");
-
-            let dummy = var(Img::new_empty(Txt::from_static("")));
-            self.cache.insert(
-                key,
-                CacheEntry {
-                    image: dummy.clone(),
-                    error: AtomicBool::new(false),
-                    max_decoded_len: limits.max_decoded_len,
-                    downscale: opt.downscale,
-                    mask: opt.mask,
-                    entries: opt.entries,
-                },
-            );
-            return dummy.read_only();
-        }
-
-        let max_encoded_size = limits.max_encoded_len;
-
-        match source {
-            ImageSource::Read(path) => self.load_task(
-                key,
-                limits.max_decoded_len,
-                opt,
-                task::run(async move {
-                    let mut r = ImageData {
-                        format: path
-                            .extension()
-                            .and_then(|e| e.to_str())
-                            .map(|s| ImageDataFormat::FileExtension(Txt::from_str(s)))
-                            .unwrap_or(ImageDataFormat::Unknown),
-                        r: Err(Txt::from_static("")),
-                    };
-
-                    let mut file = match task::fs::File::open(path).await {
-                        Ok(f) => f,
-                        Err(e) => {
-                            r.r = Err(e.to_txt());
-                            return r;
-                        }
-                    };
-
-                    let len = match file.metadata().await {
-                        Ok(m) => m.len() as usize,
-                        Err(e) => {
-                            r.r = Err(e.to_txt());
-                            return r;
-                        }
-                    };
-
-                    if len > max_encoded_size.0 {
-                        r.r = Err(formatx!("file size `{}` exceeds the limit of `{max_encoded_size}`", len.bytes()));
-                        return r;
-                    }
-
-                    let mut data = Vec::with_capacity(len);
-                    r.r = match file.read_to_end(&mut data).await {
-                        Ok(_) => match IpcBytes::from_vec_blocking(data) {
-                            Ok(r) => Ok(r),
-                            Err(e) => Err(e.to_txt()),
-                        },
-                        Err(e) => Err(e.to_txt()),
-                    };
-
-                    r
-                }),
-            ),
-            #[cfg(feature = "http")]
-            ImageSource::Download(uri, accept) => {
-                let accept = accept.unwrap_or_else(|| self.download_accept());
-
-                self.load_task(
-                    key,
-                    limits.max_decoded_len,
-                    opt,
-                    task::run(async move {
-                        let mut r = ImageData {
-                            format: ImageDataFormat::Unknown,
-                            r: Err(Txt::from_static("")),
-                        };
-
-                        let request = task::http::Request::get(uri)
-                            .unwrap()
-                            .header(task::http::header::ACCEPT, accept.as_str())
-                            .unwrap()
-                            .max_length(max_encoded_size);
-
-                        match task::http::send(request).await {
-                            Ok(mut rsp) => {
-                                if let Some(m) = rsp.header().get(&task::http::header::CONTENT_TYPE).and_then(|v| v.to_str().ok()) {
-                                    let m = m.to_lowercase();
-                                    if m.starts_with("image/") {
-                                        r.format = ImageDataFormat::MimeType(Txt::from_str(&m));
-                                    }
-                                }
-
-                                r.r = rsp.body().await.map_err(|e| formatx!("download error: {e}"));
-                            }
-                            Err(e) => {
-                                r.r = Err(formatx!("request error: {e}"));
-                            }
-                        }
-
-                        r
-                    }),
-                )
-            }
-            ImageSource::Data(_, bytes, fmt) => {
-                let r = ImageData { format: fmt, r: Ok(bytes) };
-                self.load_task(key, limits.max_decoded_len, opt, async { r })
-            }
-            ImageSource::Render(rfn, args) => {
-                let mask = opt.mask;
-                let img = self.new_cache_image(key, limits.max_decoded_len, opt);
-                self.render_img(mask, clmv!(rfn, || rfn(&args.unwrap_or_default())), &img);
-                img.read_only()
-            }
-            ImageSource::Image(_) => unreachable!(),
-        }
-    }
-
-    #[cfg(feature = "http")]
-    fn download_accept(&mut self) -> Txt {
-        if self.download_accept.is_empty() {
-            if VIEW_PROCESS.is_available() {
-                let mut r = String::new();
-                let mut sep = "";
-                for fmt in self.available_formats() {
-                    for t in fmt.media_type_suffixes_iter() {
-                        r.push_str(sep);
-                        r.push_str("image/");
-                        r.push_str(t);
-                        sep = ",";
-                    }
-                }
-            }
-            if self.download_accept.is_empty() {
-                self.download_accept = "image/*".into();
-            }
-        }
-        self.download_accept.clone()
-    }
-
-    fn available_formats(&self) -> Vec<ImageFormat> {
-        let mut formats = VIEW_PROCESS.info().image.clone();
-        for ext in &self.extensions {
-            ext.available_formats(&mut formats);
-        }
-        formats
-    }
-
-    fn cleanup_not_cached(&mut self, force: bool) {
-        if force || self.not_cached.len() > 1000 {
-            self.not_cached.retain(|c| c.image.strong_count() > 0);
-        }
-    }
-
-    fn new_cache_image(&mut self, key: ImageHash, max_decoded_len: ByteLength, options: ImageOptions) -> Var<Img> {
-        self.cleanup_not_cached(false);
-
-        if let ImageCacheMode::Reload = options.cache_mode {
-            self.cache
-                .entry(key)
-                .or_insert_with(|| CacheEntry {
-                    image: var(Img::new_cached(key)),
-                    error: AtomicBool::new(false),
-                    max_decoded_len,
-                    downscale: options.downscale,
-                    mask: options.mask,
-                    entries: options.entries,
-                })
-                .image
-                .clone()
-        } else if let ImageCacheMode::Ignore = options.cache_mode {
-            let img = var(Img::new_loading(ViewImageHandle::dummy()));
-            self.not_cached.push(NotCachedEntry {
-                image: img.downgrade(),
-                max_decoded_len,
-                downscale: options.downscale,
-                mask: options.mask,
-                entries: options.entries,
-            });
-            img
-        } else {
-            let img = var(Img::new_cached(key));
-            self.cache.insert(
-                key,
-                CacheEntry {
-                    image: img.clone(),
-                    error: AtomicBool::new(false),
-                    max_decoded_len,
-                    downscale: options.downscale,
-                    mask: options.mask,
-                    entries: options.entries,
-                },
-            );
-            img
-        }
-    }
-
-    /// The `fetch_bytes` future is polled in the UI thread, use `task::run` for futures that poll a lot.
-    #[allow(clippy::too_many_arguments)]
-    fn load_task(
-        &mut self,
-        key: ImageHash,
-        max_decoded_len: ByteLength,
-        options: ImageOptions,
-        fetch_bytes: impl Future<Output = ImageData> + Send + 'static,
-    ) -> ImageVar {
-        let img = self.new_cache_image(key, max_decoded_len, options.clone());
-        let r = img.read_only();
-
-        self.loading.push(ImageLoadingTask {
-            task: Mutex::new(UiTask::new(None, fetch_bytes)),
-            image: img,
-            max_decoded_len,
-            key,
-            options,
-        });
-        zng_app::update::UPDATES.update(None);
-
-        r
-    }
-
-    fn find_decoding(&self, id: zng_view_api::image::ImageId) -> Option<ImageVar> {
-        self.decoding.iter().find_map(|i| {
-            if i.image.with(|i| i.handle.image_id() == id) {
-                Some(i.image.clone())
-            } else {
-                i.image.with(|i| i.find_entry(id))
-            }
-        })
+        service::on_app_update();
     }
 }
 
@@ -897,12 +78,12 @@ impl IMAGES {
     /// [`dummy`]: IMAGES::dummy
     /// [`VIEW_PROCESS`]: zng_app::view_process::VIEW_PROCESS
     pub fn load_in_headless(&self) -> Var<bool> {
-        IMAGES_SV.read().load_in_headless.clone()
+        service::load_in_headless()
     }
 
     /// Default loading and decoding limits for each image.
     pub fn limits(&self) -> Var<ImageLimits> {
-        IMAGES_SV.read().limits.clone()
+        service::limits()
     }
 
     /// Returns a dummy image that reports it is loaded or an error.
@@ -912,7 +93,7 @@ impl IMAGES {
 
     /// Cache or load an image file from a file system `path`.
     pub fn read(&self, path: impl Into<PathBuf>) -> ImageVar {
-        self.image_impl(path.into().into(), ImageOptions::cache(), None)
+        service::image(path.into().into(), ImageOptions::cache(), None)
     }
 
     /// Get a cached `uri` or download it.
@@ -926,7 +107,7 @@ impl IMAGES {
         <U as TryInto<task::http::Uri>>::Error: ToTxt,
     {
         match uri.try_into() {
-            Ok(uri) => self.image(ImageSource::Download(uri, accept), ImageOptions::cache(), None),
+            Ok(uri) => service::image(ImageSource::Download(uri, accept), ImageOptions::cache(), None),
             Err(e) => self.dummy(Some(e.to_txt())),
         }
     }
@@ -948,7 +129,7 @@ impl IMAGES {
     /// let image_var = IMAGES.from_static(include_bytes!("ico.png"), "png");
     /// # }
     pub fn from_static(&self, data: &'static [u8], format: impl Into<ImageDataFormat>) -> ImageVar {
-        self.image_impl((data, format.into()).into(), ImageOptions::cache(), None)
+        service::image((data, format.into()).into(), ImageOptions::cache(), None)
     }
 
     /// Get a cached image from shared data.
@@ -957,7 +138,7 @@ impl IMAGES {
     ///
     /// The data can be any of the formats described in [`ImageDataFormat`].
     pub fn from_data(&self, data: IpcBytes, format: impl Into<ImageDataFormat>) -> ImageVar {
-        self.image_impl((data, format.into()).into(), ImageOptions::cache(), None)
+        service::image((data, format.into()).into(), ImageOptions::cache(), None)
     }
 
     /// Get or load an image with full configuration.
@@ -966,12 +147,7 @@ impl IMAGES {
     ///
     /// [`IMAGES.limits`]: IMAGES::limits
     pub fn image(&self, source: impl Into<ImageSource>, options: ImageOptions, limits: Option<ImageLimits>) -> ImageVar {
-        self.image_impl(source.into(), options, limits)
-    }
-    fn image_impl(&self, source: ImageSource, options: ImageOptions, limits: Option<ImageLimits>) -> ImageVar {
-        let limits = limits.unwrap_or_else(|| IMAGES_SV.read().limits.get());
-        let extensions = mem::take(&mut IMAGES_SV.write().extensions);
-        ImagesService::image(extensions, source, options, limits)
+        service::image(source.into(), options, limits)
     }
 
     /// Await for an image source, then get or load the image.
@@ -1000,7 +176,7 @@ impl IMAGES {
         let img = var(Img::new_empty(Txt::from_static("")));
         task::spawn(async_clmv!(img, {
             let source = source.await;
-            let actual_img = IMAGES.image_impl(source, options, limits);
+            let actual_img = service::image(source, options, limits);
             actual_img.set_bind(&img).perm();
             img.hold(actual_img).perm();
         }));
@@ -1021,7 +197,7 @@ impl IMAGES {
         key: Option<ImageHash>,
         image: (ViewImageHandle, ImageDecoded),
     ) -> std::result::Result<ImageVar, ((ViewImageHandle, ImageDecoded), ImageVar)> {
-        IMAGES_SV.write().register(key, image, Txt::from_static(""))
+        service::register(key, image, Txt::from_static(""))
     }
 
     /// Remove the image from the cache, if it is only held by the cache.
@@ -1031,7 +207,7 @@ impl IMAGES {
     ///
     /// Returns `true` if the image was removed.
     pub fn clean(&self, key: ImageHash) -> bool {
-        ImagesService::remove(mem::take(&mut IMAGES_SV.write().extensions), key, false)
+        service::remove(key, false)
     }
 
     /// Remove the image from the cache, even if it is still referenced outside of the cache.
@@ -1041,13 +217,13 @@ impl IMAGES {
     ///
     /// Returns `true` if the image was removed, that is, if it was cached.
     pub fn purge(&self, key: ImageHash) -> bool {
-        ImagesService::remove(mem::take(&mut IMAGES_SV.write().extensions), key, true)
+        service::remove(key, true)
     }
 
     /// Gets the cache key of an image.
     pub fn cache_key(&self, image: &Img) -> Option<ImageHash> {
         if let Some(key) = &image.cache_key
-            && IMAGES_SV.read().cache.contains_key(key)
+            && service::contains_key(key)
         {
             return Some(*key);
         }
@@ -1056,11 +232,7 @@ impl IMAGES {
 
     /// If the image is cached.
     pub fn is_cached(&self, image: &Img) -> bool {
-        image
-            .cache_key
-            .as_ref()
-            .map(|k| IMAGES_SV.read().cache.contains_key(k))
-            .unwrap_or(false)
+        image.cache_key.as_ref().map(service::contains_key).unwrap_or(false)
     }
 
     /// Returns an image that is not cached.
@@ -1068,14 +240,12 @@ impl IMAGES {
     /// If the `image` is the only reference returns it and removes it from the cache. If there are other
     /// references a new [`ImageVar`] is generated from a clone of the image.
     pub fn detach(&self, image: ImageVar) -> ImageVar {
-        IMAGES_SV.write().detach(image)
+        service::detach(image)
     }
 
     /// Clear cached images that are not referenced outside of the cache.
     pub fn clean_all(&self) {
-        let mut img = IMAGES_SV.write();
-        img.extensions.iter_mut().for_each(|p| p.clear(false));
-        img.cache.retain(|_, v| v.image.strong_count() > 1);
+        service::clean_all()
     }
 
     /// Clear all cached images, including images that are still referenced outside of the cache.
@@ -1083,26 +253,20 @@ impl IMAGES {
     /// Image memory only drops when all strong references are removed, so if an image is referenced
     /// outside of the cache it will merely be disconnected from the cache by this method.
     pub fn purge_all(&self) {
-        let mut img = IMAGES_SV.write();
-        img.cache.clear();
-        img.extensions.iter_mut().for_each(|p| p.clear(true));
+        service::purge_all()
     }
 
     /// Add an images service extension.
     ///
     /// See [`ImagesExtension`] for extension capabilities.
     pub fn extend(&self, extension: Box<dyn ImagesExtension>) {
-        IMAGES_SV.write().extensions.push(extension);
+        service::extend(extension)
     }
 
     /// Image formats implemented by the current view-process and extensions.
     pub fn available_formats(&self) -> Vec<ImageFormat> {
-        IMAGES_SV.read().available_formats()
+        service::available_formats()
     }
-}
-struct ImageData {
-    format: ImageDataFormat,
-    r: std::result::Result<IpcBytes, Txt>,
 }
 
 fn absolute_path(path: &Path, base: impl FnOnce() -> PathBuf, allow_escape: bool) -> PathBuf {
@@ -1149,42 +313,4 @@ fn normalize_path(path: &Path) -> PathBuf {
         }
     }
     ret
-}
-
-/// Options for [`IMAGES.image`].
-///
-/// [`IMAGES.image`]: IMAGES::image
-#[derive(Debug, Clone, PartialEq)]
-#[non_exhaustive]
-pub struct ImageOptions {
-    /// If and how the image is cached.
-    pub cache_mode: ImageCacheMode,
-    /// How the image is downscaled after decoding.
-    pub downscale: Option<ImageDownscaleMode>,
-    /// How to convert the decoded image to an alpha mask.
-    pub mask: Option<ImageMaskMode>,
-    /// How to decode containers with multiple images.
-    pub entries: ImageEntriesMode,
-}
-
-impl ImageOptions {
-    /// New.
-    pub fn new(
-        cache_mode: ImageCacheMode,
-        downscale: Option<ImageDownscaleMode>,
-        mask: Option<ImageMaskMode>,
-        entries: ImageEntriesMode,
-    ) -> Self {
-        Self {
-            cache_mode,
-            downscale,
-            mask,
-            entries,
-        }
-    }
-
-    /// New with only cache enabled.
-    pub fn cache() -> Self {
-        Self::new(ImageCacheMode::Cache, None, None, ImageEntriesMode::empty())
-    }
 }

--- a/crates/zng-ext-image/src/lib.rs
+++ b/crates/zng-ext-image/src/lib.rs
@@ -18,7 +18,7 @@ use zng_app::{AppExtension, update::EventUpdate, view_process::ViewImageHandle};
 use zng_clone_move::async_clmv;
 use zng_task as task;
 use zng_task::channel::IpcBytes;
-use zng_txt::{ToTxt, Txt};
+use zng_txt::*;
 use zng_var::{Var, var};
 use zng_view_api::image::ImageDecoded;
 
@@ -190,7 +190,7 @@ impl IMAGES {
     /// Returns `Ok(ImageVar)` with the new image var that tracks `image`, or `Err(image, ImageVar)`
     /// that returns the `image` and a clone of the var already associated with the `key`.
     ///
-    /// Note that you can register entries on the returned [`Img::insert_entry`].
+    /// Note that you can register entries on the returned [`ImageEntry::insert_entry`].
     #[allow(clippy::result_large_err)] // boxing here does not really help performance
     pub fn register(
         &self,

--- a/crates/zng-ext-image/src/service.rs
+++ b/crates/zng-ext-image/src/service.rs
@@ -1,0 +1,883 @@
+use std::{
+    env, mem,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use crate::types::*;
+use parking_lot::Mutex;
+use task::io::AsyncReadExt;
+use zng_app::{
+    APP, update::EventUpdate,
+    view_process::{
+        VIEW_PROCESS, VIEW_PROCESS_INITED_EVENT, ViewImageHandle,
+        raw_events::{LOW_MEMORY_EVENT, RAW_IMAGE_DECODE_ERROR_EVENT, RAW_IMAGE_DECODED_EVENT, RAW_IMAGE_METADATA_DECODED_EVENT},
+    },
+    widget::UiTaskWidget,
+};
+use zng_app_context::app_local;
+use zng_clone_move::clmv;
+use zng_layout::unit::{ByteLength, ByteUnits, Px, PxSize};
+use zng_task as task;
+use zng_task::{UiTask, channel::IpcBytes};
+use zng_txt::{ToTxt, Txt, formatx};
+use zng_unique_id::{IdEntry, IdMap};
+use zng_var::{Var, WeakVar, const_var, var};
+use zng_view_api::image::{ImageDecoded, ImageEntryMetadata, ImageId, ImageMetadata, ImageRequest};
+
+pub(crate) mod render;
+
+app_local! {
+    static IMAGES_SV: ImagesService = {
+        APP.extensions().require::<crate::ImageManager>();
+        ImagesService::new()
+    };
+}
+
+struct ImageData {
+    format: ImageDataFormat,
+    r: std::result::Result<IpcBytes, Txt>,
+}
+
+struct ImageLoadingTask {
+    task: Mutex<UiTask<ImageData>>,
+    image: Var<Img>,
+    max_decoded_len: ByteLength,
+    key: ImageHash,
+    options: ImageOptions,
+}
+
+struct ImageDecodingTask {
+    format: ImageDataFormat,
+    data: IpcBytes,
+    image: Var<Img>,
+}
+
+struct CacheEntry {
+    image: Var<Img>,
+    error: AtomicBool,
+    max_decoded_len: ByteLength,
+    downscale: Option<ImageDownscaleMode>,
+    mask: Option<ImageMaskMode>,
+    entries: ImageEntriesMode,
+}
+
+struct NotCachedEntry {
+    image: WeakVar<Img>,
+    max_decoded_len: ByteLength,
+    downscale: Option<ImageDownscaleMode>,
+    mask: Option<ImageMaskMode>,
+    entries: ImageEntriesMode,
+}
+
+struct ImagesService {
+    load_in_headless: Var<bool>,
+    limits: Var<ImageLimits>,
+
+    download_accept: Txt,
+    extensions: Vec<Box<dyn ImagesExtension>>,
+
+    loading: Vec<ImageLoadingTask>,
+    decoding: Vec<ImageDecodingTask>,
+    cache: IdMap<ImageHash, CacheEntry>,
+    not_cached: Vec<NotCachedEntry>,
+
+    render: render::ImagesRender,
+}
+
+pub(crate) fn load_in_headless() -> Var<bool> {
+    IMAGES_SV.read().load_in_headless.clone()
+}
+
+pub(crate) fn limits() -> Var<ImageLimits> {
+    IMAGES_SV.read().limits.clone()
+}
+
+pub(crate) fn on_app_event_preview(update: &mut EventUpdate) {
+    let mut img = None;
+    // handle any ok decode
+    if let Some(args) = RAW_IMAGE_METADATA_DECODED_EVENT.on(update) {
+        img = Some((args.handle.clone(), ImageDecoded::new(args.meta.clone(), IpcBytes::default(), true)));
+    } else if let Some(args) = RAW_IMAGE_DECODED_EVENT.on(update) {
+        img = Some((args.handle.clone(), args.image.clone()));
+    }
+
+    if let Some((handle, data)) = img {
+        let images = IMAGES_SV.read();
+
+        if let Some(var) = images.find_decoding(handle.image_id()) {
+            // image is registered already, or is entry of registered
+            var.modify(move |i| i.set_data(data));
+        } else if let Some(p) = &data.meta.parent
+            && let Some(var) = images.find_decoding(p.parent)
+        {
+            // image is not registered, but is entry of image that is, insert it
+            let entry = Img::new(handle, data);
+            var.modify(move |i| {
+                i.insert_entry(entry);
+            });
+        }
+    } else if let Some(args) = RAW_IMAGE_DECODE_ERROR_EVENT.on(update) {
+        let images = IMAGES_SV.read();
+
+        if let Some(var) = images.find_decoding(args.handle.image_id()) {
+            // image registered, update to error.
+
+            let error = args.error.clone();
+            var.modify(move |i| i.set_error(error));
+
+            if let Some(key) = var.with(|i| i.cache_key)
+                && let Some(entry) = images.cache.get(&key)
+            {
+                entry.error.store(true, Ordering::Relaxed);
+            }
+            // else is loading will flag on the pos update pass
+        }
+    }
+
+    if let Some(args) = VIEW_PROCESS_INITED_EVENT.on(update) {
+        let mut images = IMAGES_SV.write();
+        let images = &mut *images;
+        images.cleanup_not_cached(true);
+        images.download_accept.clear();
+
+        let mut decoding_interrupted = mem::take(&mut images.decoding);
+        for (img_var, max_decoded_len, downscale, mask, entries) in images
+            .cache
+            .values()
+            .map(|e| (e.image.clone(), e.max_decoded_len, &e.downscale, e.mask, e.entries))
+            .chain(
+                images
+                    .not_cached
+                    .iter()
+                    .filter_map(|e| e.image.upgrade().map(|v| (v, e.max_decoded_len, &e.downscale, e.mask, e.entries))),
+            )
+        {
+            let img = img_var.get();
+            let old_handle = img.view_handle();
+
+            if !old_handle.is_dummy() {
+                if old_handle.view_process_gen() == args.generation {
+                    continue; // already recovered, can this happen?
+                }
+                if let Some(e) = img.error() {
+                    // respawned, but image was an error.
+                    img_var.set(Img::new_empty(e));
+                } else if let Some(task_i) = decoding_interrupted
+                    .iter()
+                    .position(|e| e.image.with(|img| img.view_handle() == old_handle))
+                {
+                    let task = decoding_interrupted.swap_remove(task_i);
+                    // respawned, but image was decoding, need to restart decode.
+                    let mut request = ImageRequest::new(
+                        task.format.clone(),
+                        task.data.clone(),
+                        max_decoded_len.0 as u64,
+                        downscale.clone(),
+                        mask,
+                    );
+                    request.entries = entries;
+                    match VIEW_PROCESS.add_image(request) {
+                        Ok(img) => {
+                            img_var.set(Img::new_loading(img));
+                        }
+                        Err(_) => { /*will receive another event.*/ }
+                    }
+                    images.decoding.push(ImageDecodingTask {
+                        format: task.format.clone(),
+                        data: task.data.clone(),
+                        image: img_var,
+                    });
+                } else {
+                    // respawned and image was loaded.
+
+                    let img_format = if img.is_mask() {
+                        ImageDataFormat::A8 { size: img.size() }
+                    } else {
+                        ImageDataFormat::Bgra8 {
+                            size: img.size(),
+                            density: img.density(),
+                            original_color_type: img.original_color_type(),
+                        }
+                    };
+
+                    let entries = img.entries();
+
+                    let data = img.pixels().unwrap();
+                    let request = ImageRequest::new(img_format.clone(), data.clone(), max_decoded_len.0 as u64, None, mask);
+                    let img = match VIEW_PROCESS.add_image(request) {
+                        Ok(img) => img,
+                        Err(_) => return, // we will receive another event.
+                    };
+                    let mut img = Img::new_loading(img);
+
+                    fn add_entries(max_decoded_len: ByteLength, mask: Option<ImageMaskMode>, entries: Vec<ImageVar>, img: &mut Img) {
+                        for (i, entry) in entries.into_iter().enumerate() {
+                            let entry = entry.get();
+                            let entry_handle = entry.view_handle();
+                            if !entry_handle.is_dummy() {
+                                if entry.is_loaded() {
+                                    let img_format = if img.is_mask() {
+                                        ImageDataFormat::A8 { size: entry.size() }
+                                    } else {
+                                        ImageDataFormat::Bgra8 {
+                                            size: entry.size(),
+                                            density: entry.density(),
+                                            original_color_type: entry.original_color_type(),
+                                        }
+                                    };
+                                    let data = entry.pixels().unwrap();
+                                    let mut request =
+                                        ImageRequest::new(img_format.clone(), data.clone(), max_decoded_len.0 as u64, None, mask);
+                                    request.parent = Some(ImageEntryMetadata::new(img.view_handle().image_id(), i, entry.entry_kind()));
+                                    let entry_img = match VIEW_PROCESS.add_image(request) {
+                                        Ok(img) => img,
+                                        Err(_) => return, // we will receive another event.
+                                    };
+                                    let entry_img = img.insert_entry(Img::new_loading(entry_img));
+
+                                    add_entries(max_decoded_len, mask, entry.entries(), &mut entry_img.get());
+                                    continue;
+                                } else if entry.is_error() {
+                                    img.insert_entry(entry);
+                                    continue;
+                                }
+                            }
+                            tracing::warn!("respawn not implemented for multi entry image partially decoded on crash");
+                        }
+                    }
+                    add_entries(max_decoded_len, mask, entries, &mut img);
+
+                    img_var.set(img);
+
+                    images.decoding.push(ImageDecodingTask {
+                        format: img_format,
+                        data,
+                        image: img_var,
+                    });
+                }
+            } else if let Some(task_i) = decoding_interrupted.iter().position(|e| e.image.var_eq(&img_var)) {
+                // respawned, but image had not started decoding, start it now.
+                let task = decoding_interrupted.swap_remove(task_i);
+                let mut request = ImageRequest::new(
+                    task.format.clone(),
+                    task.data.clone(),
+                    max_decoded_len.0 as u64,
+                    downscale.clone(),
+                    mask,
+                );
+                request.entries = entries;
+                match VIEW_PROCESS.add_image(request) {
+                    Ok(img) => {
+                        img_var.set(Img::new_loading(img));
+                    }
+                    Err(_) => { /*will receive another event.*/ }
+                }
+                images.decoding.push(ImageDecodingTask {
+                    format: task.format.clone(),
+                    data: task.data.clone(),
+                    image: img_var,
+                });
+            }
+            // else { *is loading, will continue normally in self.update_preview()* }
+        }
+    } else if LOW_MEMORY_EVENT.on(update).is_some() {
+        clean_all();
+    } else {
+        IMAGES_SV.write().event_preview_render(update);
+    }
+}
+
+pub(crate) fn on_app_update_preview() {
+    // update loading tasks:
+
+    let mut images = IMAGES_SV.write();
+    let mut loading = Vec::with_capacity(images.loading.len());
+    let loading_tasks = mem::take(&mut images.loading);
+    let mut extensions = mem::take(&mut images.extensions);
+    drop(images); // extensions can use IMAGES
+
+    'loading_tasks: for mut t in loading_tasks {
+        t.task.get_mut().update();
+        match t.task.into_inner().into_result() {
+            Ok(d) => {
+                match d.r {
+                    Ok(data) => {
+                        for ext in &mut extensions {
+                            if let Some(img) = ext.image_data(t.max_decoded_len, &t.key, &data, &d.format, &t.options) {
+                                img.set_bind(&t.image).perm();
+                                t.image.hold(img).perm();
+                                continue 'loading_tasks;
+                            }
+                        }
+
+                        if VIEW_PROCESS.is_available() {
+                            // success and we have a view-process.
+                            let mut request = ImageRequest::new(
+                                d.format.clone(),
+                                data.clone(),
+                                t.max_decoded_len.0 as u64,
+                                t.options.downscale.clone(),
+                                t.options.mask,
+                            );
+                            request.entries = t.options.entries;
+                            match VIEW_PROCESS.add_image(request) {
+                                Ok(img) => {
+                                    // request sent, add to `decoding` will receive
+                                    // image decoded events
+                                    t.image.modify(move |v| {
+                                        v.set_handle(img);
+                                    });
+                                }
+                                Err(_) => {
+                                    // will recover in VIEW_PROCESS_INITED_EVENT
+                                }
+                            }
+                            IMAGES_SV.write().decoding.push(ImageDecodingTask {
+                                format: d.format,
+                                data,
+                                image: t.image,
+                            });
+                        } else {
+                            // success, but we are only doing `load_in_headless` validation.
+                            t.image.modify(move |v| {
+                                let data = ImageDecoded::new(
+                                    ImageMetadata::new(ImageId::INVALID, PxSize::splat(Px(1)), false, ColorType::BGRA8),
+                                    IpcBytes::from_vec_blocking(vec![0, 0, 0, 0]).unwrap(),
+                                    false,
+                                );
+                                v.set_data(data);
+                            });
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("load error: {e:?}");
+                        // load error.
+                        t.image.modify(move |v| {
+                            v.set_error(e);
+                        });
+
+                        // flag error for user retry
+                        if let Some(k) = &t.image.with(|img| img.cache_key)
+                            && let Some(e) = IMAGES_SV.read().cache.get(k)
+                        {
+                            e.error.store(true, Ordering::Relaxed);
+                        }
+                    }
+                }
+            }
+            Err(task) => {
+                loading.push(ImageLoadingTask {
+                    task: Mutex::new(task),
+                    image: t.image,
+                    max_decoded_len: t.max_decoded_len,
+                    key: t.key,
+                    options: t.options,
+                });
+            }
+        }
+    }
+    let mut images = IMAGES_SV.write();
+    images.loading = loading;
+    images.extensions = extensions;
+}
+
+pub(crate) fn on_app_update() {
+    let mut images = IMAGES_SV.write();
+    let images = &mut *images;
+
+    images.decoding.retain(|t| {
+        t.image.with(|i| {
+            let retain = i.is_loading() || i.has_loading_entries();
+
+            if !retain
+                && i.is_error()
+                && let Some(key) = i.cache_key
+                && let Some(entry) = images.cache.get_mut(&key)
+            {
+                *entry.error.get_mut() = true;
+            }
+
+            retain
+        })
+    });
+
+    images.update_render();
+}
+
+/// Associate the `handle` with the `key` or return it with the already existing image if the `key` already has an entry.
+#[allow(clippy::result_large_err)]
+pub(crate) fn register(
+    key: Option<ImageHash>,
+    image: (ViewImageHandle, ImageDecoded),
+    error: Txt,
+) -> std::result::Result<ImageVar, ((ViewImageHandle, ImageDecoded), ImageVar)> {
+    let mut s = IMAGES_SV.write();
+    let s = &mut *s;
+
+    let limits = s.limits.get();
+    let limits = ImageLimits {
+        max_encoded_len: limits.max_encoded_len,
+        max_decoded_len: limits.max_decoded_len.max(image.1.pixels.len().bytes()),
+        allow_path: PathFilter::BlockAll,
+        #[cfg(feature = "http")]
+        allow_uri: UriFilter::BlockAll,
+    };
+
+    let (handle, image) = image;
+    let is_error = !error.is_empty();
+    let is_loading = !is_error && (image.partial.is_some() || image.pixels.is_empty());
+
+    if let Some(key) = key {
+        match s.cache.entry(key) {
+            IdEntry::Occupied(e) => Err(((handle, image), e.get().image.read_only())),
+            IdEntry::Vacant(e) => {
+                let is_mask = image.meta.is_mask;
+                let format = if is_mask {
+                    ImageDataFormat::A8 { size: image.meta.size }
+                } else {
+                    ImageDataFormat::Bgra8 {
+                        size: image.meta.size,
+                        density: image.meta.density,
+                        original_color_type: image.meta.original_color_type.clone(),
+                    }
+                };
+                let img_var = var(Img::new(handle, image));
+                if is_loading {
+                    s.decoding.push(ImageDecodingTask {
+                        format,
+                        data: IpcBytes::default(),
+                        image: img_var.clone(),
+                    });
+                }
+
+                Ok(e.insert(CacheEntry {
+                    error: AtomicBool::new(is_error),
+                    image: img_var,
+                    max_decoded_len: limits.max_decoded_len,
+                    downscale: None,
+                    mask: if is_mask { Some(ImageMaskMode::A) } else { None },
+                    entries: ImageEntriesMode::PRIMARY,
+                })
+                .image
+                .read_only())
+            }
+        }
+    } else if is_loading {
+        let is_mask = image.meta.is_mask;
+        let image = var(Img::new(handle, image));
+        s.not_cached.push(NotCachedEntry {
+            image: image.downgrade(),
+            max_decoded_len: limits.max_decoded_len,
+            downscale: None,
+            mask: if is_mask { Some(ImageMaskMode::A) } else { None },
+            entries: ImageEntriesMode::PRIMARY,
+        });
+        Ok(image.read_only())
+    } else {
+        // not cached and already loaded
+        Ok(const_var(Img::new(handle, image)))
+    }
+}
+
+pub(crate) fn detach(image: ImageVar) -> ImageVar {
+    if let Some(key) = &image.with(|i| i.cache_key) {
+        let mut s = IMAGES_SV.write();
+
+        let decoded_size = image.with(|img| img.pixels().map(|b| b.len()).unwrap_or(0).bytes());
+        let mut max_decoded_len = s.limits.with(|l| l.max_decoded_len.max(decoded_size));
+        let mut downscale = None;
+        let mut mask = None;
+        let mut entries = ImageEntriesMode::PRIMARY;
+
+        if let Some(e) = s.cache.get(key) {
+            max_decoded_len = e.max_decoded_len;
+            downscale = e.downscale.clone();
+            mask = e.mask;
+            entries = e.entries;
+
+            // is cached, `clean` if is only external reference.
+            if image.strong_count() == 2 {
+                s.cache.remove(key);
+            }
+        }
+
+        // remove `cache_key` from image, this clones the `Img` only-if is still in cache.
+        let mut img = image.get();
+        img.cache_key = None;
+        let img = var(img);
+        s.not_cached.push(NotCachedEntry {
+            image: img.downgrade(),
+            max_decoded_len,
+            downscale,
+            mask,
+            entries,
+        });
+        img.read_only()
+    } else {
+        // already not cached
+        image
+    }
+}
+
+pub(crate) fn remove(mut key: ImageHash, mut purge: bool) -> bool {
+    let mut sv = IMAGES_SV.write();
+    let mut extensions = mem::take(&mut sv.extensions);
+    if !extensions.is_empty() {
+        drop(sv);
+        for ext in &mut extensions {
+            if !ext.remove(&mut key, &mut purge) {
+                IMAGES_SV.write().restore_extensions(extensions);
+                return false;
+            }
+        }
+        sv = IMAGES_SV.write();
+        sv.restore_extensions(extensions);
+    }
+
+    if purge || sv.cache.get(&key).map(|v| v.image.strong_count() > 1).unwrap_or(false) {
+        sv.cache.remove(&key).is_some()
+    } else {
+        false
+    }
+}
+
+pub(crate) fn image(mut source: ImageSource, mut options: ImageOptions, limits: Option<ImageLimits>) -> ImageVar {
+    let mut sv = IMAGES_SV.write();
+    let limits = limits.unwrap_or_else(|| sv.limits.get());
+    let mut extensions = mem::take(&mut sv.extensions);
+    if !extensions.is_empty() {
+        drop(sv);
+        for ext in &mut extensions {
+            ext.image(&limits, &mut source, &mut options);
+        }
+        sv = IMAGES_SV.write();
+        sv.restore_extensions(extensions);
+    }
+
+    let source = match source {
+        ImageSource::Read(path) => {
+            // check limits
+            let path = crate::absolute_path(&path, || env::current_dir().expect("could not access current dir"), true);
+            if !limits.allow_path.allows(&path) {
+                let error = formatx!("limits filter blocked `{}`", path.display());
+                tracing::error!("{error}");
+                return var(Img::new_empty(error)).read_only();
+            }
+            ImageSource::Read(path)
+        }
+        #[cfg(feature = "http")]
+        // check limits
+        ImageSource::Download(uri, accepts) => {
+            if !limits.allow_uri.allows(&uri) {
+                let error = formatx!("limits filter blocked `{uri}`");
+                tracing::error!("{error}");
+                return var(Img::new_empty(error)).read_only();
+            }
+            ImageSource::Download(uri, accepts)
+        }
+        // Image is supposed to return directly
+        ImageSource::Image(r) => {
+            return r;
+        }
+        source => source,
+    };
+
+    // continue to loading, ext.image_data gain, decoding
+
+    let key = source.hash128(&options).unwrap();
+
+    match options.cache_mode {
+        ImageCacheMode::Cache => {
+            if let Some(v) = sv.cache.get(&key) {
+                return v.image.read_only();
+            }
+        }
+        ImageCacheMode::Retry => {
+            if let Some(e) = sv.cache.get(&key)
+                && !e.error.load(Ordering::Relaxed)
+            {
+                return e.image.read_only();
+            }
+        }
+        ImageCacheMode::Ignore | ImageCacheMode::Reload => {}
+    }
+
+    if !VIEW_PROCESS.is_available() && !sv.load_in_headless.get() {
+        tracing::warn!("loading dummy image, set `load_in_headless=true` to actually load without renderer");
+
+        let dummy = var(Img::new_empty(Txt::from_static("")));
+        sv.cache.insert(
+            key,
+            CacheEntry {
+                image: dummy.clone(),
+                error: AtomicBool::new(false),
+                max_decoded_len: limits.max_decoded_len,
+                downscale: options.downscale,
+                mask: options.mask,
+                entries: options.entries,
+            },
+        );
+        return dummy.read_only();
+    }
+
+    let max_encoded_size = limits.max_encoded_len;
+
+    match source {
+        ImageSource::Read(path) => sv.load_task(
+            key,
+            limits.max_decoded_len,
+            options,
+            task::run(async move {
+                let mut r = ImageData {
+                    format: path
+                        .extension()
+                        .and_then(|e| e.to_str())
+                        .map(|s| ImageDataFormat::FileExtension(Txt::from_str(s)))
+                        .unwrap_or(ImageDataFormat::Unknown),
+                    r: Err(Txt::from_static("")),
+                };
+
+                let mut file = match task::fs::File::open(path).await {
+                    Ok(f) => f,
+                    Err(e) => {
+                        r.r = Err(e.to_txt());
+                        return r;
+                    }
+                };
+
+                let len = match file.metadata().await {
+                    Ok(m) => m.len() as usize,
+                    Err(e) => {
+                        r.r = Err(e.to_txt());
+                        return r;
+                    }
+                };
+
+                if len > max_encoded_size.0 {
+                    r.r = Err(formatx!("file size `{}` exceeds the limit of `{max_encoded_size}`", len.bytes()));
+                    return r;
+                }
+
+                let mut data = Vec::with_capacity(len);
+                r.r = match file.read_to_end(&mut data).await {
+                    Ok(_) => match IpcBytes::from_vec_blocking(data) {
+                        Ok(r) => Ok(r),
+                        Err(e) => Err(e.to_txt()),
+                    },
+                    Err(e) => Err(e.to_txt()),
+                };
+
+                r
+            }),
+        ),
+        #[cfg(feature = "http")]
+        ImageSource::Download(uri, accept) => {
+            let accept = accept.unwrap_or_else(|| sv.download_accept());
+
+            sv.load_task(
+                key,
+                limits.max_decoded_len,
+                options,
+                task::run(async move {
+                    let mut r = ImageData {
+                        format: ImageDataFormat::Unknown,
+                        r: Err(Txt::from_static("")),
+                    };
+
+                    let request = task::http::Request::get(uri)
+                        .unwrap()
+                        .header(task::http::header::ACCEPT, accept.as_str())
+                        .unwrap()
+                        .max_length(max_encoded_size);
+
+                    match task::http::send(request).await {
+                        Ok(mut rsp) => {
+                            if let Some(m) = rsp.header().get(&task::http::header::CONTENT_TYPE).and_then(|v| v.to_str().ok()) {
+                                let m = m.to_lowercase();
+                                if m.starts_with("image/") {
+                                    r.format = ImageDataFormat::MimeType(Txt::from_str(&m));
+                                }
+                            }
+
+                            r.r = rsp.body().await.map_err(|e| formatx!("download error: {e}"));
+                        }
+                        Err(e) => {
+                            r.r = Err(formatx!("request error: {e}"));
+                        }
+                    }
+
+                    r
+                }),
+            )
+        }
+        ImageSource::Data(_, bytes, fmt) => {
+            let r = ImageData { format: fmt, r: Ok(bytes) };
+            sv.load_task(key, limits.max_decoded_len, options, async { r })
+        }
+        ImageSource::Render(rfn, args) => {
+            let mask = options.mask;
+            let img = sv.new_cache_image(key, limits.max_decoded_len, options);
+            sv.render_img(mask, clmv!(rfn, || rfn(&args.unwrap_or_default())), &img);
+            img.read_only()
+        }
+        ImageSource::Image(_) => unreachable!(),
+    }
+}
+
+pub(crate) fn available_formats() -> Vec<ImageFormat> {
+    IMAGES_SV.read().available_formats()
+}
+
+impl ImagesService {
+    fn new() -> Self {
+        Self {
+            load_in_headless: var(false),
+            limits: var(ImageLimits::default()),
+            extensions: vec![],
+            loading: vec![],
+            decoding: vec![],
+            download_accept: Txt::from_static(""),
+            cache: IdMap::new(),
+            not_cached: vec![],
+            render: render::ImagesRender::default(),
+        }
+    }
+
+    fn restore_extensions(&mut self, mut extensions: Vec<Box<dyn ImagesExtension>>) {
+        extensions.append(&mut self.extensions);
+        self.extensions = extensions;
+    }
+
+    #[cfg(feature = "http")]
+    fn download_accept(&mut self) -> Txt {
+        if self.download_accept.is_empty() {
+            if VIEW_PROCESS.is_available() {
+                let mut r = String::new();
+                let mut sep = "";
+                for fmt in self.available_formats() {
+                    for t in fmt.media_type_suffixes_iter() {
+                        r.push_str(sep);
+                        r.push_str("image/");
+                        r.push_str(t);
+                        sep = ",";
+                    }
+                }
+            }
+            if self.download_accept.is_empty() {
+                self.download_accept = "image/*".into();
+            }
+        }
+        self.download_accept.clone()
+    }
+
+    fn available_formats(&self) -> Vec<ImageFormat> {
+        let mut formats = VIEW_PROCESS.info().image.clone();
+        for ext in &self.extensions {
+            ext.available_formats(&mut formats);
+        }
+        formats
+    }
+
+    fn cleanup_not_cached(&mut self, force: bool) {
+        if force || self.not_cached.len() > 1000 {
+            self.not_cached.retain(|c| c.image.strong_count() > 0);
+        }
+    }
+
+    fn new_cache_image(&mut self, key: ImageHash, max_decoded_len: ByteLength, options: ImageOptions) -> Var<Img> {
+        self.cleanup_not_cached(false);
+
+        if let ImageCacheMode::Reload = options.cache_mode {
+            self.cache
+                .entry(key)
+                .or_insert_with(|| CacheEntry {
+                    image: var(Img::new_cached(key)),
+                    error: AtomicBool::new(false),
+                    max_decoded_len,
+                    downscale: options.downscale,
+                    mask: options.mask,
+                    entries: options.entries,
+                })
+                .image
+                .clone()
+        } else if let ImageCacheMode::Ignore = options.cache_mode {
+            let img = var(Img::new_loading(ViewImageHandle::dummy()));
+            self.not_cached.push(NotCachedEntry {
+                image: img.downgrade(),
+                max_decoded_len,
+                downscale: options.downscale,
+                mask: options.mask,
+                entries: options.entries,
+            });
+            img
+        } else {
+            let img = var(Img::new_cached(key));
+            self.cache.insert(
+                key,
+                CacheEntry {
+                    image: img.clone(),
+                    error: AtomicBool::new(false),
+                    max_decoded_len,
+                    downscale: options.downscale,
+                    mask: options.mask,
+                    entries: options.entries,
+                },
+            );
+            img
+        }
+    }
+
+    /// The `fetch_bytes` future is polled in the UI thread, use `task::run` for futures that poll a lot.
+    #[allow(clippy::too_many_arguments)]
+    fn load_task(
+        &mut self,
+        key: ImageHash,
+        max_decoded_len: ByteLength,
+        options: ImageOptions,
+        fetch_bytes: impl Future<Output = ImageData> + Send + 'static,
+    ) -> ImageVar {
+        let img = self.new_cache_image(key, max_decoded_len, options.clone());
+        let r = img.read_only();
+
+        self.loading.push(ImageLoadingTask {
+            task: Mutex::new(UiTask::new(None, fetch_bytes)),
+            image: img,
+            max_decoded_len,
+            key,
+            options,
+        });
+        zng_app::update::UPDATES.update(None);
+
+        r
+    }
+
+    fn find_decoding(&self, id: zng_view_api::image::ImageId) -> Option<ImageVar> {
+        self.decoding.iter().find_map(|i| {
+            if i.image.with(|i| i.handle.image_id() == id) {
+                Some(i.image.clone())
+            } else {
+                i.image.with(|i| i.find_entry(id))
+            }
+        })
+    }
+}
+
+pub(crate) fn clean_all() {
+    let mut s = IMAGES_SV.write();
+    s.extensions.iter_mut().for_each(|p| p.clear(false));
+    s.cache.retain(|_, v| v.image.strong_count() > 1);
+}
+
+pub(crate) fn contains_key(key: &ImageHash) -> bool {
+    IMAGES_SV.read().cache.contains_key(key)
+}
+
+pub(crate) fn purge_all() {
+    let mut s = IMAGES_SV.write();
+    s.cache.clear();
+    s.extensions.iter_mut().for_each(|p| p.clear(true));
+}
+
+pub(crate) fn extend(extension: Box<dyn ImagesExtension + 'static>) {
+    IMAGES_SV.write().extensions.push(extension);
+}

--- a/crates/zng-ext-image/src/service.rs
+++ b/crates/zng-ext-image/src/service.rs
@@ -7,7 +7,8 @@ use crate::types::*;
 use parking_lot::Mutex;
 use task::io::AsyncReadExt;
 use zng_app::{
-    APP, update::EventUpdate,
+    APP,
+    update::EventUpdate,
     view_process::{
         VIEW_PROCESS, VIEW_PROCESS_INITED_EVENT, ViewImageHandle,
         raw_events::{LOW_MEMORY_EVENT, RAW_IMAGE_DECODE_ERROR_EVENT, RAW_IMAGE_DECODED_EVENT, RAW_IMAGE_METADATA_DECODED_EVENT},

--- a/crates/zng-ext-image/src/service/render.rs
+++ b/crates/zng-ext-image/src/service/render.rs
@@ -15,7 +15,9 @@ use zng_state_map::{StateId, static_id};
 use zng_var::{IntoVar, Var, WeakVar, var};
 use zng_view_api::{image::ImageMaskMode, window::RenderMode};
 
-use crate::{IMAGES, IMAGES_SV, ImageRenderArgs, ImageSource, ImageVar, ImagesService, Img};
+use crate::{IMAGES, ImageRenderArgs, ImageSource, ImageVar, Img};
+
+use super::{IMAGES_SV, ImagesService};
 
 impl ImagesService {
     fn render<N, R>(&mut self, mask: Option<ImageMaskMode>, render: N) -> ImageVar

--- a/crates/zng-ext-image/src/service/render.rs
+++ b/crates/zng-ext-image/src/service/render.rs
@@ -15,7 +15,7 @@ use zng_state_map::{StateId, static_id};
 use zng_var::{IntoVar, Var, WeakVar, var};
 use zng_view_api::{image::ImageMaskMode, window::RenderMode};
 
-use crate::{IMAGES, ImageRenderArgs, ImageSource, ImageVar, ImageEntry};
+use crate::{IMAGES, ImageEntry, ImageRenderArgs, ImageSource, ImageVar};
 
 use super::{IMAGES_SV, ImagesService};
 

--- a/crates/zng-ext-image/src/types.rs
+++ b/crates/zng-ext-image/src/types.rs
@@ -26,7 +26,7 @@ use zng_txt::Txt;
 use zng_var::{Var, VarEq, animation::Transitionable, impl_from_and_into_var};
 use zng_view_api::image::{ImageDecoded, ImageEncodeRequest, ImageId, ImageMetadata, ImageTextureId};
 
-use crate::{ImageOptions, render::ImageRenderWindowRoot};
+use crate::ImageRenderWindowRoot;
 
 pub use zng_view_api::image::{
     ColorType, ImageDataFormat, ImageDownscaleMode, ImageEntriesMode, ImageEntryKind, ImageFormat, ImageFormatCapability, ImageMaskMode,
@@ -1669,4 +1669,42 @@ impl Default for ImageLimits {
 }
 impl_from_and_into_var! {
     fn from(some: ImageLimits) -> Option<ImageLimits>;
+}
+
+/// Options for [`IMAGES.image`].
+///
+/// [`IMAGES.image`]: IMAGES::image
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct ImageOptions {
+    /// If and how the image is cached.
+    pub cache_mode: ImageCacheMode,
+    /// How the image is downscaled after decoding.
+    pub downscale: Option<ImageDownscaleMode>,
+    /// How to convert the decoded image to an alpha mask.
+    pub mask: Option<ImageMaskMode>,
+    /// How to decode containers with multiple images.
+    pub entries: ImageEntriesMode,
+}
+
+impl ImageOptions {
+    /// New.
+    pub fn new(
+        cache_mode: ImageCacheMode,
+        downscale: Option<ImageDownscaleMode>,
+        mask: Option<ImageMaskMode>,
+        entries: ImageEntriesMode,
+    ) -> Self {
+        Self {
+            cache_mode,
+            downscale,
+            mask,
+            entries,
+        }
+    }
+
+    /// New with only cache enabled.
+    pub fn cache() -> Self {
+        Self::new(ImageCacheMode::Cache, None, None, ImageEntriesMode::empty())
+    }
 }

--- a/crates/zng-ext-image/src/types.rs
+++ b/crates/zng-ext-image/src/types.rs
@@ -109,7 +109,7 @@ pub trait ImagesExtension: Send + Sync + Any {
     }
 }
 
-/// Represents an [`Img`] tracked by the [`IMAGES`] cache.
+/// Represents an [`ImageEntry`] tracked by the [`IMAGES`] cache.
 ///
 /// The variable updates when the image updates.
 ///
@@ -905,7 +905,7 @@ impl ImageSource {
         Self::Data(hash, data, format)
     }
 
-    /// Returns the image hash, unless the source is [`Img`].
+    /// Returns the image hash, unless the source is [`ImageEntry`].
     pub fn hash128(&self, options: &ImageOptions) -> Option<ImageHash> {
         match self {
             ImageSource::Read(p) => Some(Self::hash128_read(p, options)),
@@ -1677,7 +1677,7 @@ impl_from_and_into_var! {
 
 /// Options for [`IMAGES.image`].
 ///
-/// [`IMAGES.image`]: IMAGES::image
+/// [`IMAGES.image`]: crate::IMAGES::image
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct ImageOptions {

--- a/crates/zng-ext-image/src/types.rs
+++ b/crates/zng-ext-image/src/types.rs
@@ -547,7 +547,11 @@ impl ImageEntry {
     /// Encode the images to the format.
     ///
     /// This image is the first *page* followed by the `entries` in the given order.
-    pub async fn encode_with_entries(&self, entries: &[(ImageEntry, ImageEntryKind)], format: Txt) -> std::result::Result<IpcBytes, EncodeError> {
+    pub async fn encode_with_entries(
+        &self,
+        entries: &[(ImageEntry, ImageEntryKind)],
+        format: Txt,
+    ) -> std::result::Result<IpcBytes, EncodeError> {
         if self.is_loading() {
             if self.handle.is_dummy() {
                 return Err(EncodeError::Dummy);

--- a/crates/zng-ext-svg/src/lib.rs
+++ b/crates/zng-ext-svg/src/lib.rs
@@ -88,7 +88,7 @@ fn load(max_decoded_len: ByteLength, data: SvgData, downscale: Option<ImageDowns
             }
 
             if size.width() as usize * size.height() as usize * 4 > max_decoded_len.bytes() {
-                let img = Img::new_empty(formatx!("cannot render svg, would exceed max {max_decoded_len} allowed"));
+                let img = ImageEntry::new_empty(formatx!("cannot render svg, would exceed max {max_decoded_len} allowed"));
                 return ImageSource::Image(zng_var::const_var(img));
             }
 

--- a/crates/zng-ext-window/src/control.rs
+++ b/crates/zng-ext-window/src/control.rs
@@ -59,7 +59,7 @@ use crate::{
 use zng_app::{Deadline, view_process::raw_events::RAW_FRAME_RENDERED_EVENT};
 
 #[cfg(feature = "image")]
-use zng_ext_image::{IMAGES, ImageRenderArgs, ImageSource, ImageVar, Img};
+use zng_ext_image::{IMAGES, ImageRenderArgs, ImageSource, ImageVar, ImageEntry};
 
 #[cfg(feature = "image")]
 use crate::{FRAME_IMAGE_READY_EVENT, FrameCaptureMode, FrameImageReadyArgs};
@@ -455,7 +455,7 @@ impl HeadedCtrl {
             if let Some(cur) = &self.img_res.cursor_var {
                 let hotspot = self.vars.cursor().with(|i| i.hotspot().cloned().unwrap_or_default());
 
-                let cursor_img_to_actual = move |img: &Img| -> Option<(Img, PxPoint)> {
+                let cursor_img_to_actual = move |img: &ImageEntry| -> Option<(ImageEntry, PxPoint)> {
                     let hotspot = if img.is_loaded() {
                         let mut metrics = LayoutMetrics::new(1.fct(), img.size(), Px(16));
                         if let Some(density) = img.density() {

--- a/crates/zng-ext-window/src/control.rs
+++ b/crates/zng-ext-window/src/control.rs
@@ -59,7 +59,7 @@ use crate::{
 use zng_app::{Deadline, view_process::raw_events::RAW_FRAME_RENDERED_EVENT};
 
 #[cfg(feature = "image")]
-use zng_ext_image::{IMAGES, ImageRenderArgs, ImageSource, ImageVar, ImageEntry};
+use zng_ext_image::{IMAGES, ImageEntry, ImageRenderArgs, ImageSource, ImageVar};
 
 #[cfg(feature = "image")]
 use crate::{FRAME_IMAGE_READY_EVENT, FrameCaptureMode, FrameImageReadyArgs};

--- a/crates/zng-ext-window/src/service.rs
+++ b/crates/zng-ext-window/src/service.rs
@@ -58,7 +58,7 @@ use std::any::Any;
 use zng_app::view_process::{ViewImageHandle, ViewRenderer};
 
 #[cfg(feature = "image")]
-use zng_ext_image::{ImageRenderWindowRoot, ImageRenderWindowsService, ImageVar, ImageEntry};
+use zng_ext_image::{ImageEntry, ImageRenderWindowRoot, ImageRenderWindowsService, ImageVar};
 
 #[cfg(feature = "image")]
 use crate::{FRAME_IMAGE_READY_EVENT, FrameCaptureMode, HeadlessMonitor, StartPosition};

--- a/crates/zng-ext-window/src/service.rs
+++ b/crates/zng-ext-window/src/service.rs
@@ -495,7 +495,7 @@ impl WINDOWS {
     ///
     /// If the window is not found the error is reported in the [image error].
     ///
-    /// [image error]: zng_ext_image::Img::error
+    /// [image error]: zng_ext_image::ImageEntry::error
     #[cfg(feature = "image")]
     pub fn frame_image(&self, window_id: impl Into<WindowId>, mask: Option<ImageMaskMode>) -> ImageVar {
         let window_id = window_id.into();
@@ -518,7 +518,7 @@ impl WINDOWS {
     ///
     /// If the window is not found the error is reported in the image error.
     ///
-    /// [image error]: zng_ext_image::Img::error
+    /// [image error]: zng_ext_image::ImageEntry::error
     #[cfg(feature = "image")]
     pub fn frame_image_rect(&self, window_id: impl Into<WindowId>, mut rect: PxRect, mask: Option<ImageMaskMode>) -> ImageVar {
         let mut window_id = window_id.into();

--- a/crates/zng-ext-window/src/service.rs
+++ b/crates/zng-ext-window/src/service.rs
@@ -58,7 +58,7 @@ use std::any::Any;
 use zng_app::view_process::{ViewImageHandle, ViewRenderer};
 
 #[cfg(feature = "image")]
-use zng_ext_image::{ImageRenderWindowRoot, ImageRenderWindowsService, ImageVar, Img};
+use zng_ext_image::{ImageRenderWindowRoot, ImageRenderWindowsService, ImageVar, ImageEntry};
 
 #[cfg(feature = "image")]
 use crate::{FRAME_IMAGE_READY_EVENT, FrameCaptureMode, HeadlessMonitor, StartPosition};
@@ -201,13 +201,13 @@ impl WindowsService {
 
                         IMAGES.register(None, (handle, ImageDecoded::default())).unwrap()
                     }
-                    Err(_) => const_var(Img::new_empty(formatx!("{}", WindowNotFoundError::new(window_id)))),
+                    Err(_) => const_var(ImageEntry::new_empty(formatx!("{}", WindowNotFoundError::new(window_id)))),
                 }
             } else {
-                const_var(Img::new_empty(formatx!("window `{window_id}` is headless without renderer")))
+                const_var(ImageEntry::new_empty(formatx!("window `{window_id}` is headless without renderer")))
             }
         } else {
-            const_var(Img::new_empty(formatx!("{}", WindowNotFoundError::new(window_id))))
+            const_var(ImageEntry::new_empty(formatx!("{}", WindowNotFoundError::new(window_id))))
         }
     }
 
@@ -1933,7 +1933,7 @@ impl ImageRenderWindowsService for WINDOWS {
         );
     }
 
-    fn on_frame_image_ready(&self, update: &EventUpdate) -> Option<(WindowId, Img)> {
+    fn on_frame_image_ready(&self, update: &EventUpdate) -> Option<(WindowId, ImageEntry)> {
         if let Some(args) = FRAME_IMAGE_READY_EVENT.on(update)
             && let Some(img) = &args.frame_image
         {

--- a/crates/zng-ext-window/src/vars.rs
+++ b/crates/zng-ext-window/src/vars.rs
@@ -21,16 +21,16 @@ use zng_view_api::{
 #[cfg(feature = "image")]
 use crate::FrameCaptureMode;
 #[cfg(feature = "image")]
-use zng_ext_image::Img;
+use zng_ext_image::ImageEntry;
 
 pub(super) struct WindowVarsData {
     chrome: Var<bool>,
     icon: Var<WindowIcon>,
     #[cfg(feature = "image")]
-    pub(super) actual_icon: Var<Option<Img>>,
+    pub(super) actual_icon: Var<Option<ImageEntry>>,
     cursor: Var<CursorSource>,
     #[cfg(feature = "image")]
-    pub(super) actual_cursor_img: Var<Option<(Img, PxPoint)>>,
+    pub(super) actual_cursor_img: Var<Option<(ImageEntry, PxPoint)>>,
     title: Var<Txt>,
 
     state: Var<WindowState>,
@@ -224,7 +224,7 @@ impl WindowVars {
     /// [`icon`]: Self::icon
     /// [`Img`]: zng_ext_image::Img
     #[cfg(feature = "image")]
-    pub fn actual_icon(&self) -> Var<Option<Img>> {
+    pub fn actual_icon(&self) -> Var<Option<ImageEntry>> {
         self.0.actual_icon.read_only()
     }
 
@@ -249,7 +249,7 @@ impl WindowVars {
     /// [`Img`]: zng_ext_image::Img
     /// [`PxPoint`]: zng_layout::unit::PxPoint
     #[cfg(feature = "image")]
-    pub fn actual_cursor_img(&self) -> Var<Option<(Img, PxPoint)>> {
+    pub fn actual_cursor_img(&self) -> Var<Option<(ImageEntry, PxPoint)>> {
         self.0.actual_cursor_img.read_only()
     }
 

--- a/crates/zng-ext-window/src/vars.rs
+++ b/crates/zng-ext-window/src/vars.rs
@@ -218,11 +218,11 @@ impl WindowVars {
 
     /// Window icon image.
     ///
-    /// This is `None` if [`icon`] is [`WindowIcon::Default`], otherwise it is an [`Img`]
+    /// This is `None` if [`icon`] is [`WindowIcon::Default`], otherwise it is an [`ImageEntry`]
     /// reference clone.
     ///
     /// [`icon`]: Self::icon
-    /// [`Img`]: zng_ext_image::Img
+    /// [`ImageEntry`]: zng_ext_image::ImageEntry
     #[cfg(feature = "image")]
     pub fn actual_icon(&self) -> Var<Option<ImageEntry>> {
         self.0.actual_icon.read_only()
@@ -242,11 +242,11 @@ impl WindowVars {
 
     /// Window custom cursor image.
     ///
-    /// This is `None` if [`cursor`] is not set to a custom image, otherwise it is an [`Img`]
+    /// This is `None` if [`cursor`] is not set to a custom image, otherwise it is an [`ImageEntry`]
     /// reference clone with computed hotspot [`PxPoint`].
     ///
     /// [`cursor`]: Self::cursor
-    /// [`Img`]: zng_ext_image::Img
+    /// [`ImageEntry`]: zng_ext_image::ImageEntry
     /// [`PxPoint`]: zng_layout::unit::PxPoint
     #[cfg(feature = "image")]
     pub fn actual_cursor_img(&self) -> Var<Option<(ImageEntry, PxPoint)>> {

--- a/crates/zng-wgt-image/src/border.rs
+++ b/crates/zng-wgt-image/src/border.rs
@@ -3,7 +3,7 @@
 use std::mem;
 
 use zng_app::render::RepeatMode;
-use zng_ext_image::{IMAGES, ImageCacheMode, ImageOptions, ImageRenderArgs, ImageSource, Img};
+use zng_ext_image::{IMAGES, ImageCacheMode, ImageOptions, ImageRenderArgs, ImageSource, ImageEntry};
 use zng_wgt::prelude::*;
 
 use crate::{IMAGE_CACHE_VAR, IMAGE_LIMITS_VAR, IMAGE_RENDERING_VAR};
@@ -27,7 +27,7 @@ pub fn border_img(
     let source = source.into_var();
     let slices = slices.into_var();
 
-    let mut img = var(Img::new_empty(Txt::default())).read_only();
+    let mut img = var(ImageEntry::new_empty(Txt::default())).read_only();
     let mut _img_sub = VarHandle::dummy();
     let mut slices_img_size = PxSize::zero();
     let mut slices_px = PxSideOffsets::zero();
@@ -68,7 +68,7 @@ pub fn border_img(
                 }
             }
             UiNodeOp::Deinit => {
-                img = var(Img::new_empty(Txt::default())).read_only();
+                img = var(ImageEntry::new_empty(Txt::default())).read_only();
                 _img_sub = VarHandle::dummy();
             }
             UiNodeOp::Update { .. } => {
@@ -97,7 +97,7 @@ pub fn border_img(
                         img = if is_cached {
                             // must not cache, but is cached, detach from cache.
 
-                            let img = mem::replace(&mut img, var(Img::new_empty(Txt::default())).read_only());
+                            let img = mem::replace(&mut img, var(ImageEntry::new_empty(Txt::default())).read_only());
                             IMAGES.detach(img)
                         } else {
                             // must cache, but image is not cached, get source again.

--- a/crates/zng-wgt-image/src/border.rs
+++ b/crates/zng-wgt-image/src/border.rs
@@ -3,7 +3,7 @@
 use std::mem;
 
 use zng_app::render::RepeatMode;
-use zng_ext_image::{IMAGES, ImageCacheMode, ImageOptions, ImageRenderArgs, ImageSource, ImageEntry};
+use zng_ext_image::{IMAGES, ImageCacheMode, ImageEntry, ImageOptions, ImageRenderArgs, ImageSource};
 use zng_wgt::prelude::*;
 
 use crate::{IMAGE_CACHE_VAR, IMAGE_LIMITS_VAR, IMAGE_RENDERING_VAR};

--- a/crates/zng-wgt-image/src/image_properties.rs
+++ b/crates/zng-wgt-image/src/image_properties.rs
@@ -419,7 +419,7 @@ pub fn is_loaded(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNode {
 
 /// Gets the [`CONTEXT_IMAGE_VAR`].
 #[property(LAYOUT, widget_impl(Image))]
-pub fn get_img(child: impl IntoUiNode, state: impl IntoVar<Option<Img>>) -> UiNode {
+pub fn get_img(child: impl IntoUiNode, state: impl IntoVar<Option<ImageEntry>>) -> UiNode {
     bind_state(child, CONTEXT_IMAGE_VAR.map_into(), state)
 }
 
@@ -514,7 +514,7 @@ pub fn on_error(child: impl IntoUiNode, handler: Handler<ImgErrorArgs>) -> UiNod
         UiNodeOp::Init => {
             WIDGET.sub_var(&CONTEXT_IMAGE_VAR);
 
-            if CONTEXT_IMAGE_VAR.with(Img::is_error) {
+            if CONTEXT_IMAGE_VAR.with(ImageEntry::is_error) {
                 first_update = true;
                 WIDGET.update();
             }
@@ -582,7 +582,7 @@ pub fn on_load(child: impl IntoUiNode, handler: Handler<ImgLoadArgs>) -> UiNode 
         UiNodeOp::Init => {
             WIDGET.sub_var(&CONTEXT_IMAGE_VAR);
 
-            if CONTEXT_IMAGE_VAR.with(Img::is_loaded) {
+            if CONTEXT_IMAGE_VAR.with(ImageEntry::is_loaded) {
                 first_update = true;
                 WIDGET.update();
             }
@@ -596,7 +596,7 @@ pub fn on_load(child: impl IntoUiNode, handler: Handler<ImgLoadArgs>) -> UiNode 
                 if new_img.is_loaded() {
                     handler.event(&ImgLoadArgs {});
                 }
-            } else if std::mem::take(&mut first_update) && CONTEXT_IMAGE_VAR.with(Img::is_loaded) {
+            } else if std::mem::take(&mut first_update) && CONTEXT_IMAGE_VAR.with(ImageEntry::is_loaded) {
                 handler.event(&ImgLoadArgs {});
             }
 
@@ -634,7 +634,7 @@ pub fn on_load_layout(child: impl IntoUiNode, handler: Handler<ImgLoadArgs>) -> 
         UiNodeOp::Init => {
             WIDGET.sub_var(&CONTEXT_IMAGE_VAR);
 
-            update = CONTEXT_IMAGE_VAR.with(Img::is_loaded);
+            update = CONTEXT_IMAGE_VAR.with(ImageEntry::is_loaded);
             if update {
                 WIDGET.layout();
             }
@@ -653,7 +653,7 @@ pub fn on_load_layout(child: impl IntoUiNode, handler: Handler<ImgLoadArgs>) -> 
             handler.update();
         }
         UiNodeOp::Layout { .. } => {
-            if std::mem::take(&mut update) && CONTEXT_IMAGE_VAR.with(Img::is_loaded) {
+            if std::mem::take(&mut update) && CONTEXT_IMAGE_VAR.with(ImageEntry::is_loaded) {
                 handler.event(&ImgLoadArgs {});
             }
         }
@@ -681,7 +681,7 @@ pub fn img_block_window_load(child: impl IntoUiNode, enabled: impl IntoValue<Blo
             }
         }
         UiNodeOp::Update { .. } => {
-            if block.is_some() && !CONTEXT_IMAGE_VAR.with(Img::is_loading) {
+            if block.is_some() && !CONTEXT_IMAGE_VAR.with(ImageEntry::is_loading) {
                 block = None;
             }
         }

--- a/crates/zng-wgt-image/src/lib.rs
+++ b/crates/zng-wgt-image/src/lib.rs
@@ -9,7 +9,7 @@
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 
-use zng_ext_image::{ImageSource, Img};
+use zng_ext_image::{ImageSource, ImageEntry};
 use zng_wgt::prelude::*;
 
 mod image_properties;
@@ -56,7 +56,7 @@ fn on_build(wgt: &mut WidgetBuilding) {
     wgt.set_child(node);
 
     let source = wgt.capture_var::<ImageSource>(property_id!(source)).unwrap_or_else(|| {
-        let error = Img::new_empty(Txt::from_static("no source"));
+        let error = ImageEntry::new_empty(Txt::from_static("no source"));
         let error = ImageSource::Image(var(error).read_only());
         const_var(error)
     });

--- a/crates/zng-wgt-image/src/lib.rs
+++ b/crates/zng-wgt-image/src/lib.rs
@@ -9,7 +9,7 @@
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 
-use zng_ext_image::{ImageSource, ImageEntry};
+use zng_ext_image::{ImageEntry, ImageSource};
 use zng_wgt::prelude::*;
 
 mod image_properties;

--- a/crates/zng-wgt-image/src/node.rs
+++ b/crates/zng-wgt-image/src/node.rs
@@ -15,10 +15,10 @@ context_var! {
     /// Image acquired by [`image_source`], or `"no image source in context"` error by default.
     ///
     /// [`image_source`]: fn@image_source
-    pub static CONTEXT_IMAGE_VAR: Img = no_context_image();
+    pub static CONTEXT_IMAGE_VAR: ImageEntry = no_context_image();
 }
-fn no_context_image() -> Img {
-    Img::new_empty(Txt::from_static("no image source in context"))
+fn no_context_image() -> ImageEntry {
+    ImageEntry::new_empty(Txt::from_static("no image source in context"))
 }
 
 /// Requests an image from [`IMAGES`] and sets [`CONTEXT_IMAGE_VAR`].
@@ -33,9 +33,9 @@ fn no_context_image() -> Img {
 /// [`IMAGES`]: zng_ext_image::IMAGES
 pub fn image_source(child: impl IntoUiNode, source: impl IntoVar<ImageSource>) -> UiNode {
     let source = source.into_var();
-    let ctx_img = var(Img::new_empty(Txt::default()));
+    let ctx_img = var(ImageEntry::new_empty(Txt::default()));
     let child = with_context_var(child, CONTEXT_IMAGE_VAR, ctx_img.read_only());
-    let mut img = var(Img::new_empty(Txt::default())).read_only();
+    let mut img = var(ImageEntry::new_empty(Txt::default())).read_only();
     let mut _ctx_binding = None;
 
     match_node(child, move |child, op| match op {
@@ -96,7 +96,7 @@ pub fn image_source(child: impl IntoUiNode, source: impl IntoVar<ImageSource>) -
                     img = if is_cached {
                         // must not cache, but is cached, detach from cache.
 
-                        let img = mem::replace(&mut img, var(Img::new_empty(Txt::default())).read_only());
+                        let img = mem::replace(&mut img, var(ImageEntry::new_empty(Txt::default())).read_only());
                         IMAGES.detach(img)
                     } else {
                         // must cache, but image is not cached, get source again.
@@ -211,7 +211,7 @@ pub fn image_presenter() -> UiNode {
                 .sub_var_layout(&IMAGE_REPEAT_SPACING_VAR)
                 .sub_var_render(&IMAGE_RENDERING_VAR);
 
-            img_size = CONTEXT_IMAGE_VAR.with(Img::size);
+            img_size = CONTEXT_IMAGE_VAR.with(ImageEntry::size);
         }
         UiNodeOp::Update { .. } => {
             if let Some(img) = CONTEXT_IMAGE_VAR.get_new() {
@@ -237,7 +237,7 @@ pub fn image_presenter() -> UiNode {
                 }
                 ImageAutoScale::Density => {
                     let screen = metrics.screen_density();
-                    let image = CONTEXT_IMAGE_VAR.with(Img::density).unwrap_or(PxDensity2d::splat(screen));
+                    let image = CONTEXT_IMAGE_VAR.with(ImageEntry::density).unwrap_or(PxDensity2d::splat(screen));
                     scale *= Factor2d::new(screen.ppcm() / image.width.ppcm(), screen.ppcm() / image.height.ppcm());
                 }
             }
@@ -269,7 +269,7 @@ pub fn image_presenter() -> UiNode {
                 }
                 ImageAutoScale::Density => {
                     let screen = metrics.screen_density();
-                    let image = CONTEXT_IMAGE_VAR.with(Img::density).unwrap_or(PxDensity2d::splat(screen));
+                    let image = CONTEXT_IMAGE_VAR.with(ImageEntry::density).unwrap_or(PxDensity2d::splat(screen));
                     scale *= Factor2d::new(screen.ppcm() / image.width.ppcm(), screen.ppcm() / image.height.ppcm());
                 }
             }

--- a/crates/zng/src/image.rs
+++ b/crates/zng/src/image.rs
@@ -72,9 +72,9 @@
 //! See [`zng_ext_image`] for the full image API and [`zng_wgt_image`] for the full widget API.
 
 pub use zng_ext_image::{
-    ColorType, IMAGE_RENDER, IMAGES, ImageCacheMode, ImageDataFormat, ImageDownscaleMode, ImageEntriesMode, ImageEntryKind, ImageFormat,
-    ImageFormatCapability, ImageHash, ImageHasher, ImageLimits, ImageOptions, ImageRenderArgs, ImageSource, ImageSourceFilter, ImageVar,
-    ImageEntry, PathFilter, render_retain,
+    ColorType, IMAGE_RENDER, IMAGES, ImageCacheMode, ImageDataFormat, ImageDownscaleMode, ImageEntriesMode, ImageEntry, ImageEntryKind,
+    ImageFormat, ImageFormatCapability, ImageHash, ImageHasher, ImageLimits, ImageOptions, ImageRenderArgs, ImageSource, ImageSourceFilter,
+    ImageVar, PathFilter, render_retain,
 };
 
 #[cfg(feature = "http")]

--- a/crates/zng/src/image.rs
+++ b/crates/zng/src/image.rs
@@ -74,7 +74,7 @@
 pub use zng_ext_image::{
     ColorType, IMAGE_RENDER, IMAGES, ImageCacheMode, ImageDataFormat, ImageDownscaleMode, ImageEntriesMode, ImageEntryKind, ImageFormat,
     ImageFormatCapability, ImageHash, ImageHasher, ImageLimits, ImageOptions, ImageRenderArgs, ImageSource, ImageSourceFilter, ImageVar,
-    Img, PathFilter, render_retain,
+    ImageEntry, PathFilter, render_retain,
 };
 
 #[cfg(feature = "http")]

--- a/examples/headless/src/image.rs
+++ b/examples/headless/src/image.rs
@@ -1,5 +1,5 @@
 use std::io::Write as _;
-use zng::{image::Img, prelude::*};
+use zng::{image::ImageEntry, prelude::*};
 
 /// This example uses the `IMAGES` service to render to an image.
 pub fn run() {
@@ -13,7 +13,7 @@ pub fn run() {
     let img = zng::image::IMAGES.render_node(window::RenderMode::Integrated, 1.fct(), None, logo);
 
     app.run_task(async move {
-        while img.with(Img::is_loading) {
+        while img.with(ImageEntry::is_loading) {
             img.wait_update().await;
         }
         let img = img.get();

--- a/examples/image/src/main.rs
+++ b/examples/image/src/main.rs
@@ -839,7 +839,7 @@ fn multi_image_container() -> UiNode {
                         Stack! {
                             direction = StackDirection::left_to_right();
                             spacing = 2;
-                            children = entries.present_list_from_iter(wgt_fn!(|entry: VarEq<image::Img>| {
+                            children = entries.present_list_from_iter(wgt_fn!(|entry: VarEq<image::ImageEntry>| {
                                 Image! {
                                     layout::force_size = entry.0.map(|e| e.size().into());
                                     source = entry.0;

--- a/tests/image.rs
+++ b/tests/image.rs
@@ -3,14 +3,14 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
-use zng::{image::Img, prelude::*};
+use zng::{image::ImageEntry, prelude::*};
 
 #[test]
 fn error_view_recursion() {
     let mut app = APP.defaults().run_headless(false);
     zng_app::test_log();
 
-    let img = var(Img::new_empty("test error".to_txt())).read_only();
+    let img = var(ImageEntry::new_empty("test error".to_txt())).read_only();
 
     zng::image::IMAGES.load_in_headless().set(true);
     let ok = Arc::new(AtomicBool::new(false));

--- a/tests/render-tests/src/tests.rs
+++ b/tests/render-tests/src/tests.rs
@@ -1,5 +1,5 @@
 use zng::{
-    image::{IMAGES, Img},
+    image::{IMAGES, ImageEntry},
     layout::LayoutPassId,
     prelude::*,
     prelude_wgt::*,
@@ -28,11 +28,11 @@ pub async fn bw_rgb(render_mode: RenderMode, scale_factor: Factor) {
         }),
     );
 
-    while img.with(Img::is_loading) {
+    while img.with(ImageEntry::is_loading) {
         if task::with_deadline(img.wait_update(), 20.secs()).await.is_err() {
             panic!(
                 "img wait_update timeout after 20s, img.is_loading: {}, APP.is_running: {}, VIEW_PROCESS.is_connected: {}",
-                img.with(Img::is_loading),
+                img.with(ImageEntry::is_loading),
                 APP.is_running(),
                 zng_app::view_process::VIEW_PROCESS.is_connected(),
             );

--- a/tests/render-tests/src/tests.rs
+++ b/tests/render-tests/src/tests.rs
@@ -74,7 +74,7 @@ pub async fn bw_rgb(render_mode: RenderMode, scale_factor: Factor) {
 //                 density: None,
 //             },
 //         );
-//         while img.with(Img::is_loading) {
+//         while img.with(ImageEntry::is_loading) {
 //             img.wait_update().await;
 //         }
 //         let img = img.get();


### PR DESCRIPTION
First, it was called  `Img` because `Image` is the name of the widget and there was no support for multiple entry images. Now there is, and we will be adding `AudioVar = Var<AudioTrack>` so this rename harmonizes with that.