### PR TITLE
Fix `is_mouse_active` stops updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `is_mouse_active` stops updating.
 * Change `IpcBytes` to not block on IO when deserializing named memmap.
     - Memmap reconnection now runs in parallel, only blocks on first read if not ready yet.
     - Reconnection errors are now panic on first read.

--- a/crates/zng-wgt-input/src/state.rs
+++ b/crates/zng-wgt-input/src/state.rs
@@ -516,9 +516,16 @@ pub fn is_mouse_active(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiN
 
             let id = WIDGET.id();
 
-            // activate on mouse move >= cfg.area
             let mut first_pos = None::<DipPoint>;
+
+            // update timer interval
+            let handle = cfg.hook(clmv!(activate, |_| {
+                activate.update();
+                true
+            }));
+            // activate on mouse move >= cfg.area
             let handle = MOUSE_MOVE_EVENT.hook(clmv!(activate, cfg, |args| {
+                let _hold = &handle;
                 if args.target.contains(id) {
                     let dist = if let Some(prev_pos) = first_pos {
                         (prev_pos - args.position).abs()
@@ -551,12 +558,7 @@ pub fn is_mouse_active(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiN
                 }
                 true
             }));
-            // update timer interval
-            let handle = cfg.hook(move |_| {
-                let _hold = &handle;
-                activate.update();
-                true
-            });
+            // event always hooks, so its ok to chain handles like this
             WIDGET.push_var_handle(handle);
         }
         UiNodeOp::Deinit => {


### PR DESCRIPTION
Init code uses a trick where each event handle holds the previous handle, to avoid pushing multiple entries to the `WIDGET.push_var_handle`, this is ok for event vars that always retain hooks, but the code also used this trick to hook to a context_var, that drops the hook when the context is not capable of updates. The fix was to move the context var hooking up.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->