### PR TITLE
Add explicit permissions restrictions to Github actions

### DIFF
--- a/.github/workflows/check-features.yml
+++ b/.github/workflows/check-features.yml
@@ -17,6 +17,8 @@ env:
 
 jobs:
   check-ubuntu:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -32,6 +34,8 @@ jobs:
       - run: cargo do check-all-features ${{ matrix.profile }} --max ${{ github.event.inputs.max }} --clean ${{ github.event.inputs.clean }} --chunk "${{ matrix.chunk }}/12"
       - run: cargo clean
   check-macos:
+    permissions:
+      contents: read
     needs: [check-ubuntu]
     strategy:
       fail-fast: false
@@ -47,6 +51,8 @@ jobs:
       - run: cargo do check-all-features ${{ matrix.profile }} --max ${{ github.event.inputs.max }} --clean ${{ github.event.inputs.clean }} --chunk "${{ matrix.chunk }}/12"
       - run: cargo clean
   check-windows:
+    permissions:
+      contents: read
     needs: [check-ubuntu]
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -9,6 +9,8 @@ on:
     - cron: "0 0 * * *" # daily
 jobs:
   security_audit:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ env:
 
 jobs:
   check-ubuntu:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +36,8 @@ jobs:
       - run: cargo do check
       - run: cargo do l10n --all --check
   check-macos:
+    permissions:
+      contents: read
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,6 +49,8 @@ jobs:
       - run: cargo do fmt --check --full
       - run: cargo do check
   check-windows:
+    permissions:
+      contents: read
     runs-on: windows-latest
     env:
       CC: 'clang-cl'
@@ -59,6 +65,8 @@ jobs:
       - run: cargo do fmt --check --full
       - run: cargo do check
   check-release:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [check-ubuntu]
     steps:
@@ -70,6 +78,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --examples --tests --release
   check-wasm:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [check-ubuntu]
     steps:
@@ -85,6 +95,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo do run-wasm multi --no-serve
   check-android:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [check-ubuntu]
     steps:
@@ -100,6 +112,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo do build-apk multi
   check-android-windows:
+    permissions:
+      contents: read
     runs-on: windows-latest
     needs: [check-windows]
     steps:
@@ -115,6 +129,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo do build-apk multi
   check-android-macos:
+    permissions:
+      contents: read
     runs-on: macos-latest
     needs: [check-macos]
     steps:
@@ -130,6 +146,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo do build-apk multi
   # check-ios:
+  # permissions:
+  #   contents: read
   #   runs-on: macos-latest
   #   needs: [check-macos]
   #   steps:
@@ -145,6 +163,8 @@ jobs:
   #     - uses: Swatinem/rust-cache@v2
   #     - run: cargo do build-ios multi
   doc:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [check-ubuntu]
     steps:
@@ -158,6 +178,8 @@ jobs:
           cache-targets: false # do doc needs a clean target/doc
       - run: cargo do doc
   test-ubuntu:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [check-ubuntu]
     env:
@@ -179,6 +201,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - run: cargo do test --nextest
   test-windows:
+    permissions:
+      contents: read
     runs-on: windows-latest
     needs: [check-windows]
     env:
@@ -201,6 +225,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - run: cargo do test --nextest
   test-macos:
+    permissions:
+      contents: read
     runs-on: macos-latest
     needs: [check-macos]
     env:
@@ -221,6 +247,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - run: cargo do test --nextest
   test-doc:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [check-ubuntu]
     steps:
@@ -232,6 +260,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo do test --doc
   test-macro:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [check-ubuntu]
     steps:
@@ -243,6 +273,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo do test --macro --all
   test-render-ubuntu:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [check-ubuntu]
     steps:
@@ -261,6 +293,8 @@ jobs:
         with:
           run: cargo do test --render --no-prebuilt
   test-render-windows:
+    permissions:
+      contents: read
     runs-on: windows-latest
     needs: [check-windows]
     env:
@@ -275,6 +309,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - run: cargo do test --render --no-prebuilt
   test-render-macos:
+    permissions:
+      contents: read
     runs-on: macos-latest
     needs: [check-macos]
     env:
