### PR TITLE
Force tar upgrade to avoid vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Force update `tar` dependency to avoid vulnerability.
 * Add machine translated l10n resources for German, Spanish, French, Italian, Japanese, Korean and Simplified Chinese.
 * Add `ImageEntry::format_name`.
 * Change `Image::on_load_layout` to await window load.

--- a/crates/zng-env/Cargo.toml
+++ b/crates/zng-env/Cargo.toml
@@ -34,7 +34,7 @@ zng-unique-id = { path = "../zng-unique-id", version = "0.11.0", default-feature
 zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
-tar = { version = "0.4", default-features = false, features = ["xattr"] }
+tar = { version = "0.4.45", default-features = false, features = ["xattr"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 linkme = { version = "0.3.35", default-features = false }

--- a/crates/zng-ext-l10n/Cargo.toml
+++ b/crates/zng-ext-l10n/Cargo.toml
@@ -44,7 +44,7 @@ semver = { version = "1.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"], optional = true }
-tar = { version = "0.4", default-features = false, features = ["xattr"], optional = true }
+tar = { version = "0.4.45", default-features = false, features = ["xattr"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/examples/localize/src/main.rs
+++ b/examples/localize/src/main.rs
@@ -204,6 +204,7 @@ fn locale_menu() -> UiNode {
                                 text::font_style = if actual { FontStyle::Normal } else { FontStyle::Italic };
                                 child = Text!("{l:#}");
                                 value::<zng::l10n::Lang> = l.clone();
+                                lang = l.clone();
                             }
                         });
                     }


### PR DESCRIPTION
https://github.com/alexcrichton/tar-rs/security/advisories/GHSA-j4xf-2g29-59ph

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->