### PR TITLE
Fix `command_property!` not generating full property for `can_*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `command_property!` not generating full property for `can_*`.
 
 # 0.21.1
 

--- a/crates/zng-wgt/src/node.rs
+++ b/crates/zng-wgt/src/node.rs
@@ -844,6 +844,7 @@ macro_rules! command_property_impl {
             /// command handlers are enabled in the widget and descendants.
             ///
             #[doc = "Sets the [`"$can_ident:upper "_VAR`]."]
+            #[$crate::node::__macro_util::property(CONTEXT, default([<$can_ident:upper _VAR>]))]
             $vis fn $can_ident(
                 child: impl $crate::node::__macro_util::IntoUiNode,
                 enabled: impl $crate::node::__macro_util::IntoVar<bool>,


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->