### PR TITLE
Release 0.21.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+
+# 0.21.8
+
 * Fix view-process image format magic number matching any empty pattern.
 * Fix AVIF image format magic number.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ First add `zng` to your `Cargo.toml`, or call `cargo add zng -F view_prebuilt`:
 
 ```toml
 [dependencies]
-zng = { version = "0.21.7", features = ["view_prebuilt"] }
+zng = { version = "0.21.8", features = ["view_prebuilt"] }
 ```
 
 Then create your first window:

--- a/crates/zng-app/Cargo.toml
+++ b/crates/zng-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-app"
-version = "0.22.6"
+version = "0.22.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -85,12 +85,12 @@ zng-time = { path = "../zng-time", version = "0.9.2", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
 zng-task = { path = "../zng-task", version = "0.12.5", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", features = [
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", features = [
     "var",
 ], default-features = false }
 zng-state-map = { path = "../zng-state-map", version = "0.10.0", default-features = false }
 zng-layout = { path = "../zng-layout", version = "0.10.4", default-features = false }
-zng-color = { path = "../zng-color", version = "0.12.6", default-features = false }
+zng-color = { path = "../zng-color", version = "0.12.7", default-features = false }
 
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "fmt", "ansi", "smallvec", "tracing-log", "env-filter"] }

