### PR TITLE
Fix `can_<command>` properties holding command handle after deinit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `can_<command>` properties holding command handle after deinit.
 
 # 0.21.8
 

--- a/crates/zng-wgt/src/node.rs
+++ b/crates/zng-wgt/src/node.rs
@@ -974,15 +974,16 @@ pub fn command_contextual_enabled(child: UiNode, cmd: Command, ctx: ContextVar<b
                 CommandHandle::dummy()
             };
             if !ctx.capabilities().is_const() {
+                let handle = handle.enabled().clone();
+                let win_handle = win_handle.enabled().clone();
                 _handle = ctx.hook(move |a| {
-                    handle.enabled().set(*a.value());
-                    win_handle.enabled().set(*a.value());
+                    handle.set(*a.value());
+                    win_handle.set(*a.value());
                     true
                 });
-            } else {
-                _wgt_handle = handle;
-                _win_handle = win_handle;
             }
+            _wgt_handle = handle;
+            _win_handle = win_handle;
         }
         UiNodeOp::Deinit => {
             _handle = VarHandle::dummy();


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->