### PR TITLE
Better cleanup of leftover memmap files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Now also cleans old memmap files not removed due to crash on first memmap usage, not just on exit.
 * Fix `is_mouse_active` stops updating.
 * Change `IpcBytes` to not block on IO when deserializing named memmap.
     - Memmap reconnection now runs in parallel, only blocks on first read if not ready yet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
-* Now also cleans old memmap files not removed due to crash on first memmap usage, not just on exit.
+* Better cleanup of leftover memmap files after crash.
+    - Now the crash-handler-process runs the cleanup after spawning the app-process.
+    - Add `zng_task::channel::cleanup_memmap_storage` for manual cleanup in advanced scenarios where the crash-handler is not used.
 * Fix `is_mouse_active` stops updating.
 * Change `IpcBytes` to not block on IO when deserializing named memmap.
     - Memmap reconnection now runs in parallel, only blocks on first read if not ready yet.

--- a/crates/zng-app/src/crash_handler.rs
+++ b/crates/zng-app/src/crash_handler.rs
@@ -1055,6 +1055,8 @@ fn run_process(
     let stdout = capture_and_print(app_process.stdout.take().unwrap(), false);
     let stderr = capture_and_print(app_process.stderr.take().unwrap(), true);
 
+    zng_task::channel::cleanup_memmap_storage();
+
     let status = app_process.wait()?;
 
     let stdout = match stdout.join() {

--- a/crates/zng-task/src/channel.rs
+++ b/crates/zng-task/src/channel.rs
@@ -38,7 +38,7 @@ pub use ipc::{IpcReceiver, IpcSender, IpcValue, NamedIpcReceiver, NamedIpcSender
 mod ipc_bytes;
 pub use ipc_bytes::{
     IpcBytes, IpcBytesCast, IpcBytesCastIntoIter, IpcBytesIntoIter, IpcBytesMut, IpcBytesMutCast, IpcBytesWriter, IpcBytesWriterBlocking,
-    WeakIpcBytes,
+    WeakIpcBytes, cleanup_memmap_storage,
 };
 
 #[cfg(ipc)]

--- a/crates/zng-task/src/channel/ipc_bytes.rs
+++ b/crates/zng-task/src/channel/ipc_bytes.rs
@@ -531,7 +531,10 @@ impl IpcBytes {
         let mut count = MEMMAP_DIR.lock();
 
         if *count == 0 {
+            // cleanup any leftover after crash
+            IpcBytes::cleanup_memmap_storage();
             zng_env::on_process_exit(|_| {
+                // cleanup own resources and any leftover of other instances
                 IpcBytes::cleanup_memmap_storage();
             });
         }
@@ -554,7 +557,7 @@ impl IpcBytes {
             }
         };
 
-        // read because some callers create a MmapMut
+        // read(true) because some callers create a MmapMut
         let file = fs::OpenOptions::new()
             .create(true)
             .read(true)

--- a/crates/zng-task/src/channel/ipc_bytes.rs
+++ b/crates/zng-task/src/channel/ipc_bytes.rs
@@ -532,10 +532,9 @@ impl IpcBytes {
 
         if *count == 0 {
             // cleanup any leftover after crash
-            IpcBytes::cleanup_memmap_storage();
             zng_env::on_process_exit(|_| {
                 // cleanup own resources and any leftover of other instances
-                IpcBytes::cleanup_memmap_storage();
+                cleanup_memmap_storage();
             });
         }
 
@@ -565,17 +564,6 @@ impl IpcBytes {
             .truncate(true)
             .open(&name)?;
         Ok((name, file))
-    }
-    #[cfg(ipc)]
-    fn cleanup_memmap_storage() {
-        if let Ok(dir) = fs::read_dir(zng_env::cache("zng-task-ipc-mem")) {
-            let entries: Vec<_> = dir.flatten().map(|e| e.path()).collect();
-            for entry in entries {
-                if entry.is_dir() {
-                    fs::remove_dir_all(entry).ok();
-                }
-            }
-        }
     }
 
     /// Memory map an existing file.
@@ -611,6 +599,22 @@ impl IpcBytes {
             map: IpcMemMapData::Connected(map, read_handle),
             is_custom: true,
         }))))
+    }
+}
+
+/// If built with `"ipc"` feature removes all leftover memmap files of crashed processes.
+///
+/// Note that this is already called on normal process exit if any memmap was created. It is also called
+/// by the crash handler process on startup after it spawns the app-process.
+pub fn cleanup_memmap_storage() {
+    #[cfg(ipc)]
+    if let Ok(dir) = fs::read_dir(zng_env::cache("zng-task-ipc-mem")) {
+        let entries: Vec<_> = dir.flatten().map(|e| e.path()).collect();
+        for entry in entries {
+            if entry.is_dir() {
+                fs::remove_dir_all(entry).ok();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->