### PR TITLE
Fix `command_property!` requiring preview property declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `command_property!` requiring preview property declaration.
 
 # 0.21.0
 

--- a/crates/zng-wgt/src/node.rs
+++ b/crates/zng-wgt/src/node.rs
@@ -683,7 +683,7 @@ where
 macro_rules! event_property {
     ($(
         $(#[$meta:meta])+
-        $vis:vis fn $on_ident:ident $(< $on_pre_ident:ident >)? (
+        $vis:vis fn $on_ident:ident $(< $on_pre_ident:ident $(,)?>)? (
             $child:ident: impl $IntoUiNode:path,
             $handler:ident: $Handler:ty $(,)?
         ) -> $UiNode:path {
@@ -794,16 +794,16 @@ macro_rules! event_property_impl {
 macro_rules! command_property {
     ($(
         $(#[$meta:meta])+
-        $vis:vis fn $on_ident:ident < $on_pre_ident:ident $(, $can_ident:ident)?> (
+        $vis:vis fn $on_ident:ident $(< $on_pre_ident:ident $(, $can_ident:ident)? $(,)?>)? (
             $child:ident: impl $IntoUiNode:path,
-            $handler:ident: $Handler:ty
+            $handler:ident: $Handler:ty $(,)?
         ) -> $UiNode:path {
             $COMMAND:path
         }
     )+) => {$(
        $crate::command_property_impl! {
             $(#[$meta])+
-            $vis fn $on_ident<$on_pre_ident $(, $can_ident)?>($child: impl $IntoUiNode, $handler: $Handler) -> $UiNode {
+            $vis fn $on_ident$(<$on_pre_ident $(, $can_ident)?>)?($child: impl $IntoUiNode, $handler: $Handler) -> $UiNode {
                 $COMMAND
             }
        }
@@ -879,7 +879,7 @@ macro_rules! command_property_impl {
     };
     (
         $(#[$meta:meta])+
-        $vis:vis fn $on_ident:ident < $on_pre_ident:ident> (
+        $vis:vis fn $on_ident:ident< $on_pre_ident:ident> (
             $child:ident: impl $IntoUiNode:path,
             $handler:ident: $Handler:ty
         ) -> $UiNode:path {
@@ -900,6 +900,32 @@ macro_rules! command_property_impl {
             $vis fn $on_ident<$on_pre_ident>($child: impl $IntoUiNode, $handler: $Handler) -> $UiNode {
                 const PRE: bool;
                 let child = $crate::node::EventNodeBuilder::new(*$COMMAND).build::<PRE>($child, $handler);
+                $crate::node::command_always_enabled(child, $COMMAND)
+            }
+        }
+    };
+    (
+        $(#[$meta:meta])+
+        $vis:vis fn $on_ident:ident (
+            $child:ident: impl $IntoUiNode:path,
+            $handler:ident: $Handler:ty
+        ) -> $UiNode:path {
+            $COMMAND:path
+        }
+    ) => {
+        $crate::event_property! {
+            $(#[$meta])+
+            ///
+            /// # Command
+            ///
+            /// This property will subscribe to the
+            #[doc = concat!("[`", stringify!($COMMAND), "`]")]
+            /// command scoped on the widget. If set on the `Window!` root widget it will also subscribe to
+            /// the command scoped on the window.
+            ///
+            /// The command handle is always enabled.
+            $vis fn $on_ident($child: impl $IntoUiNode, $handler: $Handler) -> $UiNode {
+                let child = $crate::node::EventNodeBuilder::new(*$COMMAND).build::<false>($child, $handler);
                 $crate::node::command_always_enabled(child, $COMMAND)
             }
         }

--- a/tools/cargo-do/src/main.rs
+++ b/tools/cargo-do/src/main.rs
@@ -1672,7 +1672,14 @@ fn publish(mut args: Vec<&str>) {
                     println(f!("publish dry-run {}", member.name.as_str()));
                     cmd(
                         "cargo",
-                        &["publish", "--dry-run", "--allow-dirty", "--package", member.name.as_str(), "--quiet"],
+                        &[
+                            "publish",
+                            "--dry-run",
+                            "--allow-dirty",
+                            "--package",
+                            member.name.as_str(),
+                            "--quiet",
+                        ],
                         &[],
                     );
                 } else {


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->