### PR TITLE
Disable "memory_profiler" in tests

### DIFF
--- a/crates/zng-app/src/memory_profiler.rs
+++ b/crates/zng-app/src/memory_profiler.rs
@@ -1,6 +1,13 @@
 #![cfg(all(
     feature = "memory_profiler",
-    not(any(target_arch = "wasm32", target_os = "android", target_os = "ios", test, doc))
+    not(any(
+        target_arch = "wasm32",
+        target_os = "android",
+        target_os = "ios",
+        test,
+        feature = "test_util",
+        doctest
+    ))
 ))]
 
 //! Memory profiler.

--- a/crates/zng/build.rs
+++ b/crates/zng/build.rs
@@ -11,6 +11,5 @@ fn main() {
         single_instance: { all(feature = "single_instance", not(any(android, wasm))) },
         crash_handler: { all(feature = "crash_handler", not(any(android, wasm))) },
         trace_recorder: { all(feature = "trace_recorder", not(any(android, wasm))) },
-        memory_profiler: { all(feature = "memory_profiler", not(any(android, wasm))) },
     }
 }

--- a/crates/zng/src/app.rs
+++ b/crates/zng/src/app.rs
@@ -631,8 +631,18 @@ pub mod trace_recorder {
 ///
 /// # Full API
 ///
-/// See [`zng_app::memory_profiler`] for the full API.
-#[cfg(memory_profiler)]
+/// See `zng_app::memory_profiler` for the full API.
 pub mod memory_profiler {
+    #[cfg(all(
+        feature = "memory_profiler",
+        not(any(
+            target_arch = "wasm32",
+            target_os = "android",
+            target_os = "ios",
+            test,
+            feature = "test_util",
+            doctest
+        ))
+    ))]
     pub use zng_app::memory_profiler::stop_recording;
 }

--- a/crates/zng/src/clipboard.rs
+++ b/crates/zng/src/clipboard.rs
@@ -92,11 +92,8 @@
 //! use zng::clipboard;
 //! use zng::prelude::*;
 //!
-//! # let mut app = APP.defaults().run_headless(false);
-//! # app.doc_test_window(async {
-//! let img_source = var(ImageSource::flood(layout::PxSize::splat(layout::Px(1)), colors::BLACK, None));
+//! # fn demo(img_source: Var<zng::image::ImageSource>) { let _ =
 //! Window! {
-//!     # widget::on_init = hn_once!(|_| {WINDOW.close();});
 //!     child_top = Button!(clipboard::PASTE_CMD.scoped(WINDOW.id()));
 //!     child = Image!(img_source.clone());
 //!     clipboard::on_paste = hn!(|_| {
@@ -105,7 +102,7 @@
 //!         }
 //!     });
 //! }
-//! # });
+//! # ;}
 //! ```
 //!
 //! # Full API


### PR DESCRIPTION
This may be the cause of deadlock in Github Windows runner. It should be disabled anyway but the cfg line was incorrect.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->