### PR TITLE
Fix `cargo zng trace` ignoring custom `thread` args in task spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `cargo zng trace` ignoring custom `thread` args in task spans.
 * App-process now only blocks on view-process busy when another frame is in the buffer.
     - Increases parallelization during sporadic slow frames, builds next frame while current is rendering.
     - Input latency is doubled during slow frames.

--- a/crates/cargo-zng/src/trace.rs
+++ b/crates/cargo-zng/src/trace.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::{HashMap, HashSet},
     io::{Read as _, Write},
     path::PathBuf,
     time::SystemTime,
@@ -138,6 +139,25 @@ pub fn run(args: TraceArgs) {
         }
         let json = &json[1..];
 
+        let mut thread_ids = HashSet::new();
+        // peek thread ids
+        {
+            let mut search = json;
+            let prefix = r#""tid":"#;
+            while let Some(i) = search.find(prefix) {
+                search = &search[i + prefix.len()..];
+                if let Some(i) = search.find(',') {
+                    let tid = &search[..i];
+                    if let Ok(tid) = tid.parse::<u64>() {
+                        thread_ids.insert(tid);
+                    }
+                    search = &search[i + 1..];
+                }
+            }
+        }
+        let mut custom_thread_id = 9000u64;
+        let mut custom_threads = HashMap::new();
+
         let mut reader = std::io::Cursor::new(json.as_bytes());
         loop {
             // skip white space and commas to the next object
@@ -162,22 +182,93 @@ pub fn run(args: TraceArgs) {
                         *pid = serde_json::Number::from(name_sys_pid);
                     }
 
-                    // convert the INFO message process name to actual "process_name" metadata
-                    match &entry {
+                    // convert custom entries to actual trace format
+                    match &mut entry {
                         serde_json::Value::Object(entry) => {
-                            if let Some(serde_json::Value::String(ph)) = entry.get("ph")
-                                && ph == "i"
-                                && let Some(serde_json::Value::Object(args)) = entry.get("args")
-                                && let Some(serde_json::Value::String(msg)) = args.get("message")
-                                && let Some(rest) = msg.strip_prefix("pid: ")
-                                && let Some((sys_pid, p_name)) = rest.split_once(", name: ")
-                                && let Ok(sys_pid) = sys_pid.parse::<u64>()
-                                && name_sys_pid == sys_pid
-                            {
-                                out.write_fmt(format_args!(
-                                    r#"{separator}{{"ph":"M","pid":{sys_pid},"name":"process_name","args":{{"name":"{p_name}"}}}}"#,
-                                ))
-                                .unwrap_or_else(|e| fatal!("cannot write {}, {e}", out_file.display()));
+                            enum Phase {
+                                Event,
+                                Begin,
+                                End,
+                                Other,
+                            }
+                            let mut ph = Phase::Other;
+                            if let Some(serde_json::Value::String(p)) = entry.get("ph") {
+                                match p.as_str() {
+                                    "i" => ph = Phase::Event,
+                                    "B" => ph = Phase::Begin,
+                                    "E" => ph = Phase::End,
+                                    _ => {}
+                                }
+                            }
+                            if let Some(serde_json::Value::Object(args)) = entry.get_mut("args") {
+                                match ph {
+                                    Phase::Event => {
+                                        // convert the INFO message process name to actual "process_name" metadata
+                                        if let Some(serde_json::Value::String(msg)) = args.get("message")
+                                            && let Some(rest) = msg.strip_prefix("pid: ")
+                                            && let Some((sys_pid, p_name)) = rest.split_once(", name: ")
+                                            && let Ok(sys_pid) = sys_pid.parse::<u64>()
+                                            && name_sys_pid == sys_pid
+                                        {
+                                            let args = format_args!(
+                                                r#"{separator}{{"ph":"M","pid":{sys_pid},"name":"process_name","args":{{"name":"{p_name}"}}}}"#,
+                                            );
+                                            out.write_fmt(args)
+                                                .unwrap_or_else(|e| fatal!("cannot write {}, {e}", out_file.display()));
+                                        } else if let Some(serde_json::Value::String(custom_thread)) = args.remove("thread")
+                                            && let Some(serde_json::Value::Number(n)) = entry.get_mut("tid")
+                                        {
+                                            let tid = match custom_threads.entry(custom_thread) {
+                                                std::collections::hash_map::Entry::Occupied(e) => *e.get(),
+                                                std::collections::hash_map::Entry::Vacant(e) => {
+                                                    let name = serde_json::Value::String(e.key().clone());
+
+                                                    while !thread_ids.insert(custom_thread_id) {
+                                                        custom_thread_id = custom_thread_id.wrapping_add(1);
+                                                    }
+                                                    e.insert(custom_thread_id);
+
+                                                    let args = format_args!(
+                                                        r#"{separator}{{"ph":"M","pid":{name_sys_pid},"tid":{custom_thread_id},"name":"thread_name","args":{{"name":{name}}}}}"#,
+                                                    );
+                                                    out.write_fmt(args)
+                                                        .unwrap_or_else(|e| fatal!("cannot write {}, {e}", out_file.display()));
+
+                                                    custom_thread_id
+                                                }
+                                            };
+                                            *n = tid.into();
+                                        }
+                                    }
+                                    Phase::Begin | Phase::End => {
+                                        // convert "thread" arg to actual tid
+                                        if let Some(serde_json::Value::String(custom_thread)) = args.remove("thread")
+                                            && let Some(serde_json::Value::Number(n)) = entry.get_mut("tid")
+                                        {
+                                            let tid = match custom_threads.entry(custom_thread.clone()) {
+                                                std::collections::hash_map::Entry::Occupied(e) => *e.get(),
+                                                std::collections::hash_map::Entry::Vacant(e) => {
+                                                    let name = serde_json::Value::String(e.key().clone());
+
+                                                    while !thread_ids.insert(custom_thread_id) {
+                                                        custom_thread_id = custom_thread_id.wrapping_add(1);
+                                                    }
+                                                    e.insert(custom_thread_id);
+
+                                                    let args = format_args!(
+                                                        r#"{separator}{{"ph":"M","pid":{name_sys_pid},"tid":{custom_thread_id},"name":"thread_name","args":{{"name":{name}}}}}"#,
+                                                    );
+                                                    out.write_fmt(args)
+                                                        .unwrap_or_else(|e| fatal!("cannot write {}, {e}", out_file.display()));
+
+                                                    custom_thread_id
+                                                }
+                                            };
+                                            *n = tid.into();
+                                        }
+                                    }
+                                    Phase::Other => {}
+                                }
                             }
                         }
                         _ => {

--- a/crates/zng-app/src/trace_recorder.rs
+++ b/crates/zng-app/src/trace_recorder.rs
@@ -300,7 +300,7 @@ impl Trace {
 
         let mut out = Trace { processes: vec![] };
 
-        for entry in entries {
+        for mut entry in entries {
             let sys_pid = *process_sys_pid.entry(entry.pid).or_insert(entry.pid);
             let process = if let Some(p) = out.processes.iter_mut().find(|p| p.id == sys_pid) {
                 p
@@ -314,7 +314,11 @@ impl Trace {
                 out.processes.last_mut().unwrap()
             };
 
-            let thread_name = thread_names.entry(entry.tid).or_insert_with(|| entry.tid.to_txt()).clone();
+            let thread_name = if let Some(custom_name) = entry.args.remove("thread") {
+                custom_name.clone()
+            } else {
+                thread_names.entry(entry.tid).or_insert_with(|| entry.tid.to_txt()).clone()
+            };
             let thread = if let Some(t) = process.threads.iter_mut().find(|t| t.name == thread_name) {
                 t
             } else {

--- a/crates/zng-view/src/surface.rs
+++ b/crates/zng-view/src/surface.rs
@@ -6,6 +6,7 @@ use webrender::{
     api::{DocumentId, DynamicProperties, FontInstanceKey, FontKey, FontVariation, PipelineId},
 };
 use winit::event_loop::ActiveEventLoop;
+use zng_txt::{Txt, formatx};
 use zng_unit::{DipSize, DipToPx, Factor, Px, PxRect, Rgba};
 use zng_view_api::{
     ViewProcessGen,
@@ -49,6 +50,8 @@ pub(crate) struct Surface {
     pending_frames: VecDeque<(FrameId, FrameCapture, Option<EnteredSpan>)>,
     rendered_frame_id: FrameId,
     resized: bool,
+
+    frame_span_lane: Txt,
 }
 impl fmt::Debug for Surface {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -179,6 +182,8 @@ impl Surface {
             pending_frames: VecDeque::new(),
             rendered_frame_id: FrameId::INVALID,
             resized: true,
+
+            frame_span_lane: formatx!("<headless#{}-wr>", id.get()),
         }
     }
 
@@ -338,7 +343,8 @@ impl Surface {
         txn.generate_frame(frame.id.get(), true, false, render_reasons);
 
         let frame_scope =
-            tracing::trace_span!("<frame>", ?frame.id, capture = ?frame.capture, from_update = false, thread = "<webrender>").entered();
+            tracing::trace_span!("<frame>", ?frame.id, capture = ?frame.capture, from_update = false, thread = %self.frame_span_lane)
+                .entered();
         self.pending_frames.push_back((frame.id, frame.capture, Some(frame_scope)));
 
         self.api.send_transaction(self.document_id, txn);
@@ -383,7 +389,7 @@ impl Surface {
                     txn.append_dynamic_properties(p);
                 }
 
-                tracing::trace_span!("<frame-update>", ?frame.id, capture = ?frame.capture, thread = "<webrender>")
+                tracing::trace_span!("<frame-update>", ?frame.id, capture = ?frame.capture, thread = %self.frame_span_lane)
             }
             Err(d) => {
                 txn.reset_dynamic_properties();
@@ -395,7 +401,7 @@ impl Surface {
 
                 txn.set_display_list(webrender::api::Epoch(frame.id.epoch()), (self.pipeline_id, d));
 
-                tracing::trace_span!("<frame>", ?frame.id, capture = ?frame.capture, from_update = true, thread = "<webrender>")
+                tracing::trace_span!("<frame>", ?frame.id, capture = ?frame.capture, from_update = true, thread = %self.frame_span_lane)
             }
         };
 

--- a/crates/zng-view/src/window.rs
+++ b/crates/zng-view/src/window.rs
@@ -18,7 +18,7 @@ use winit::{
     monitor::{MonitorHandle, VideoModeHandle as GVideoMode},
     window::{CustomCursor, Fullscreen, Icon, Window as GWindow, WindowAttributes},
 };
-use zng_txt::{ToTxt, Txt};
+use zng_txt::{ToTxt, Txt, formatx};
 use zng_unit::{DipPoint, DipRect, DipSideOffsets, DipSize, DipToPx, Factor, Px, PxPoint, PxRect, PxToDip, PxVector, Rgba};
 use zng_view_api::{
     Event, ViewProcessGen,
@@ -128,6 +128,8 @@ pub(crate) struct Window {
         target_os = "openbsd"
     ))]
     xlib_maximize: bool,
+
+    frame_span_lane: Txt,
 }
 impl fmt::Debug for Window {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -483,6 +485,8 @@ impl Window {
                 target_os = "openbsd"
             ))]
             xlib_maximize: false,
+
+            frame_span_lane: formatx!("<headed#{}-wr>", id.get()),
         };
 
         if !cfg.default_position && win.state.state == WindowState::Normal {
@@ -1492,7 +1496,8 @@ impl Window {
         txn.set_display_list(webrender::api::Epoch(frame.id.epoch()), (self.pipeline_id, display_list));
 
         let frame_scope =
-            tracing::trace_span!("<frame>", ?frame.id, capture = ?frame.capture, from_update = false, thread = "<webrender>").entered();
+            tracing::trace_span!("<frame>", ?frame.id, capture = ?frame.capture, from_update = false, thread = %self.frame_span_lane)
+                .entered();
 
         self.pending_frames.push_back((frame.id, frame.capture, Some(frame_scope)));
 
@@ -1539,7 +1544,7 @@ impl Window {
                     txn.append_dynamic_properties(p);
                 }
 
-                tracing::trace_span!("<frame-update>", ?frame.id, capture = ?frame.capture, thread = "<webrender>")
+                tracing::trace_span!("<frame-update>", ?frame.id, capture = ?frame.capture, thread = %self.frame_span_lane)
             }
             Err(d) => {
                 txn.reset_dynamic_properties();
@@ -1551,7 +1556,7 @@ impl Window {
 
                 txn.set_display_list(webrender::api::Epoch(frame.id.epoch()), (self.pipeline_id, d));
 
-                tracing::trace_span!("<frame>", ?frame.id, capture = ?frame.capture, from_update = true, thread = "<webrender>")
+                tracing::trace_span!("<frame>", ?frame.id, capture = ?frame.capture, from_update = true, thread = %self.frame_span_lane)
             }
         };
 

--- a/crates/zng/src/app.rs
+++ b/crates/zng/src/app.rs
@@ -562,6 +562,9 @@ pub mod crash_handler {
 /// The process record start timestamp is defined by an event INFO message that reads `"zng-record-start: {timestamp}"`. This timestamp is also
 /// in microseconds from Unix epoch.
 ///
+/// Fake *threads* can be defined to better track a *task span* by setting a `thread = "<name>"` argument in the span. Both fake threads and process
+/// names are converted to real entries by `cargo zng trace`.
+///
 /// # Cargo Zng
 ///
 /// You can also use the `cargo zng trace` subcommand to record traces, it handles setting the env variables, merges the multi

--- a/examples/countdown/src/main.rs
+++ b/examples/countdown/src/main.rs
@@ -3,13 +3,17 @@
 use zng::{image, prelude::*, widget::background_color};
 
 fn main() {
-    unsafe {
-        // see zng::app::trace_recorder for more details
-        std::env::set_var("ZNG_RECORD_TRACE", "");
-        // note that "trace_wgt_item" feature uses "trace" level
-        std::env::set_var("ZNG_RECORD_TRACE_FILTER", "debug");
-    }
+    // unsafe {
+    //     // see zng::app::trace_recorder for more details
+    //     std::env::set_var("ZNG_RECORD_TRACE", "");
+    //     // note that "trace_wgt_item" feature uses "trace" level
+    //     std::env::set_var("ZNG_RECORD_TRACE_FILTER", "debug");
+    // }
     zng::env::init!();
+
+    if std::env::var("ZNG_RECORD_TRACE").is_err() {
+        println!("call `cargo zng trace -f debug -- cargo do countdown` to record a trace");
+    }
 
     app_main();
 }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->