@@ -288,6 +324,8 @@ jobs:
     - run: cargo do test --render --no-prebuilt
 
   test-all:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [
       check-release, 

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -13,6 +13,8 @@ env:
 
 jobs:
   check-ubuntu:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -29,6 +31,8 @@ jobs:
       - run: sudo apt-get update -o Acquire::Retries=5 && sudo apt install libfontconfig1-dev -o Acquire::Retries=5 && sudo apt install libasound2-dev -o Acquire::Retries=5
       - run: cargo +nightly check --workspace ${{ matrix.feature }} ${{ matrix.profile }} 
   check-windows:
+    permissions:
+      contents: read
     needs: [check-ubuntu]
     strategy:
       fail-fast: false
@@ -50,6 +54,8 @@ jobs:
           crate: cargo-about
       - run: cargo +nightly check --workspace ${{ matrix.feature }} ${{ matrix.profile }}
   check-macos:
+    permissions:
+      contents: read
     needs: [check-ubuntu]
     strategy:
       fail-fast: false
@@ -66,6 +72,8 @@ jobs:
           crate: cargo-about
       - run: cargo +nightly check --workspace ${{ matrix.feature }} ${{ matrix.profile }} 
   doc:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [check-ubuntu]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ env:
 
 jobs:
   check-ubuntu:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -63,6 +65,8 @@ jobs:
       - run: cargo clean
         if: ${{ github.event.inputs.skip_checks != 'true' }}
   check-windows:
+    permissions:
+      contents: read
     runs-on: windows-latest
     env:
       CC: 'clang-cl'
@@ -87,6 +91,8 @@ jobs:
       - run: cargo clean
         if: ${{ github.event.inputs.skip_checks != 'true' }}
   check-macos:
+    permissions:
+      contents: read
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -108,6 +114,8 @@ jobs:
       - run: cargo clean
         if: ${{ github.event.inputs.skip_checks != 'true' }}
   check-android:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -133,6 +141,8 @@ jobs:
         if: ${{ github.event.inputs.skip_checks != 'true' }}
 
   prebuild-ubuntu:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -205,6 +215,8 @@ jobs:
           if-no-files-found: error
           
   prebuild-windows:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -285,6 +297,8 @@ jobs:
           path: crates/zng-view-prebuilt/lib/zng_view.${{ matrix.target }}.dll
           if-no-files-found: error
   prebuild-macos:
+    permissions:
+      contents: read
     runs-on: macos-latest
     needs: [check-macos]
     env:
@@ -341,6 +355,8 @@ jobs:
           path: crates/zng-view-prebuilt/lib/libzng_view.aarch64-apple-darwin.dylib
           if-no-files-found: error
   prebuild-macos-x86:
+    permissions:
+      contents: read
     runs-on: macos-latest
     needs: [check-macos]
     env:
@@ -405,6 +421,8 @@ jobs:
         if: ${{ github.event.inputs.skip_doc != 'true' }}
 
   test-ubuntu:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [prebuild-ubuntu]
     steps:
@@ -457,6 +475,8 @@ jobs:
         if: ${{ github.event.inputs.skip_tests != 'true' }}
   
   test-windows:
+    permissions:
+      contents: read
     runs-on: windows-latest
     needs: [prebuild-windows]
     env:
@@ -501,6 +521,8 @@ jobs:
       - run: cargo clean
         if: ${{ github.event.inputs.skip_tests != 'true' }}
   test-macos:
+    permissions:
+      contents: read
     runs-on: macos-latest
     needs: [prebuild-macos]
     steps:
@@ -543,6 +565,8 @@ jobs:
         if: ${{ github.event.inputs.skip_tests != 'true' }}
 
   test-cargo-publish:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -672,6 +696,8 @@ jobs:
         if: ${{ env.HAS_CHANGES && github.event.inputs.skip_doc != 'true' }}
 
   publish-crates:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [publish-release, publish-doc]
     env:
@@ -688,6 +714,8 @@ jobs:
       - run: cargo do publish --execute ${{ github.run_attempt > 1 && '--no-burst' || '' }}
         if: ${{ github.event.inputs.skip_crates != 'true' }}
   test-previous:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [publish-crates]
     steps:
@@ -704,6 +732,8 @@ jobs:
 
 
   cleanup:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: always()
     needs: [publish-release, publish-doc]

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -9,6 +9,8 @@ env:
 
 jobs:
   semver-checks:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -15,6 +15,8 @@ env:
 
 jobs:
   doc:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,6 +58,8 @@ jobs:
           git push
 
   cleanup:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: always()
     needs: [publish-doc]


### PR DESCRIPTION
There where already restricted by organization settings, making them explicit as as suggestion from code scanning

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->