### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         if: ${{ github.event.inputs.skip_checks != 'true' }}
       - run: cargo do check
         if: ${{ github.event.inputs.skip_checks != 'true' }}
-      - run: cargo do clean
+      - run: cargo clean
         if: ${{ github.event.inputs.skip_checks != 'true' }}
       - run:  cargo check --workspace --examples --tests --release
         if: ${{ github.event.inputs.skip_checks != 'true' }}
@@ -107,7 +107,7 @@ jobs:
         if: ${{ github.event.inputs.skip_checks != 'true' }}
       - run: cargo do check
         if: ${{ github.event.inputs.skip_checks != 'true' }}
-      - run: cargo do clean
+      - run: cargo clean
         if: ${{ github.event.inputs.skip_checks != 'true' }}
       - run:  cargo check --workspace --examples --tests --release
         if: ${{ github.event.inputs.skip_checks != 'true' }}
@@ -469,7 +469,7 @@ jobs:
         uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
         with:
           run: cargo do test --render
-      - run: cargo do clean
+      - run: cargo clean
         if: ${{ github.event.inputs.skip_tests != 'true' }}
       - run: cargo do build -e focus --release
         if: ${{ github.event.inputs.skip_tests != 'true' }}
@@ -516,7 +516,7 @@ jobs:
         if: ${{ github.event.inputs.skip_tests != 'true' }}
       - run: cargo do test --render
         if: ${{ github.event.inputs.skip_tests != 'true' }}
-      - run: cargo do clean
+      - run: cargo clean
         if: ${{ github.event.inputs.skip_tests != 'true' }}
       - run: cargo do build -e focus --release
         if: ${{ github.event.inputs.skip_tests != 'true' }}
@@ -559,7 +559,7 @@ jobs:
         if: ${{ github.event.inputs.skip_tests != 'true' }}
       - run: cargo do test --render
         if: ${{ github.event.inputs.skip_tests != 'true' }}
-      - run: cargo do clean
+      - run: cargo clean
         if: ${{ github.event.inputs.skip_tests != 'true' }}
       - run: cargo do build -e focus --release
         if: ${{ github.event.inputs.skip_tests != 'true' }}


### PR DESCRIPTION
Change to add do tool to workspace means `cargo do clean` can't work on Windows. Workflow does not need it anyway because `cargo do clean` without args is the same as a full `cargo clean`.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->