### PR TITLE
Fix `ImageEntry::flat_entries` var force updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `ImageEntry::flat_entries` var force updating.
 
 # 0.21.2
 

--- a/crates/zng-ext-image/src/types.rs
+++ b/crates/zng-ext-image/src/types.rs
@@ -321,7 +321,11 @@ impl ImageEntry {
         handles: &mut Vec<zng_var::VarHandle>,
     ) {
         handles.push(img.hook(zng_clone_move::clmv!(signal, |_| {
-            signal.update();
+            // update using modify, not `update` because we don't want
+            // downstream vars to force update
+            signal.modify(|a| {
+                let _ = a.value_mut();
+            });
             true
         })));
         let i = out.len();


### PR DESCRIPTION
Using `update` to signal updates causes all mapping variables to propagate a forced update.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->