### PR TITLE
Fix images decoded from RGBf32 crashing the view-process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix images decoded from RGBf32 crashing the view-process.
 * Implement image encoding for GIF, PNM, TGA, HDR, OpenEXR and Farbfeld.
 * Optimize image encoding, now is faster and uses less memory.
 * Add `IpcBytesMut::from_bytes` and `from_bytes_blocking`.

--- a/crates/zng-view/src/image_cache/decode.rs
+++ b/crates/zng-view/src/image_cache/decode.rs
@@ -611,6 +611,7 @@ impl ImageCache {
                             (b * 255.0).clamp(0.0, 255.0) as u8,
                             (g * 255.0).clamp(0.0, 255.0) as u8,
                             (r * 255.0).clamp(0.0, 255.0) as u8,
+                            255,
                         ]
                     });
                 }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->