--- a/crates/zng-color/Cargo.toml
+++ b/crates/zng-color/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-color"
-version = "0.12.6"
+version = "0.12.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -16,7 +16,7 @@ zng-color-proc-macros = { path = "../zng-color-proc-macros", version = "0.4.0", 
 zng-layout = { path = "../zng-layout", version = "0.10.4", default-features = false }
 zng-app-context = { path = "../zng-app-context", version = "0.12.2", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
 
 pastey = { version = "0.2", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }

--- a/crates/zng-ext-audio/Cargo.toml
+++ b/crates/zng-ext-audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-ext-audio"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -19,8 +19,8 @@ http = ["zng-task/http"]
 zng-app-context = { path = "../zng-app-context", version = "0.12.2", default-features = false }
 zng-unique-id = { path = "../zng-unique-id", version = "0.11.0", default-features = false, features = ["named"] }
 zng-clone-move = { path = "../zng-clone-move", version = "0.4.0", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
 zng-task = { path = "../zng-task", version = "0.12.5", default-features = false }

--- a/crates/zng-ext-clipboard/Cargo.toml
+++ b/crates/zng-ext-clipboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-ext-clipboard"
-version = "0.11.6"
+version = "0.11.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -13,12 +13,12 @@ keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
 zng-app-context = { path = "../zng-app-context", version = "0.12.2", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
-zng-ext-image = { path = "../zng-ext-image", version = "0.11.6", default-features = false }
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
+zng-ext-image = { path = "../zng-ext-image", version = "0.11.7", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
 zng-task = { path = "../zng-task", version = "0.12.5", default-features = false }
 
 tracing = { version = "0.1", default-features = false, features = ["std"] }

--- a/crates/zng-ext-config/Cargo.toml
+++ b/crates/zng-ext-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-ext-config"
-version = "0.12.6"
+version = "0.12.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -23,13 +23,13 @@ ron = ["dep:ron", "zng-ext-fs-watcher/ron"]
 
 [dependencies]
 zng-app-context = { path = "../zng-app-context", version = "0.12.2", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
 zng-task = { path = "../zng-task", version = "0.12.5", default-features = false }
 zng-clone-move = { path = "../zng-clone-move", version = "0.4.0", default-features = false }
 zng-unique-id = { path = "../zng-unique-id", version = "0.11.0", default-features = false }
-zng-ext-fs-watcher = { path = "../zng-ext-fs-watcher", version = "0.11.6", default-features = false }
+zng-ext-fs-watcher = { path = "../zng-ext-fs-watcher", version = "0.11.7", default-features = false }
 zng-state-map = { path = "../zng-state-map", version = "0.10.0", default-features = false }
 zng-unit = { path = "../zng-unit", version = "0.6.2", default-features = false }
 

--- a/crates/zng-ext-font/Cargo.toml
+++ b/crates/zng-ext-font/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-ext-font"
-version = "0.13.7"
+version = "0.13.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -29,15 +29,15 @@ ipc = ["zng-task/ipc"]
 [dependencies]
 zng-clone-move = { path = "../zng-clone-move", version = "0.4.0", default-features = false }
 zng-app-context = { path = "../zng-app-context", version = "0.12.2", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
-zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.7", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
+zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.8", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
 zng-task = { path = "../zng-task", version = "0.12.5", default-features = false }
 zng-layout = { path = "../zng-layout", version = "0.10.4", default-features = false }
-zng-color = { path = "../zng-color", version = "0.12.6", default-features = false }
-zng-ext-image = { path = "../zng-ext-image", version = "0.11.6", default-features = false }
+zng-color = { path = "../zng-color", version = "0.12.7", default-features = false }
+zng-ext-image = { path = "../zng-ext-image", version = "0.11.7", default-features = false }
 
 serde = { version = "1.0", default-features = false }
 unicase = { version = "2.7", default-features = false }

--- a/crates/zng-ext-fs-watcher/Cargo.toml
+++ b/crates/zng-ext-fs-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-ext-fs-watcher"
-version = "0.11.6"
+version = "0.11.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -23,7 +23,7 @@ ron = ["dep:ron"]
 
 [dependencies]
 zng-app-context = { path = "../zng-app-context", version = "0.12.2", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 zng-clone-move = { path = "../zng-clone-move", version = "0.4.0", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }

--- a/crates/zng-ext-hot-reload/Cargo.toml
+++ b/crates/zng-ext-hot-reload/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-ext-hot-reload"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -19,8 +19,8 @@ zng-ext-hot-reload-proc-macros = { path = "../zng-ext-hot-reload-proc-macros", v
 zng-unique-id = { path = "../zng-unique-id", version = "0.11.0", default-features = false, features = ["hot_reload"] }
 zng-env = { path = "../zng-env", version = "0.10.2", default-features = false }
 zng-app-context = { path = "../zng-app-context", version = "0.12.2", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-ext-fs-watcher = { path = "../zng-ext-fs-watcher", version = "0.11.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-ext-fs-watcher = { path = "../zng-ext-fs-watcher", version = "0.11.7", default-features = false }
 zng-unit = { path = "../zng-unit", version = "0.6.2", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
 zng-task = { path = "../zng-task", version = "0.12.5", default-features = false }

--- a/crates/zng-ext-image/Cargo.toml
+++ b/crates/zng-ext-image/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-ext-image"
-version = "0.11.6"
+version = "0.11.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -19,13 +19,13 @@ http = ["zng-task/http"]
 zng-app-context = { path = "../zng-app-context", version = "0.12.2", default-features = false }
 zng-unique-id = { path = "../zng-unique-id", version = "0.11.0", default-features = false }
 zng-clone-move = { path = "../zng-clone-move", version = "0.4.0", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
 zng-task = { path = "../zng-task", version = "0.12.5", default-features = false }
 zng-layout = { path = "../zng-layout", version = "0.10.4", default-features = false }
-zng-color = { path = "../zng-color", version = "0.12.6", default-features = false }
+zng-color = { path = "../zng-color", version = "0.12.7", default-features = false }
 zng-state-map = { path = "../zng-state-map", version = "0.10.0", default-features = false }
 zng-env = { path = "../zng-env", version = "0.10.2", default-features = false }
 

--- a/crates/zng-ext-input/Cargo.toml
+++ b/crates/zng-ext-input/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-ext-input"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -18,15 +18,15 @@ drag_drop = []
 [dependencies]
 zng-app-context = { path = "../zng-app-context", version = "0.12.2", default-features = false }
 zng-clone-move = { path = "../zng-clone-move", version = "0.4.0", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
 zng-layout = { path = "../zng-layout", version = "0.10.4", default-features = false }
 zng-handle = { path = "../zng-handle", version = "0.4.0", default-features = false }
 zng-state-map = { path = "../zng-state-map", version = "0.10.0", default-features = false }
 zng-unique-id = { path = "../zng-unique-id", version = "0.11.0", default-features = false }
-zng-ext-window = { path = "../zng-ext-window", version = "0.12.6", default-features = false }
+zng-ext-window = { path = "../zng-ext-window", version = "0.12.7", default-features = false }
 zng-task = { path = "../zng-task", version = "0.12.5", default-features = false }
 zng-env = { path = "../zng-env", version = "0.10.2", default-features = false }
 

--- a/crates/zng-ext-l10n/Cargo.toml
+++ b/crates/zng-ext-l10n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-ext-l10n"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -21,14 +21,14 @@ lang_autonym = []
 zng-ext-l10n-proc-macros = { path = "../zng-ext-l10n-proc-macros", version = "0.4.0", default-features = false }
 
 zng-app-context = { path = "../zng-app-context", version = "0.12.2", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
 zng-clone-move = { path = "../zng-clone-move", version = "0.4.0", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
 zng-layout = { path = "../zng-layout", version = "0.10.4", default-features = false }
 zng-task = { path = "../zng-task", version = "0.12.5", default-features = false }
-zng-ext-fs-watcher = { path = "../zng-ext-fs-watcher", version = "0.11.6", default-features = false }
+zng-ext-fs-watcher = { path = "../zng-ext-fs-watcher", version = "0.11.7", default-features = false }
 zng-env = { path = "../zng-env", version = "0.10.2", default-features = false }
 
 fluent = { version = "0.17", default-features = false }

--- a/crates/zng-ext-single-instance/Cargo.toml
+++ b/crates/zng-ext-single-instance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-ext-single-instance"
-version = "0.12.6"
+version = "0.12.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -13,10 +13,10 @@ keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
 zng-env = { path = "../zng-env", version = "0.10.2", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
 zng-task = { path = "../zng-task", version = "0.12.5", default-features = false }
-zng-ext-fs-watcher = { path = "../zng-ext-fs-watcher", version = "0.11.6", default-features = false }
+zng-ext-fs-watcher = { path = "../zng-ext-fs-watcher", version = "0.11.7", default-features = false }
 
 parking_lot = { version = "0.12", default-features = false }
 single-instance = { version = "0.3", default-features = false }

--- a/crates/zng-ext-svg/Cargo.toml
+++ b/crates/zng-ext-svg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-ext-svg"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,8 +12,8 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-ext-image = { path = "../zng-ext-image", version = "0.11.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-ext-image = { path = "../zng-ext-image", version = "0.11.7", default-features = false }
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
 zng-unit = { path = "../zng-unit", version = "0.6.2", default-features = false }
 zng-task = { path = "../zng-task", version = "0.12.5", default-features = false }

--- a/crates/zng-ext-undo/Cargo.toml
+++ b/crates/zng-ext-undo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-ext-undo"
-version = "0.11.6"
+version = "0.11.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -14,16 +14,16 @@ keywords = ["gui", "ui", "user-interface", "zng"]
 [dependencies]
 zng-clone-move = { path = "../zng-clone-move", version = "0.4.0", default-features = false }
 zng-app-context = { path = "../zng-app-context", version = "0.12.2", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
 zng-state-map = { path = "../zng-state-map", version = "0.10.0", default-features = false }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }
 
 atomic = { version =  "0.6", default-features = false, features = ["fallback"] }
 parking_lot = { version = "0.12", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false, features = ["test_util"] }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false, features = ["test_util"] }

--- a/crates/zng-ext-window/Cargo.toml
+++ b/crates/zng-ext-window/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-ext-window"
-version = "0.12.6"
+version = "0.12.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -23,17 +23,17 @@ http = ["zng-task/http", "zng-ext-image?/http"]
 zng-clone-move = { path = "../zng-clone-move", version = "0.4.0", default-features = false }
 zng-unique-id = { path = "../zng-unique-id", version = "0.11.0", default-features = false }
 zng-app-context = { path = "../zng-app-context", version = "0.12.2", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
 zng-layout = { path = "../zng-layout", version = "0.10.4", default-features = false }
 zng-state-map = { path = "../zng-state-map", version = "0.10.0", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
 zng-task = { path = "../zng-task", version = "0.12.5", default-features = false }
-zng-ext-image = { path = "../zng-ext-image", version = "0.11.6", default-features = false, optional = true }
-zng-color = { path = "../zng-color", version = "0.12.6", default-features = false }
+zng-ext-image = { path = "../zng-ext-image", version = "0.11.7", default-features = false, optional = true }
+zng-color = { path = "../zng-color", version = "0.12.7", default-features = false }
 zng-env = { path = "../zng-env", version = "0.10.2", default-features = false }
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 bitflags = { version = "2.5", default-features = false, features = ["serde", "bytemuck"] }

--- a/crates/zng-view-api/Cargo.toml
+++ b/crates/zng-view-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-view-api"
-version = "0.19.6"
+version = "0.19.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"

--- a/crates/zng-view-prebuilt/Cargo.toml
+++ b/crates/zng-view-prebuilt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-view-prebuilt"
-version = "0.21.7"
+version = "0.21.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -18,7 +18,7 @@ default = ["embedded"]
 embedded = []
 
 [dependencies]
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
 zng-env = { path = "../zng-env", version = "0.10.2", default-features = false }
 libloading = { version = "0.9", default-features = false, features = ["std"] }
 dunce = { version = "1.0", default-features = false }

--- a/crates/zng-view/Cargo.toml
+++ b/crates/zng-view/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-view"
-version = "0.16.7"
+version = "0.16.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -152,7 +152,7 @@ webrender = { package = "zng-webrender", version = "0.66.0" }
 # path = "../../../zng-webrender/swgl" 
 swgl = { package = "zng-swgl", version = "0.5.0", optional = true }
 
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
 zng-unit = { path = "../zng-unit", version = "0.6.2", default-features = false }
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
 zng-tp-licenses = { path = "../zng-tp-licenses", version = "0.8.1", default-features = false }

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -11,8 +11,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! zng = "0.21.7"
-//! zng-view = "0.16.7"
+//! zng = "0.21.8"
+//! zng-view = "0.16.8"
 //! ```
 //!
 //! Then call `zng::env::init` before any other code in `main` to setup a view-process that uses

--- a/crates/zng-wgt-access/Cargo.toml
+++ b/crates/zng-wgt-access/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-access"
-version = "0.11.7"
+version = "0.11.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,7 +12,7 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.8", default-features = false }

--- a/crates/zng-wgt-ansi-text/Cargo.toml
+++ b/crates/zng-wgt-ansi-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-ansi-text"
-version = "0.12.7"
+version = "0.12.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,13 +12,13 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.6", default-features = false }
-zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.7", default-features = false }
-zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.6", default-features = false }
-zng-ext-font = { path = "../zng-ext-font", version = "0.13.7", default-features = false }
-zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.7", default-features = false }
+zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.8", default-features = false }
+zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.7", default-features = false }
+zng-ext-font = { path = "../zng-ext-font", version = "0.13.8", default-features = false }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.7", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/crates/zng-wgt-button/Cargo.toml
+++ b/crates/zng-wgt-button/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-button"
-version = "0.13.7"
+version = "0.13.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -17,17 +17,17 @@ tooltip = ["dep:zng-wgt-tooltip", "dep:zng-wgt-shortcut", "dep:zng-wgt-stack"]
 
 [dependencies]
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-ext-font = { path = "../zng-ext-font", version = "0.13.7", default-features = false }
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.6", default-features = false }
-zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.6", default-features = false }
-zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.7", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.6", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-ext-font = { path = "../zng-ext-font", version = "0.13.8", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.7", default-features = false }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.7", default-features = false }
+zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.8", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.7", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
 
-zng-wgt-tooltip = { path = "../zng-wgt-tooltip", version = "0.13.7", default-features = false, optional = true }
-zng-wgt-shortcut = { path = "../zng-wgt-shortcut", version = "0.6.7", default-features = false, optional = true }
-zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.6", optional = true, default-features = false }
+zng-wgt-tooltip = { path = "../zng-wgt-tooltip", version = "0.13.8", default-features = false, optional = true }
+zng-wgt-shortcut = { path = "../zng-wgt-shortcut", version = "0.6.8", default-features = false, optional = true }
+zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.7", optional = true, default-features = false }

--- a/crates/zng-wgt-checkerboard/Cargo.toml
+++ b/crates/zng-wgt-checkerboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-checkerboard"
-version = "0.12.6"
+version = "0.12.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,7 +12,7 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-color = { path = "../zng-color", version = "0.12.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-color = { path = "../zng-color", version = "0.12.7", default-features = false }
 
 serde = { version = "1.0", default-features = false }

--- a/crates/zng-wgt-container/Cargo.toml
+++ b/crates/zng-wgt-container/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-container"
-version = "0.13.6"
+version = "0.13.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,7 +12,7 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/crates/zng-wgt-data-view/Cargo.toml
+++ b/crates/zng-wgt-data-view/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-data-view"
-version = "0.12.6"
+version = "0.12.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,9 +12,9 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
 
 parking_lot = { version = "0.12", default-features = false }
 tracing = { version = "0.1", default-features = false }

--- a/crates/zng-wgt-data/Cargo.toml
+++ b/crates/zng-wgt-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-data"
-version = "0.11.6"
+version = "0.11.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -16,8 +16,8 @@ keywords = ["gui", "ui", "user-interface", "zng"]
 var_type_names = ["zng-var/type_names"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-color = { path = "../zng-color", version = "0.12.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-color = { path = "../zng-color", version = "0.12.7", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/crates/zng-wgt-dialog/Cargo.toml
+++ b/crates/zng-wgt-dialog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-dialog"
-version = "0.10.7"
+version = "0.10.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,25 +12,25 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.6", default-features = false }
-zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.6", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.6", default-features = false }
-zng-ext-window = { path = "../zng-ext-window", version = "0.12.6", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.7", default-features = false }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.7", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.7", default-features = false }
+zng-ext-window = { path = "../zng-ext-window", version = "0.12.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
-zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.7", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
-zng-wgt-text-input = { path = "../zng-wgt-text-input", version = "0.13.7", default-features = false }
-zng-wgt-wrap = { path = "../zng-wgt-wrap", version = "0.12.7", default-features = false }
-zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.6", default-features = false }
-zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.7", default-features = false }
-zng-ext-font = { path = "../zng-ext-font", version = "0.13.7", default-features = false }
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
-zng-wgt-transform = { path = "../zng-wgt-transform", version = "0.11.6", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
+zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.8", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
+zng-wgt-text-input = { path = "../zng-wgt-text-input", version = "0.13.8", default-features = false }
+zng-wgt-wrap = { path = "../zng-wgt-wrap", version = "0.12.8", default-features = false }
+zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.7", default-features = false }
+zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.8", default-features = false }
+zng-ext-font = { path = "../zng-ext-font", version = "0.13.8", default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
+zng-wgt-transform = { path = "../zng-wgt-transform", version = "0.11.7", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
 
 tracing = { version = "0.1", default-features = false }
 parking_lot = { version = "0.12", default-features = false }

--- a/crates/zng-wgt-fill/Cargo.toml
+++ b/crates/zng-wgt-fill/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-fill"
-version = "0.11.6"
+version = "0.11.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,4 +12,4 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }

--- a/crates/zng-wgt-filter/Cargo.toml
+++ b/crates/zng-wgt-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-filter"
-version = "0.11.6"
+version = "0.11.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,6 +12,6 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-color = { path = "../zng-color", version = "0.12.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-color = { path = "../zng-color", version = "0.12.7", default-features = false }
 tracing =  { version = "0.1", default-features = false }

--- a/crates/zng-wgt-grid/Cargo.toml
+++ b/crates/zng-wgt-grid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-grid"
-version = "0.12.7"
+version = "0.12.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,10 +12,10 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.7", default-features = false }
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.8", default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
 zng-layout = { path = "../zng-layout", version = "0.10.4", default-features = false }
 
 tracing = { version = "0.1", default-features = false }

--- a/crates/zng-wgt-image/Cargo.toml
+++ b/crates/zng-wgt-image/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-image"
-version = "0.12.7"
+version = "0.12.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,13 +12,13 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.7", default-features = false }
-zng-ext-image = { path = "../zng-ext-image", version = "0.11.6", default-features = false }
-zng-ext-window = { path = "../zng-ext-window", version = "0.12.6", default-features = false }
-zng-wgt-window = { path = "../zng-wgt-window", version = "0.15.7", default-features = false }
-zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.6", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.8", default-features = false }
+zng-ext-image = { path = "../zng-ext-image", version = "0.11.7", default-features = false }
+zng-ext-window = { path = "../zng-ext-window", version = "0.12.7", default-features = false }
+zng-wgt-window = { path = "../zng-wgt-window", version = "0.15.8", default-features = false }
+zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.7", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/crates/zng-wgt-input/Cargo.toml
+++ b/crates/zng-wgt-input/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-input"
-version = "0.11.6"
+version = "0.11.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -18,13 +18,13 @@ drag_drop = ["zng-ext-input/drag_drop"]
 image = ["zng-ext-window/image"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-transform = { path = "../zng-wgt-transform", version = "0.11.6", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
-zng-ext-window = { path = "../zng-ext-window", version = "0.12.6", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
-zng-ext-clipboard = { path = "../zng-ext-clipboard", version = "0.11.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-transform = { path = "../zng-wgt-transform", version = "0.11.7", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }
+zng-ext-window = { path = "../zng-ext-window", version = "0.12.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
+zng-ext-clipboard = { path = "../zng-ext-clipboard", version = "0.11.7", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }

--- a/crates/zng-wgt-inspector/Cargo.toml
+++ b/crates/zng-wgt-inspector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-inspector"
-version = "0.11.7"
+version = "0.11.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -23,40 +23,40 @@ crash_handler = ["zng-app/crash_handler", "dep:open"]
 image = ["zng-ext-window/image"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 zng-env = { path = "../zng-env", version = "0.10.2", default-features = false }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
-zng-ext-font = { path = "../zng-ext-font", version = "0.13.7", default-features = false }
-zng-ext-clipboard = { path = "../zng-ext-clipboard", version = "0.11.6", default-features = false }
-zng-ext-image = { path = "../zng-ext-image", version = "0.11.6", default-features = false }
-zng-ext-config = { path = "../zng-ext-config", version = "0.12.6", default-features = false }
-zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.7", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
-zng-wgt-dialog = { path = "../zng-wgt-dialog", version = "0.10.7", default-features = false }
-zng-ext-window = { path = "../zng-ext-window", version = "0.12.6", default-features = false }
-zng-wgt-window = { path = "../zng-wgt-window", version = "0.15.7", default-features = false }
-zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.7", default-features = false }
-zng-wgt-toggle = { path = "../zng-wgt-toggle", version = "0.12.7", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.7", default-features = false }
-zng-wgt-tooltip = { path = "../zng-wgt-tooltip", version = "0.13.7", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
-zng-wgt-text-input = { path = "../zng-wgt-text-input", version = "0.13.7", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.6", default-features = false }
-zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.7", default-features = false }
-zng-wgt-menu = { path = "../zng-wgt-menu", version = "0.12.7", default-features = false }
-zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.6", default-features = false }
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
-zng-wgt-wrap = { path = "../zng-wgt-wrap", version = "0.12.7", default-features = false }
-zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.6", default-features = false }
-zng-wgt-rule-line = { path = "../zng-wgt-rule-line", version = "0.12.7", default-features = false }
-zng-wgt-ansi-text = { path = "../zng-wgt-ansi-text", version = "0.12.7", default-features = false }
-zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.6", default-features = false }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }
+zng-ext-font = { path = "../zng-ext-font", version = "0.13.8", default-features = false }
+zng-ext-clipboard = { path = "../zng-ext-clipboard", version = "0.11.7", default-features = false }
+zng-ext-image = { path = "../zng-ext-image", version = "0.11.7", default-features = false }
+zng-ext-config = { path = "../zng-ext-config", version = "0.12.7", default-features = false }
+zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.8", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
+zng-wgt-dialog = { path = "../zng-wgt-dialog", version = "0.10.8", default-features = false }
+zng-ext-window = { path = "../zng-ext-window", version = "0.12.7", default-features = false }
+zng-wgt-window = { path = "../zng-wgt-window", version = "0.15.8", default-features = false }
+zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.8", default-features = false }
+zng-wgt-toggle = { path = "../zng-wgt-toggle", version = "0.12.8", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.8", default-features = false }
+zng-wgt-tooltip = { path = "../zng-wgt-tooltip", version = "0.13.8", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
+zng-wgt-text-input = { path = "../zng-wgt-text-input", version = "0.13.8", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.7", default-features = false }
+zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.8", default-features = false }
+zng-wgt-menu = { path = "../zng-wgt-menu", version = "0.12.8", default-features = false }
+zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.7", default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
+zng-wgt-wrap = { path = "../zng-wgt-wrap", version = "0.12.8", default-features = false }
+zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.7", default-features = false }
+zng-wgt-rule-line = { path = "../zng-wgt-rule-line", version = "0.12.8", default-features = false }
+zng-wgt-ansi-text = { path = "../zng-wgt-ansi-text", version = "0.12.8", default-features = false }
+zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.7", default-features = false }
 zng-layout = { path = "../zng-layout", version = "0.10.4", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
-zng-color = { path = "../zng-color", version = "0.12.6", default-features = false }
+zng-color = { path = "../zng-color", version = "0.12.7", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tracing = { version = "0.1", default-features = false }

--- a/crates/zng-wgt-layer/Cargo.toml
+++ b/crates/zng-wgt-layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-layer"
-version = "0.12.6"
+version = "0.12.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -16,17 +16,17 @@ keywords = ["gui", "ui", "user-interface", "zng"]
 image = ["zng-ext-window/image"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.6", default-features = false }
-zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.6", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.6", default-features = false }
-zng-ext-window = { path = "../zng-ext-window", version = "0.12.6", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.7", default-features = false }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.7", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.7", default-features = false }
+zng-ext-window = { path = "../zng-ext-window", version = "0.12.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
 
 parking_lot = { version = "0.12", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/crates/zng-wgt-markdown/Cargo.toml
+++ b/crates/zng-wgt-markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-markdown"
-version = "0.12.7"
+version = "0.12.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,30 +12,30 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
-zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.7", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.7", default-features = false }
-zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.6", default-features = false }
-zng-wgt-wrap = { path = "../zng-wgt-wrap", version = "0.12.7", default-features = false }
-zng-wgt-rule-line = { path = "../zng-wgt-rule-line", version = "0.12.7", default-features = false }
-zng-wgt-grid = { path = "../zng-wgt-grid", version = "0.12.7", default-features = false }
-zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.7", default-features = false }
-zng-wgt-ansi-text = { path = "../zng-wgt-ansi-text", version = "0.12.7", default-features = false }
-zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.6", default-features = false }
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
-zng-wgt-transform = { path = "../zng-wgt-transform", version = "0.11.6", default-features = false }
-zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.6", default-features = false }
-zng-wgt-image = { path = "../zng-wgt-image", version = "0.12.7", default-features = false }
-zng-wgt-tooltip = { path = "../zng-wgt-tooltip", version = "0.13.7", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.6", default-features = false }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
-zng-ext-image = { path = "../zng-ext-image", version = "0.11.6", default-features = false }
-zng-ext-font = { path = "../zng-ext-font", version = "0.13.7", default-features = false }
-zng-ext-clipboard = { path = "../zng-ext-clipboard", version = "0.11.6", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
+zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.8", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.8", default-features = false }
+zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.7", default-features = false }
+zng-wgt-wrap = { path = "../zng-wgt-wrap", version = "0.12.8", default-features = false }
+zng-wgt-rule-line = { path = "../zng-wgt-rule-line", version = "0.12.8", default-features = false }
+zng-wgt-grid = { path = "../zng-wgt-grid", version = "0.12.8", default-features = false }
+zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.8", default-features = false }
+zng-wgt-ansi-text = { path = "../zng-wgt-ansi-text", version = "0.12.8", default-features = false }
+zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.7", default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
+zng-wgt-transform = { path = "../zng-wgt-transform", version = "0.11.7", default-features = false }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.7", default-features = false }
+zng-wgt-image = { path = "../zng-wgt-image", version = "0.12.8", default-features = false }
+zng-wgt-tooltip = { path = "../zng-wgt-tooltip", version = "0.13.8", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.7", default-features = false }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }
+zng-ext-image = { path = "../zng-ext-image", version = "0.11.7", default-features = false }
+zng-ext-font = { path = "../zng-ext-font", version = "0.13.8", default-features = false }
+zng-ext-clipboard = { path = "../zng-ext-clipboard", version = "0.11.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 
 pulldown-cmark = { version = "0.13", default-features = false, features = ["html"] }
 http = { version = "1.1", default-features = false, features = ["std"] }

--- a/crates/zng-wgt-material-icons/Cargo.toml
+++ b/crates/zng-wgt-material-icons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-material-icons"
-version = "0.12.7"
+version = "0.12.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -28,11 +28,11 @@ rounded = []
 sharp = []
 
 [dependencies]
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
-zng-ext-font = { path = "../zng-ext-font", version = "0.13.7", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
+zng-ext-font = { path = "../zng-ext-font", version = "0.13.8", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
 zng-env = { path = "../zng-env", version = "0.10.2", default-features = false }
 
 phf = { version = "0.13", default-features = false }

--- a/crates/zng-wgt-menu/Cargo.toml
+++ b/crates/zng-wgt-menu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-menu"
-version = "0.12.7"
+version = "0.12.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,27 +12,27 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 zng-layout = { path = "../zng-layout", version = "0.10.4", default-features = false }
-zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.6", default-features = false }
-zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.6", default-features = false }
-zng-wgt-panel = { path = "../zng-wgt-panel", version = "0.12.7", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.7", default-features = false, features = ["tooltip"] }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
-zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.6", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
-zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.7", default-features = false }
-zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.6", default-features = false }
-zng-ext-font = { path = "../zng-ext-font", version = "0.13.7", default-features = false }
-zng-wgt-wrap = { path = "../zng-wgt-wrap", version = "0.12.7", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.6", default-features = false }
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
-zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.7", default-features = false }
-zng-wgt-rule-line = { path = "../zng-wgt-rule-line", version = "0.12.7", default-features = false }
-zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.7", default-features = false }
-zng-wgt-toggle = { path = "../zng-wgt-toggle", version = "0.12.7", default-features = false }
-zng-wgt-tooltip = { path = "../zng-wgt-tooltip", version = "0.13.7", default-features = false }
-zng-wgt-shortcut = { path = "../zng-wgt-shortcut", version = "0.6.7", default-features = false }
+zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.7", default-features = false }
+zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.7", default-features = false }
+zng-wgt-panel = { path = "../zng-wgt-panel", version = "0.12.8", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.8", default-features = false, features = ["tooltip"] }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.7", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
+zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.8", default-features = false }
+zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.7", default-features = false }
+zng-ext-font = { path = "../zng-ext-font", version = "0.13.8", default-features = false }
+zng-wgt-wrap = { path = "../zng-wgt-wrap", version = "0.12.8", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.7", default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
+zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.8", default-features = false }
+zng-wgt-rule-line = { path = "../zng-wgt-rule-line", version = "0.12.8", default-features = false }
+zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.8", default-features = false }
+zng-wgt-toggle = { path = "../zng-wgt-toggle", version = "0.12.8", default-features = false }
+zng-wgt-tooltip = { path = "../zng-wgt-tooltip", version = "0.13.8", default-features = false }
+zng-wgt-shortcut = { path = "../zng-wgt-shortcut", version = "0.6.8", default-features = false }

--- a/crates/zng-wgt-panel/Cargo.toml
+++ b/crates/zng-wgt-panel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-panel"
-version = "0.12.7"
+version = "0.12.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,6 +12,6 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-wrap = { path = "../zng-wgt-wrap", version = "0.12.7", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-wrap = { path = "../zng-wgt-wrap", version = "0.12.8", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }

--- a/crates/zng-wgt-progress/Cargo.toml
+++ b/crates/zng-wgt-progress/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-progress"
-version = "0.10.7"
+version = "0.10.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,19 +12,19 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
-zng-ext-font = { path = "../zng-ext-font", version = "0.13.7", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
+zng-ext-font = { path = "../zng-ext-font", version = "0.13.8", default-features = false }
 zng-layout = { path = "../zng-layout", version = "0.10.4", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 zng-task = { path = "../zng-task", version = "0.12.5", default-features = false }
-zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.6", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
+zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.7", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
-zng-wgt-image = { path = "../zng-wgt-image", version = "0.12.7", default-features = false }
-zng-ext-image = { path = "../zng-ext-image", version = "0.11.6", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
+zng-wgt-image = { path = "../zng-wgt-image", version = "0.12.8", default-features = false }
+zng-ext-image = { path = "../zng-ext-image", version = "0.11.7", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
 
 tracing = { version = "0.1", default-features = false }

--- a/crates/zng-wgt-rule-line/Cargo.toml
+++ b/crates/zng-wgt-rule-line/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-rule-line"
-version = "0.12.7"
+version = "0.12.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,10 +12,10 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.7", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.8", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
 bitflags = { version = "2.5", default-features = false, features = ["serde"] }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }

--- a/crates/zng-wgt-scroll/Cargo.toml
+++ b/crates/zng-wgt-scroll/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-scroll"
-version = "0.13.7"
+version = "0.13.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,18 +12,18 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.7", default-features = false }
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.6", default-features = false }
-zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.6", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-ext-window = { path = "../zng-ext-window", version = "0.12.6", default-features = false }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.8", default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.7", default-features = false }
+zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-ext-window = { path = "../zng-ext-window", version = "0.12.7", default-features = false }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
-zng-color = { path = "../zng-color", version = "0.12.6", default-features = false }
+zng-color = { path = "../zng-color", version = "0.12.7", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 atomic = { version = "0.6", default-features = false, features = ["fallback"] }

--- a/crates/zng-wgt-settings/Cargo.toml
+++ b/crates/zng-wgt-settings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-settings"
-version = "0.10.7"
+version = "0.10.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,31 +12,31 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
-zng-ext-config = { path = "../zng-ext-config", version = "0.12.6", default-features = false }
-zng-ext-font = { path = "../zng-ext-font", version = "0.13.7", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
-zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.6", default-features = false }
-zng-wgt-toggle = { path = "../zng-wgt-toggle", version = "0.12.7", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.7", default-features = false }
-zng-wgt-text-input = { path = "../zng-wgt-text-input", version = "0.13.7", default-features = false }
-zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.7", default-features = false }
-zng-wgt-rule-line = { path = "../zng-wgt-rule-line", version = "0.12.7", default-features = false }
-zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.6", default-features = false }
-zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.6", default-features = false }
-zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.6", default-features = false }
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-markdown = { path = "../zng-wgt-markdown", version = "0.12.7", default-features = false }
-zng-wgt-tooltip = { path = "../zng-wgt-tooltip", version = "0.13.7", default-features = false }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
-zng-ext-window = { path = "../zng-ext-window", version = "0.12.6", default-features = false }
-zng-wgt-window = { path = "../zng-wgt-window", version = "0.15.7", default-features = false, features = ["config"] }
+zng-ext-config = { path = "../zng-ext-config", version = "0.12.7", default-features = false }
+zng-ext-font = { path = "../zng-ext-font", version = "0.13.8", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
+zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.7", default-features = false }
+zng-wgt-toggle = { path = "../zng-wgt-toggle", version = "0.12.8", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.8", default-features = false }
+zng-wgt-text-input = { path = "../zng-wgt-text-input", version = "0.13.8", default-features = false }
+zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.8", default-features = false }
+zng-wgt-rule-line = { path = "../zng-wgt-rule-line", version = "0.12.8", default-features = false }
+zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.7", default-features = false }
+zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.7", default-features = false }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.7", default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-markdown = { path = "../zng-wgt-markdown", version = "0.12.8", default-features = false }
+zng-wgt-tooltip = { path = "../zng-wgt-tooltip", version = "0.13.8", default-features = false }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }
+zng-ext-window = { path = "../zng-ext-window", version = "0.12.7", default-features = false }
+zng-wgt-window = { path = "../zng-wgt-window", version = "0.15.8", default-features = false, features = ["config"] }
 zng-env = { path = "../zng-env", version = "0.10.2", default-features = false }
-zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.7", default-features = false }
-zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.6", default-features = false }
+zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.8", default-features = false }
+zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.7", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/crates/zng-wgt-shortcut/Cargo.toml
+++ b/crates/zng-wgt-shortcut/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-shortcut"
-version = "0.6.7"
+version = "0.6.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,14 +12,14 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-wrap = { path = "../zng-wgt-wrap", version = "0.12.7", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-wrap = { path = "../zng-wgt-wrap", version = "0.12.8", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
-zng-ext-font = { path = "../zng-ext-font", version = "0.13.7", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-color = { path = "../zng-color", version = "0.12.6", default-features = false }
-zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.7", default-features = false }
+zng-ext-font = { path = "../zng-ext-font", version = "0.13.8", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-color = { path = "../zng-color", version = "0.12.7", default-features = false }
+zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.8", default-features = false }

--- a/crates/zng-wgt-size-offset/Cargo.toml
+++ b/crates/zng-wgt-size-offset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-size-offset"
-version = "0.11.6"
+version = "0.11.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,7 +12,7 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
 
 euclid = { version = "0.22", default-features = false, features = ["std"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/crates/zng-wgt-slider/Cargo.toml
+++ b/crates/zng-wgt-slider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-slider"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -13,14 +13,14 @@ keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.6", default-features = false }
-zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.6", default-features = false }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-transform = { path = "../zng-wgt-transform", version = "0.11.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.7", default-features = false }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.7", default-features = false }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-transform = { path = "../zng-wgt-transform", version = "0.11.7", default-features = false }
 
 parking_lot = { version = "0.12", default-features = false }
 tracing = { version = "0.1", default-features = false }

--- a/crates/zng-wgt-stack/Cargo.toml
+++ b/crates/zng-wgt-stack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-stack"
-version = "0.12.6"
+version = "0.12.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,9 +12,9 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 zng-layout = { path = "../zng-layout", version = "0.10.4", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
 

--- a/crates/zng-wgt-style/Cargo.toml
+++ b/crates/zng-wgt-style/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-style"
-version = "0.12.6"
+version = "0.12.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -16,8 +16,8 @@ keywords = ["gui", "ui", "user-interface", "zng"]
 trace_widget = ["zng-app/trace_widget"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 
 tracing = { version = "0.1", default-features = false }
 pastey = { version = "0.2", default-features = false }

--- a/crates/zng-wgt-text-input/Cargo.toml
+++ b/crates/zng-wgt-text-input/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-text-input"
-version = "0.13.7"
+version = "0.13.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,22 +12,22 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.6", default-features = false }
-zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.6", default-features = false }
-zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.6", default-features = false }
-zng-wgt-undo = { path = "../zng-wgt-undo", version = "0.11.6", default-features = false }
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
-zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.6", default-features = false }
-zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.7", default-features = false }
-zng-wgt-menu = { path = "../zng-wgt-menu", version = "0.12.7", default-features = false }
-zng-wgt-rule-line = { path = "../zng-wgt-rule-line", version = "0.12.7", default-features = false }
-zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.7", default-features = false }
-zng-wgt-data = { path = "../zng-wgt-data", version = "0.11.6", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
-zng-ext-clipboard = { path = "../zng-ext-clipboard", version = "0.11.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.7", default-features = false }
+zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.7", default-features = false }
+zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.7", default-features = false }
+zng-wgt-undo = { path = "../zng-wgt-undo", version = "0.11.7", default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.7", default-features = false }
+zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.8", default-features = false }
+zng-wgt-menu = { path = "../zng-wgt-menu", version = "0.12.8", default-features = false }
+zng-wgt-rule-line = { path = "../zng-wgt-rule-line", version = "0.12.8", default-features = false }
+zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.8", default-features = false }
+zng-wgt-data = { path = "../zng-wgt-data", version = "0.11.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }
+zng-ext-clipboard = { path = "../zng-ext-clipboard", version = "0.11.7", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }

--- a/crates/zng-wgt-text/Cargo.toml
+++ b/crates/zng-wgt-text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-text"
-version = "0.13.7"
+version = "0.13.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,23 +12,23 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
 zng-app-context = { path = "../zng-app-context", version = "0.12.2", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-color = { path = "../zng-color", version = "0.12.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-color = { path = "../zng-color", version = "0.12.7", default-features = false }
 zng-layout = { path = "../zng-layout", version = "0.10.4", default-features = false }
-zng-wgt-data = { path = "../zng-wgt-data", version = "0.11.6", default-features = false }
-zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.7", default-features = false }
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
-zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.6", default-features = false }
-zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.7", default-features = false }
-zng-ext-undo = { path = "../zng-ext-undo", version = "0.11.6", default-features = false }
-zng-ext-font = { path = "../zng-ext-font", version = "0.13.7", default-features = false }
-zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.7", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
-zng-ext-clipboard = { path = "../zng-ext-clipboard", version = "0.11.6", default-features = false }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
-zng-ext-window = { path = "../zng-ext-window", version = "0.12.6", default-features = false }
+zng-wgt-data = { path = "../zng-wgt-data", version = "0.11.7", default-features = false }
+zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.8", default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
+zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.7", default-features = false }
+zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.8", default-features = false }
+zng-ext-undo = { path = "../zng-ext-undo", version = "0.11.7", default-features = false }
+zng-ext-font = { path = "../zng-ext-font", version = "0.13.8", default-features = false }
+zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.8", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
+zng-ext-clipboard = { path = "../zng-ext-clipboard", version = "0.11.7", default-features = false }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }
+zng-ext-window = { path = "../zng-ext-window", version = "0.12.7", default-features = false }
 
 atomic = { version = "0.6", default-features = false, features = ["fallback"] }
 tracing = { version = "0.1", default-features = false }

--- a/crates/zng-wgt-toggle/Cargo.toml
+++ b/crates/zng-wgt-toggle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-toggle"
-version = "0.12.7"
+version = "0.12.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,24 +12,24 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.7", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.6", default-features = false }
-zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.6", default-features = false }
-zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.7", default-features = false }
-zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.7", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.6", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
-zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.6", default-features = false }
-zng-wgt-transform = { path = "../zng-wgt-transform", version = "0.11.6", default-features = false }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
-zng-ext-font = { path = "../zng-ext-font", version = "0.13.7", default-features = false }
-zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.7", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.8", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.7", default-features = false }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.7", default-features = false }
+zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.8", default-features = false }
+zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.8", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.7", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
+zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.7", default-features = false }
+zng-wgt-transform = { path = "../zng-wgt-transform", version = "0.11.7", default-features = false }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }
+zng-ext-font = { path = "../zng-ext-font", version = "0.13.8", default-features = false }
+zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.8", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
-zng-ext-window = { path = "../zng-ext-window", version = "0.12.6", default-features = false }
+zng-ext-window = { path = "../zng-ext-window", version = "0.12.7", default-features = false }
 
 parking_lot = { version = "0.12", default-features = false }
 tracing = { version = "0.1", default-features = false }

--- a/crates/zng-wgt-tooltip/Cargo.toml
+++ b/crates/zng-wgt-tooltip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-tooltip"
-version = "0.13.7"
+version = "0.13.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,12 +12,12 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.6", default-features = false }
-zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.7", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.6", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.7", default-features = false }
+zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.8", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.7", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }

--- a/crates/zng-wgt-transform/Cargo.toml
+++ b/crates/zng-wgt-transform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-transform"
-version = "0.11.6"
+version = "0.11.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,6 +12,6 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
 
 euclid = { version = "0.22", default-features = false, features = ["std"] }

--- a/crates/zng-wgt-undo-history/Cargo.toml
+++ b/crates/zng-wgt-undo-history/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-undo-history"
-version = "0.12.7"
+version = "0.12.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,16 +12,16 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
-zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.7", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.7", default-features = false }
-zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.6", default-features = false }
-zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.6", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
-zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.6", default-features = false }
-zng-ext-undo = { path = "../zng-ext-undo", version = "0.11.6", default-features = false }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
-zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.7", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
+zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.8", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.8", default-features = false }
+zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.7", default-features = false }
+zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.7", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.7", default-features = false }
+zng-ext-undo = { path = "../zng-ext-undo", version = "0.11.7", default-features = false }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }
+zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.8", default-features = false }

--- a/crates/zng-wgt-undo/Cargo.toml
+++ b/crates/zng-wgt-undo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-undo"
-version = "0.11.6"
+version = "0.11.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,7 +12,7 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-ext-undo = { path = "../zng-ext-undo", version = "0.11.6", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-ext-undo = { path = "../zng-ext-undo", version = "0.11.7", default-features = false }
 
 tracing = { version = "0.1", default-features = false, features = ["std"] }

--- a/crates/zng-wgt-webrender-debug/Cargo.toml
+++ b/crates/zng-wgt-webrender-debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-webrender-debug"
-version = "0.12.6"
+version = "0.12.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,10 +12,10 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-ext-window = { path = "../zng-ext-window", version = "0.12.6", default-features = false }
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-ext-window = { path = "../zng-ext-window", version = "0.12.7", default-features = false }
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false }
 
 # path = "../../../zng-webrender/webrender_api" for testing webrender updates
 webrender-api = { package = "zng-webrender-api", version = "0.66.0", default-features = false }

--- a/crates/zng-wgt-window/Cargo.toml
+++ b/crates/zng-wgt-window/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-window"
-version = "0.15.7"
+version = "0.15.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -18,26 +18,26 @@ image = ["zng-ext-window/image"]
 config = ["dep:zng-ext-config"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-ext-window = { path = "../zng-ext-window", version = "0.12.6", default-features = false }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
-zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.7", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-ext-window = { path = "../zng-ext-window", version = "0.12.7", default-features = false }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }
+zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.8", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
-zng-color = { path = "../zng-color", version = "0.12.6", default-features = false }
-zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.6", default-features = false }
-zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.6", default-features = false }
-zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.6", default-features = false }
+zng-color = { path = "../zng-color", version = "0.12.7", default-features = false }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.7", default-features = false }
+zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.7", default-features = false }
+zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.7", default-features = false }
 
-zng-ext-config = { path = "../zng-ext-config", version = "0.12.6", default-features = false, optional = true }
+zng-ext-config = { path = "../zng-ext-config", version = "0.12.7", default-features = false, optional = true }
 
 # used only by fallback_chrome
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
-zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.6", default-features = false }
-zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.7", default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
+zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.7", default-features = false }
+zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.8", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 pastey = { version = "0.2", default-features = false }

--- a/crates/zng-wgt-wrap/Cargo.toml
+++ b/crates/zng-wgt-wrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt-wrap"
-version = "0.12.7"
+version = "0.12.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -12,10 +12,10 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [dependencies]
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
-zng-ext-font = { path = "../zng-ext-font", version = "0.13.7", default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
+zng-ext-font = { path = "../zng-ext-font", version = "0.13.8", default-features = false }
 zng-layout = { path = "../zng-layout", version = "0.10.4", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
 
 tracing = { version = "0.1", default-features = false }

--- a/crates/zng-wgt/Cargo.toml
+++ b/crates/zng-wgt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng-wgt"
-version = "0.14.6"
+version = "0.14.7"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -17,8 +17,8 @@ http = ["zng-task/http"]
 
 [dependencies]
 zng-clone-move = { path = "../zng-clone-move", version = "0.4.0", default-features = false }
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-color = { path = "../zng-color", version = "0.12.6", default-features = false }
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-color = { path = "../zng-color", version = "0.12.7", default-features = false }
 zng-app-context = { path = "../zng-app-context", version = "0.12.2", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
 zng-state-map = { path = "../zng-state-map", version = "0.10.0", default-features = false }

--- a/crates/zng/Cargo.toml
+++ b/crates/zng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zng"
-version = "0.21.7"
+version = "0.21.8"
 authors = ["The Zng Project Developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
@@ -474,84 +474,84 @@ zng-app-context = { path = "../zng-app-context", version = "0.12.2", default-fea
 zng-layout = { path = "../zng-layout", version = "0.10.4", default-features = false }
 zng-var = { path = "../zng-var", version = "0.13.4", default-features = false }
 zng-task = { path = "../zng-task", version = "0.12.5", default-features = false }
-zng-color = { path = "../zng-color", version = "0.12.6", default-features = false }
+zng-color = { path = "../zng-color", version = "0.12.7", default-features = false }
 zng-env = { path = "../zng-env", version = "0.10.2", default-features = false }
 zng-unique-id = { path = "../zng-unique-id", version = "0.11.0", default-features = false }
 
 # app
-zng-app = { path = "../zng-app", version = "0.22.6", default-features = false }
-zng-ext-fs-watcher = { path = "../zng-ext-fs-watcher", version = "0.11.6", optional = true, default-features = false }
-zng-ext-config = { path = "../zng-ext-config", version = "0.12.6", default-features = false, optional = true }
-zng-ext-font = { path = "../zng-ext-font", version = "0.13.7", default-features = false }
-zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.7", features = [
+zng-app = { path = "../zng-app", version = "0.22.7", default-features = false }
+zng-ext-fs-watcher = { path = "../zng-ext-fs-watcher", version = "0.11.7", optional = true, default-features = false }
+zng-ext-config = { path = "../zng-ext-config", version = "0.12.7", default-features = false, optional = true }
+zng-ext-font = { path = "../zng-ext-font", version = "0.13.8", default-features = false }
+zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.14.8", features = [
     "tar",
 ], default-features = false }
 
-zng-ext-audio = { path = "../zng-ext-audio", version = "0.2.6", optional = true, default-features = false }
-zng-ext-image = { path = "../zng-ext-image", version = "0.11.6", optional = true, default-features = false }
-zng-ext-svg = { path = "../zng-ext-svg", version = "0.10.6", optional = true, default-features = false }
-zng-ext-clipboard = { path = "../zng-ext-clipboard", version = "0.11.6", optional = true, default-features = false }
-zng-ext-window = { path = "../zng-ext-window", version = "0.12.6", optional = true, default-features = false }
-zng-ext-input = { path = "../zng-ext-input", version = "0.14.6", default-features = false }
-zng-ext-undo = { path = "../zng-ext-undo", version = "0.11.6", optional = true, default-features = false }
-zng-ext-hot-reload = { path = "../zng-ext-hot-reload", version = "0.10.6", optional = true, default-features = false }
+zng-ext-audio = { path = "../zng-ext-audio", version = "0.2.7", optional = true, default-features = false }
+zng-ext-image = { path = "../zng-ext-image", version = "0.11.7", optional = true, default-features = false }
+zng-ext-svg = { path = "../zng-ext-svg", version = "0.10.7", optional = true, default-features = false }
+zng-ext-clipboard = { path = "../zng-ext-clipboard", version = "0.11.7", optional = true, default-features = false }
+zng-ext-window = { path = "../zng-ext-window", version = "0.12.7", optional = true, default-features = false }
+zng-ext-input = { path = "../zng-ext-input", version = "0.14.7", default-features = false }
+zng-ext-undo = { path = "../zng-ext-undo", version = "0.11.7", optional = true, default-features = false }
+zng-ext-hot-reload = { path = "../zng-ext-hot-reload", version = "0.10.7", optional = true, default-features = false }
 
 # widgets
-zng-wgt = { path = "../zng-wgt", version = "0.14.6", default-features = false }
-zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.7", default-features = false }
-zng-wgt-transform = { path = "../zng-wgt-transform", version = "0.11.6", default-features = false }
-zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.6", default-features = false }
-zng-wgt-data = { path = "../zng-wgt-data", version = "0.11.6", optional = true, default-features = false }
-zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.6", optional = true, default-features = false }
-zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.6", default-features = false }
-zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.6", default-features = false }
-zng-wgt-undo = { path = "../zng-wgt-undo", version = "0.11.6", optional = true, default-features = false }
-zng-wgt-data-view = { path = "../zng-wgt-data-view", version = "0.12.6", optional = true, default-features = false }
-zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.6", default-features = false }
-zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.6", default-features = false }
-zng-wgt-checkerboard = { path = "../zng-wgt-checkerboard", version = "0.12.6", optional = true, default-features = false }
-zng-wgt-window = { path = "../zng-wgt-window", version = "0.15.7", optional = true, default-features = false }
-zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.6", default-features = false }
-zng-wgt-undo-history = { path = "../zng-wgt-undo-history", version = "0.12.7", optional = true, default-features = false }
-zng-wgt-image = { path = "../zng-wgt-image", version = "0.12.7", optional = true, default-features = false }
-zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.7", default-features = false }
-zng-wgt-text-input = { path = "../zng-wgt-text-input", version = "0.13.7", optional = true, default-features = false }
-zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.7", default-features = false, optional = true }
-zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.6", optional = true, default-features = false }
-zng-wgt-panel = { path = "../zng-wgt-panel", version = "0.12.7", default-features = false }
-zng-wgt-grid = { path = "../zng-wgt-grid", version = "0.12.7", optional = true, default-features = false }
-zng-wgt-wrap = { path = "../zng-wgt-wrap", version = "0.12.7", optional = true, default-features = false }
-zng-wgt-shortcut = { path = "../zng-wgt-shortcut", version = "0.6.7", optional = true, default-features = false }
-zng-wgt-rule-line = { path = "../zng-wgt-rule-line", version = "0.12.7", optional = true, default-features = false }
-zng-wgt-toggle = { path = "../zng-wgt-toggle", version = "0.12.7", optional = true, default-features = false }
-zng-wgt-menu = { path = "../zng-wgt-menu", version = "0.12.7", optional = true, default-features = false }
-zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.7", optional = true, default-features = false }
-zng-wgt-ansi-text = { path = "../zng-wgt-ansi-text", version = "0.12.7", optional = true, default-features = false }
-zng-wgt-tooltip = { path = "../zng-wgt-tooltip", version = "0.13.7", optional = true, default-features = false }
-zng-wgt-markdown = { path = "../zng-wgt-markdown", version = "0.12.7", optional = true, default-features = false }
-zng-wgt-inspector = { path = "../zng-wgt-inspector", version = "0.11.7", optional = true, default-features = false }
-zng-wgt-settings = { path = "../zng-wgt-settings", version = "0.10.7", optional = true, default-features = false }
-zng-wgt-dialog = { path = "../zng-wgt-dialog", version = "0.10.7", optional = true, default-features = false }
-zng-wgt-progress = { path = "../zng-wgt-progress", version = "0.10.7", optional = true, default-features = false }
-zng-wgt-slider = { path = "../zng-wgt-slider", version = "0.10.6", optional = true, default-features = false }
+zng-wgt = { path = "../zng-wgt", version = "0.14.7", default-features = false }
+zng-wgt-access = { path = "../zng-wgt-access", version = "0.11.8", default-features = false }
+zng-wgt-transform = { path = "../zng-wgt-transform", version = "0.11.7", default-features = false }
+zng-wgt-input = { path = "../zng-wgt-input", version = "0.11.7", default-features = false }
+zng-wgt-data = { path = "../zng-wgt-data", version = "0.11.7", optional = true, default-features = false }
+zng-wgt-filter = { path = "../zng-wgt-filter", version = "0.11.7", optional = true, default-features = false }
+zng-wgt-size-offset = { path = "../zng-wgt-size-offset", version = "0.11.7", default-features = false }
+zng-wgt-container = { path = "../zng-wgt-container", version = "0.13.7", default-features = false }
+zng-wgt-undo = { path = "../zng-wgt-undo", version = "0.11.7", optional = true, default-features = false }
+zng-wgt-data-view = { path = "../zng-wgt-data-view", version = "0.12.7", optional = true, default-features = false }
+zng-wgt-fill = { path = "../zng-wgt-fill", version = "0.11.7", default-features = false }
+zng-wgt-style = { path = "../zng-wgt-style", version = "0.12.7", default-features = false }
+zng-wgt-checkerboard = { path = "../zng-wgt-checkerboard", version = "0.12.7", optional = true, default-features = false }
+zng-wgt-window = { path = "../zng-wgt-window", version = "0.15.8", optional = true, default-features = false }
+zng-wgt-layer = { path = "../zng-wgt-layer", version = "0.12.7", default-features = false }
+zng-wgt-undo-history = { path = "../zng-wgt-undo-history", version = "0.12.8", optional = true, default-features = false }
+zng-wgt-image = { path = "../zng-wgt-image", version = "0.12.8", optional = true, default-features = false }
+zng-wgt-text = { path = "../zng-wgt-text", version = "0.13.8", default-features = false }
+zng-wgt-text-input = { path = "../zng-wgt-text-input", version = "0.13.8", optional = true, default-features = false }
+zng-wgt-button = { path = "../zng-wgt-button", version = "0.13.8", default-features = false, optional = true }
+zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.12.7", optional = true, default-features = false }
+zng-wgt-panel = { path = "../zng-wgt-panel", version = "0.12.8", default-features = false }
+zng-wgt-grid = { path = "../zng-wgt-grid", version = "0.12.8", optional = true, default-features = false }
+zng-wgt-wrap = { path = "../zng-wgt-wrap", version = "0.12.8", optional = true, default-features = false }
+zng-wgt-shortcut = { path = "../zng-wgt-shortcut", version = "0.6.8", optional = true, default-features = false }
+zng-wgt-rule-line = { path = "../zng-wgt-rule-line", version = "0.12.8", optional = true, default-features = false }
+zng-wgt-toggle = { path = "../zng-wgt-toggle", version = "0.12.8", optional = true, default-features = false }
+zng-wgt-menu = { path = "../zng-wgt-menu", version = "0.12.8", optional = true, default-features = false }
+zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.13.8", optional = true, default-features = false }
+zng-wgt-ansi-text = { path = "../zng-wgt-ansi-text", version = "0.12.8", optional = true, default-features = false }
+zng-wgt-tooltip = { path = "../zng-wgt-tooltip", version = "0.13.8", optional = true, default-features = false }
+zng-wgt-markdown = { path = "../zng-wgt-markdown", version = "0.12.8", optional = true, default-features = false }
+zng-wgt-inspector = { path = "../zng-wgt-inspector", version = "0.11.8", optional = true, default-features = false }
+zng-wgt-settings = { path = "../zng-wgt-settings", version = "0.10.8", optional = true, default-features = false }
+zng-wgt-dialog = { path = "../zng-wgt-dialog", version = "0.10.8", optional = true, default-features = false }
+zng-wgt-progress = { path = "../zng-wgt-progress", version = "0.10.8", optional = true, default-features = false }
+zng-wgt-slider = { path = "../zng-wgt-slider", version = "0.10.7", optional = true, default-features = false }
 
-zng-wgt-material-icons = { path = "../zng-wgt-material-icons", version = "0.12.7", default-features = false, optional = true }
-zng-ext-single-instance = { path = "../zng-ext-single-instance", version = "0.12.6", optional = true, default-features = false }
+zng-wgt-material-icons = { path = "../zng-wgt-material-icons", version = "0.12.8", default-features = false, optional = true }
+zng-ext-single-instance = { path = "../zng-ext-single-instance", version = "0.12.7", optional = true, default-features = false }
 
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 # view
-zng-view-api = { path = "../zng-view-api", version = "0.19.6", default-features = false, features = [
+zng-view-api = { path = "../zng-view-api", version = "0.19.7", default-features = false, features = [
     "var",
 ] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-zng-view = { path = "../zng-view", version = "0.16.7", default-features = false, optional = true }
+zng-view = { path = "../zng-view", version = "0.16.8", default-features = false, optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android", target_os = "ios")))'.dependencies]
-zng-view-prebuilt = { path = "../zng-view-prebuilt", version = "0.21.7", optional = true, default-features = false, features = [
+zng-view-prebuilt = { path = "../zng-view-prebuilt", version = "0.21.8", optional = true, default-features = false, features = [
     "embedded",
 ] }
 

--- a/crates/zng/README.md
+++ b/crates/zng/README.md
@@ -10,7 +10,7 @@ First add `zng` to your `Cargo.toml`, or call `cargo add zng -F view_prebuilt`:
 
 ```toml
 [dependencies]
-zng = { version = "0.21.7", features = ["view_prebuilt"] }
+zng = { version = "0.21.8", features = ["view_prebuilt"] }
 ```
 
 Then create your first window:

--- a/crates/zng/src/app.rs
+++ b/crates/zng/src/app.rs
@@ -23,7 +23,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! zng = { version = "0.21.7", features = ["view_prebuilt"] }
+//! zng = { version = "0.21.8", features = ["view_prebuilt"] }
 //! ```
 //!
 //! ```no_run

--- a/crates/zng/src/env.rs
+++ b/crates/zng/src/env.rs
@@ -99,7 +99,7 @@ pub use zng_env::init_built_res;
 ///
 /// ```toml
 /// [dependencies]
-/// zng = "0.21.7"
+/// zng = "0.21.8"
 ///
 /// [target.'cfg(windows)'.build-dependencies]
 /// zng-env = { version = "0.10.2", features = ["build_cli_com_proxy"] }

--- a/crates/zng/src/icon.rs
+++ b/crates/zng/src/icon.rs
@@ -75,7 +75,7 @@ pub use zng_wgt_text::icon::{GlyphIcon, GlyphSource, Icon, ico_color, ico_size};
 /// [Material Design Icons]: https://github.com/google/material-design-icons
 ///
 /// ```toml
-/// zng = { version = "0.21.7", features = ["material_icons"] }
+/// zng = { version = "0.21.8", features = ["material_icons"] }
 /// ```
 ///
 /// Handlers are registered for [`ICONS`] that provides the icons, the raw codepoints and glyph icon metadata is available in each font module.

--- a/crates/zng/src/lib.rs
+++ b/crates/zng/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! zng = { version = "0.21.7", features = ["view_prebuilt"] }
+//! zng = { version = "0.21.8", features = ["view_prebuilt"] }
 //! ```
 //!
 //! Then create your first app:


### PR DESCRIPTION
This is a quick release to fix a serious image decoding issue in prebuilt.

AVIF image format did not define a magic number and that triggered an error that causes it to match before any other format. The AVIF format is available in prebuilt so all image decoding without extension is broken in 0.21.7.