### PR TITLE
Avoid deadlock in doctest

### DIFF
--- a/crates/zng-ext-l10n/src/lib.rs
+++ b/crates/zng-ext-l10n/src/lib.rs
@@ -95,11 +95,13 @@ on_process_start!(|args: &zng_env::ProcessStartArgs| {
 /// The message string syntax is the [Fluent Project] syntax, interpolations in the form of `"{$var}"` are resolved to a local `$var`.
 ///
 /// ```
+/// # fn demo() {
 /// # use zng_ext_l10n::*;
 /// # use zng_var::*;
 /// # let _scope = zng_app::APP.minimal();
 /// let name = var("World");
 /// let msg = l10n!("file/id.attribute", "Hello {$name}!");
+/// # }
 /// ```
 ///
 /// ## Key


### PR DESCRIPTION
Github Windows runner keeps getting deadlocked in some doctests, can't reproduce issue in my machine.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->