### PR TITLE
Add more `"system-ui"` font names on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Fix non-spacing marks rendering disconnected in text width ligatures disabled.
     - Non-spacing marks now are merged with previous segment, always uses segment level ligatures.
     - `TextSegmentKind::NonSpacingMark` can now only appear at the start of texts and may be removed in future releases.
-* Add `"system-ui"` fonts for Hindi on Windows, fixes Hindi rendering.
+* Add `"system-ui"` font names on Windows for hi, bn, te, as, gu, kn, mr, ta, ne, or, pa, si, ta.
 * Fix panic in `Text!` when an incorrect `render_update` happens before first `render` after view-process respawn.
 
 # 0.21.11

--- a/crates/zng-ext-font/src/lib.rs
+++ b/crates/zng-ext-font/src/lib.rs
@@ -2165,9 +2165,6 @@ impl GenericFontsService {
 
         let mut system_ui = LangMap::with_capacity(5);
 
-        // source: VSCode
-        // https://github.com/microsoft/vscode/blob/6825c886700ac11d07f7646d8d8119c9cdd9d288/src/vs/code/electron-sandbox/processExplorer/media/processExplorer.css
-
         if cfg!(windows) {
             system_ui.insert(
                 lang!("zh-Hans"),
@@ -2185,10 +2182,35 @@ impl GenericFontsService {
                 lang!("ko"),
                 ["Segoe UI", "Malgun Gothic", "Dotom", "Segoe Ui Emoji", "sans-serif"].into(),
             );
-            system_ui.insert(
+            for lang in [
                 lang!("hi"),
-                ["Segoe UI", "Nirmala UI", "Mangal", "Segoe Ui Emoji", "sans-serif"].into(),
+                lang!("bn"),
+                lang!("te"),
+                lang!("as"),
+                lang!("gu"),
+                lang!("kn"),
+                lang!("mr"),
+                lang!("ne"),
+                lang!("or"),
+                lang!("pa"),
+                lang!("si"),
+            ] {
+                system_ui.insert(lang, ["Segoe UI", "Nirmala UI", "Mangal", "Segoe Ui Emoji", "sans-serif"].into());
+            }
+            system_ui.insert(lang!("am"), ["Segoe UI", "Nyala", "Ebrima", "Segoe Ui Emoji", "sans-serif"].into());
+            system_ui.insert(
+                lang!("km"),
+                ["Segoe UI", "Khmer UI", "Leelawadee UI", "Segoe Ui Emoji", "sans-serif"].into(),
             );
+            system_ui.insert(
+                lang!("lo"),
+                ["Segoe UI", "lao UI", "Leelawadee UI", "Segoe Ui Emoji", "sans-serif"].into(),
+            );
+            system_ui.insert(lang!("th"), ["Segoe UI", "Leelawadee UI", "Segoe Ui Emoji", "sans-serif"].into());
+            for lang in [lang!("ml"), lang!("ta")] {
+                system_ui.insert(lang, ["Segoe UI", "Nirmala UI", "Segoe Ui Emoji", "sans-serif"].into());
+            }
+            system_ui.insert(lang!("my"), ["Segoe UI", "Myanmar Text", "Segoe Ui Emoji", "sans-serif"].into());
             system_ui.insert(lang!(und), ["Segoe UI", "Segoe Ui Emoji", "sans-serif"].into());
         } else if cfg!(target_os = "macos") {
             system_ui.insert(


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->