### PR TITLE
Fix Malay and Uzbek languages defaulting to RTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix Malay and Uzbek languages defaulting to RTL when no script tag is given.
 * Fix non-spacing marks rendering disconnected in text width ligatures disabled.
     - Non-spacing marks now are merged with previous segment, always uses segment level ligatures.
     - `TextSegmentKind::NonSpacingMark` can now only appear at the start of texts and may be removed in future releases.

--- a/crates/zng-ext-l10n/src/types.rs
+++ b/crates/zng-ext-l10n/src/types.rs
@@ -309,6 +309,14 @@ pub struct Lang(pub unic_langid::LanguageIdentifier);
 impl Lang {
     /// Returns character direction of the language.
     pub fn direction(&self) -> LayoutDirection {
+        if self == &lang!("ms") {
+            // Malay should default to "ms-Latn" that LTR, but unic_langid is matching "ms-Arab"
+            return LayoutDirection::LTR;
+        }
+        if self == &lang!("uz") {
+            // Uzbek should default to "uz-Latn"
+            return LayoutDirection::LTR;
+        }
         crate::from_unic_char_direction(self.0.character_direction())
     }
 


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->