### PR TITLE
Use local temp dir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,12 @@ members = [
     "tests",
     "tests/macro-tests",
     "tests/render-tests",
-    "tests/cargo-zng-res-tests/custom/tools/*",
+    "tests/cargo-zng-res-tests/custom/tools/*", "target/tmp/cargo-do/cargo-zng-new-tests/basic/target/the-app", "target/tmp/cargo-do/cargo-zng-new-tests/post/target/the-app", "target/tmp/cargo-do/cargo-zng-new-tests/sanitize/target/the-app",
 ]
 default-members = ["crates/*"]
+
+# local temp dir
+exclude = ["target/tmp/cargo-do/*"]
 
 [profile.dev]
 debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,9 @@ members = [
     "tests",
     "tests/macro-tests",
     "tests/render-tests",
-    "tests/cargo-zng-res-tests/custom/tools/*", "target/tmp/cargo-do/cargo-zng-new-tests/basic/target/the-app", "target/tmp/cargo-do/cargo-zng-new-tests/post/target/the-app", "target/tmp/cargo-do/cargo-zng-new-tests/sanitize/target/the-app",
+    "tests/cargo-zng-res-tests/custom/tools/*",
 ]
 default-members = ["crates/*"]
-
-# local temp dir
-exclude = ["target/tmp/cargo-do/*"]
 
 [profile.dev]
 debug = 1

--- a/tests/cargo_zng.rs
+++ b/tests/cargo_zng.rs
@@ -73,6 +73,8 @@ fn new(test: &str, keys: &[&str], expect: Expect) {
     let temp = std::env::temp_dir().join("cargo-zng-new-tests").join(test);
     fs::create_dir_all(&temp).unwrap();
 
+    fs::write(temp.join("Cargo.toml"), "[workspace]\nmembers=[]\n").unwrap();
+
     let source = test_dir.join("template");
     assert!(source.exists());
     let expected_target = source.with_file_name("expected_target");

--- a/tools/cargo-do/src/main.rs
+++ b/tools/cargo-do/src/main.rs
@@ -5,6 +5,7 @@ use std::{fmt::Write as _, format_args as f};
 use util::*;
 
 fn main() {
+    init_local_temp();
     let (task, args) = args();
 
     match task {

--- a/tools/cargo-do/src/util.rs
+++ b/tools/cargo-do/src/util.rs
@@ -189,6 +189,24 @@ pub fn args() -> (&'static str, Vec<&'static str>) {
     (task, args)
 }
 
+// rustdoc and other cargo commands use the system temp dir, that may be in another disk,
+// this changes it to target/tmp
+pub fn init_local_temp() {
+    let dir = std::env::current_dir().unwrap().join("target/tmp/cargo-do");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    #[cfg(windows)]
+    {
+        let dir = dir.display().to_string().replace('/', "\\");
+        unsafe { std::env::set_var("TMP", &dir) };
+        unsafe { std::env::set_var("TEMP", dir) };
+    }
+    #[cfg(not(windows))]
+    {
+        unsafe { std::env::set_var("TMPDIR", dir) };
+    }
+}
+
 // Information about the running task.
 pub struct TaskInfo {
     pub name: &'static str,


### PR DESCRIPTION
rustdoc creates a lot of files in the system temp dir, this change contains all this IO heavy stuff to the same disk the project is at. On Windows this removes lag from other apps that use the C: disk.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->