### PR TITLE
Fix generated `can_*` properties not updating

### DIFF
--- a/crates/zng-wgt/src/node.rs
+++ b/crates/zng-wgt/src/node.rs
@@ -974,7 +974,7 @@ pub fn command_contextual_enabled(child: UiNode, cmd: Command, ctx: ContextVar<b
                 CommandHandle::dummy()
             };
             if !ctx.capabilities().is_const() {
-                let _handle = ctx.hook(move |a| {
+                _handle = ctx.hook(move |a| {
                     handle.enabled().set(*a.value());
                     win_handle.enabled().set(*a.value());
                     true


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->