### PR TITLE
Improve spans for trace recording

### DIFF
--- a/crates/zng-app/src/update.rs
+++ b/crates/zng-app/src/update.rs
@@ -556,34 +556,46 @@ impl UpdatesTrace {
     }
 
     /// Opens a window span.
+    ///
+    /// The span is at the DEBUG level.
     pub fn window_span(id: WindowId) -> tracing::span::EnteredSpan {
-        tracing::trace_span!(target: UpdatesTrace::UPDATES_TARGET, "Window", %id, raw_id = id.get() as u64).entered()
+        tracing::debug_span!(target: UpdatesTrace::UPDATES_TARGET, "Window", %id, raw_id = id.get() as u64).entered()
     }
 
     /// Opens a widget span.
+    ///
+    /// The span is at the DEBUG level.
     #[cfg(feature = "trace_widget")]
     pub fn widget_span(id: WidgetId, name: &'static str, node_mtd: &'static str) -> tracing::span::EnteredSpan {
-        tracing::trace_span!(target: UpdatesTrace::UPDATES_TARGET, "widget", %id, raw_id = id.get(), name, %node_mtd).entered()
+        tracing::debug_span!(target: UpdatesTrace::UPDATES_TARGET, "widget", %id, raw_id = id.get(), name, %node_mtd).entered()
     }
 
     /// Opens a property span.
+    ///
+    /// The span is at the TRACE level.
     #[cfg(feature = "trace_wgt_item")]
     pub fn property_span(name: &'static str, node_mtd: &'static str) -> tracing::span::EnteredSpan {
         tracing::trace_span!(target: UpdatesTrace::UPDATES_TARGET, "property", name, %node_mtd).entered()
     }
 
     /// Opens an intrinsic span.
+    ///
+    /// The span is at the TRACE level.
     #[cfg(feature = "trace_wgt_item")]
     pub fn intrinsic_span(name: &'static str, node_mtd: &'static str) -> tracing::span::EnteredSpan {
         tracing::trace_span!(target: UpdatesTrace::UPDATES_TARGET, "intrinsic", name, %node_mtd).entered()
     }
 
     /// Opens a custom named span.
+    ///
+    /// The span is at the TRACE level.
     pub fn custom_span(name: &str, node_mtd: &'static str) -> tracing::span::EnteredSpan {
         tracing::trace_span!(target: UpdatesTrace::UPDATES_TARGET, "tag", %name, %node_mtd).entered()
     }
 
     /// Log a direct update request.
