### PR TITLE
Fix checkerboard empty rendering

### DIFF
--- a/crates/zng-wgt-checkerboard/src/lib.rs
+++ b/crates/zng-wgt-checkerboard/src/lib.rs
@@ -136,6 +136,10 @@ pub fn node() -> UiNode {
             }
         }
         UiNodeOp::Render { frame } => {
+            if render_size.is_empty() {
+                return;
+            }
+
             let [c0, c1] = COLORS_VAR.get().0;
             let sch = COLOR_SCHEME_VAR.get();
             let colors = [c0[sch], c1[sch]];


### PR DESCRIPTION
This fixes warnings printed when conic gradient is empty

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->