### PR TITLE
Fix AVIF image format magic number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix view-process image format magic number matching any empty pattern.
+* Fix AVIF image format magic number.
 
 # 0.21.7
 

--- a/crates/zng-view-api/src/image.rs
+++ b/crates/zng-view-api/src/image.rs
@@ -757,7 +757,7 @@ impl ImageFormat {
     /// A good size for `file_prefix` is 24 bytes, it should cover all image formats.
     pub fn matches_magic(&self, file_prefix: &[u8]) -> bool {
         'search: for magic in self.magic_numbers.split(',') {
-            if magic.len() > file_prefix.len() * 2 {
+            if magic.is_empty() || magic.len() > file_prefix.len() * 2 {
                 continue 'search;
             }
             'm: for (c, b) in magic.as_bytes().chunks_exact(2).zip(file_prefix) {

--- a/crates/zng-view/src/image_cache.rs
+++ b/crates/zng-view/src/image_cache.rs
@@ -37,7 +37,7 @@ pub(crate) mod lcms2 {
 
 pub(crate) const FORMATS: &[ImageFormat] = &[
     #[cfg(any(feature = "image_avif", zng_view_image_has_avif))]
-    ImageFormat::from_static2("AVIF", "avif", "avif", "", Cap::empty()),
+    ImageFormat::from_static2("AVIF", "avif", "avif", "xxxxxxxx6674797061766966", Cap::empty()),
     #[cfg(feature = "image_bmp")]
     ImageFormat::from_static2("BMP", "bmp", "bmp,dib", "424D", Cap::ENCODE),
     #[cfg(feature = "image_dds")]


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->