+    ///
+    /// The event is at the TRACE level.
     pub fn log_update() {
         tracing::event!(target: UpdatesTrace::UPDATES_TARGET, tracing::Level::TRACE, {
             kind = "update"
@@ -591,6 +603,8 @@ impl UpdatesTrace {
     }
 
     /// Log a direct info rebuild request.
+    ///
+    /// The event is at the TRACE level.
     pub fn log_info() {
         tracing::event!(target: UpdatesTrace::UPDATES_TARGET, tracing::Level::TRACE, {
             kind = "info"
@@ -598,6 +612,8 @@ impl UpdatesTrace {
     }
 
     /// Log a direct layout request.
+    ///
+    /// The event is at the TRACE level.
     pub fn log_layout() {
         tracing::event!(target: UpdatesTrace::UPDATES_TARGET, tracing::Level::TRACE, {
             kind = "layout"
@@ -605,6 +621,8 @@ impl UpdatesTrace {
     }
 
     /// Log a direct render request.
+    ///
+    /// The event is at the TRACE level.
     pub fn log_render() {
         tracing::event!(target: UpdatesTrace::UPDATES_TARGET, tracing::Level::TRACE, {
             kind = "render"
@@ -612,6 +630,8 @@ impl UpdatesTrace {
     }
 
     /// Log a custom event.
+    ///
+    /// The event is at the TRACE level.
     pub fn log_custom(tag: &str) {
         tracing::event!(
             target: UpdatesTrace::UPDATES_TARGET,
@@ -621,6 +641,8 @@ impl UpdatesTrace {
     }
 
     /// Log a var update request.
+    ///
+    /// The event is at the TRACE level.
     pub fn log_var(type_name: &str) {
         tracing::event!(
             target: UpdatesTrace::UPDATES_TARGET,

--- a/crates/zng-ext-font/src/shaping.rs
+++ b/crates/zng-ext-font/src/shaping.rs
@@ -2322,6 +2322,7 @@ impl ShapedTextBuilder {
     }
 
     fn shape_text(fonts: &[Font], text: &SegmentedText, config: &TextShapingArgs) -> ShapedText {
+        let _span = tracing::trace_span!("shape_text").entered();
         let mut t = Self {
             out: ShapedText {
                 glyphs: Default::default(),

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -354,7 +354,6 @@ pub(crate) struct App {
 
     gl_manager: GlContextManager,
     winit_loop: util::WinitEventLoop,
-    idle: IdleTrace,
     app_sender: AppEventSender,
     request_recv: Receiver<RequestEvent>,
 
@@ -983,8 +982,6 @@ impl winit::application::ApplicationHandler<AppEvent> for App {
     }
 
     fn new_events(&mut self, winit_loop: &ActiveEventLoop, cause: winit::event::StartCause) {
-        self.idle.exit();
-
         // pull events sets a timeout, winit constantly polls if the timeout is elapsed,
         // so in case the pull timer elapses and a normal event happens the normal event
         // is processed first and the pull events update on the next poll.
@@ -1152,7 +1149,6 @@ impl winit::application::ApplicationHandler<AppEvent> for App {
         {
             self.skip_ralt = false;
         }
-        self.idle.enter();
 
         winit_loop_guard.unset(&mut self.winit_loop);
     }
@@ -1204,16 +1200,6 @@ enum AppState {
     PreInitSuspended,
     Resumed,
     Suspended,
-}
-
-struct IdleTrace(Option<tracing::span::EnteredSpan>);
-impl IdleTrace {
-    pub fn enter(&mut self) {
-        self.0 = Some(tracing::trace_span!("<winit-idle>").entered());
-    }
-    pub fn exit(&mut self) {
-        self.0 = None;
-    }
 }
 impl App {
     fn set_device_events_filter(&mut self, filter: DeviceEventsFilter, t: Option<&ActiveEventLoop>) {
@@ -1406,12 +1392,9 @@ impl App {
         {
             exts.window("zng-view.prefer_angle", extensions::PreferAngleExt::new);
         }
-        let mut idle = IdleTrace(None);
-        idle.enter();
         App {
             headless: false,
             exts,
-            idle,
             gl_manager: GlContextManager::default(),
             image_cache: ImageCache::new(app_sender.clone()),
             audio_cache: AudioCache::new(app_sender.clone()),

--- a/crates/zng/Cargo.toml
+++ b/crates/zng/Cargo.toml
@@ -168,6 +168,8 @@ crash_handler = ["zng-app/crash_handler"]
 crash_handler_debug = ["zng-wgt-inspector/crash_handler", "window"]
 
 # Instrument every widget outer-most node to trace UI methods.
+# 
+# Widget spans are traced at the DEBUG level.
 trace_widget = ["zng-app/trace_widget", "zng-wgt-style/trace_widget"]
 
 # Enable trace recording.
@@ -179,6 +181,8 @@ trace_recorder = ["zng-app/trace_recorder"]
 
 # Instrument every property and intrinsic node to trace UI methods.
 #
+# Property and other node spans are traced at the TRACE level.
+# 
 # Note that this can cause very large trace files and bad performance.
 trace_wgt_item = ["zng-app/trace_wgt_item"]
 

--- a/crates/zng/src/app.rs
+++ b/crates/zng/src/app.rs
@@ -519,7 +519,7 @@ pub mod crash_handler {
 /// All tracing instrumentation in Zng projects is done using the `tracing` crate, trace recording is done using the `tracing-chrome` crate.
 /// The recorded traces can be viewed in `chrome://tracing` or `ui.perfetto.dev` and can be parsed by the [`Trace`] data model.
 ///
-/// Build the app with `"trace_recorder"` and run the with the `"ZNG_RECORD_TRACE"` env var set to record all other processes spawned by the app.
+/// Build the app with `"trace_recorder"` and run it with the `"ZNG_RECORD_TRACE"` env var to record all processes spawned by the app.
 ///
 /// ```no_run
 /// use zng::prelude::*;

--- a/examples/countdown/Cargo.toml
+++ b/examples/countdown/Cargo.toml
@@ -5,5 +5,5 @@ publish = false
 edition = "2024"
 
 [dependencies]
-zng = { path = "../../crates/zng", features = ["view", "trace_recorder"] }
+zng = { path = "../../crates/zng", features = ["view", "trace_recorder", "trace_widget", "trace_wgt_item"] }
 tracing = "0.1"

--- a/examples/countdown/src/main.rs
+++ b/examples/countdown/src/main.rs
@@ -6,7 +6,8 @@ fn main() {
     unsafe {
         // see zng::app::trace_recorder for more details
         std::env::set_var("ZNG_RECORD_TRACE", "");
-        std::env::set_var("ZNG_RECORD_TRACE_FILTER", "debug");
+        // note that "trace_wgt_item" feature uses "trace" level
+        std::env::set_var("ZNG_RECORD_TRACE_FILTER", "trace");
     }
     zng::env::init!();
 


### PR DESCRIPTION
Removed idle span from view-process too. Use DEBUG level for window and widget spans. Document spans in crate features

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->