### PR TITLE
Optimizations for better handling of gigapixel images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Refactor `ImageEntry::with_best_reduce` to not select entries more than twice the requested size.
+    - Fixes low framerate when presenting partially loaded gigapixel images.
 * Better cleanup of leftover memmap files after crash.
     - Now crash-handler-process runs the cleanup after spawning the app-process.
     - Now app-process runs cleanup on view-process respawn.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
 * Better cleanup of leftover memmap files after crash.
-    - Now the crash-handler-process runs the cleanup after spawning the app-process.
+    - Now crash-handler-process runs the cleanup after spawning the app-process.
+    - Now app-process runs cleanup on view-process respawn.
     - Add `zng_task::channel::cleanup_memmap_storage` for manual cleanup in advanced scenarios where the crash-handler is not used.
 * Fix `is_mouse_active` stops updating.
 * Change `IpcBytes` to not block on IO when deserializing named memmap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unreleased
 
-* Refactor `ImageEntry::with_best_reduce` to not select entries more than twice the requested size.
+* Image widget now does not render large images when a better reduced alternate is loading.
     - Fixes low framerate when presenting partially loaded gigapixel images.
+    - Refactor `ImageEntry::with_best_reduce` to not select entries more than twice the requested size.
+    - Also applies to mask properties.
 * Better cleanup of leftover memmap files after crash.
     - Now crash-handler-process runs the cleanup after spawning the app-process.
     - Now app-process runs cleanup on view-process respawn.

--- a/crates/zng-app/src/crash_handler.rs
+++ b/crates/zng-app/src/crash_handler.rs
@@ -1055,6 +1055,7 @@ fn run_process(
     let stdout = capture_and_print(app_process.stdout.take().unwrap(), false);
     let stderr = capture_and_print(app_process.stderr.take().unwrap(), true);
 
+    // cleanup any leftover memmap files
     zng_task::channel::cleanup_memmap_storage();
 
     let status = app_process.wait()?;
@@ -1076,6 +1077,9 @@ fn run_process(
             Err(p) => std::panic::resume_unwind(p),
         };
     }
+
+    // cleanup any memmap files that where not dropped before exit
+    zng_task::channel::cleanup_memmap_storage();
 
     Ok((status, [stdout, stderr], dump_file))
 }

--- a/crates/zng-ext-image/src/types.rs
+++ b/crates/zng-ext-image/src/types.rs
@@ -363,7 +363,11 @@ impl ImageEntry {
 
     /// Calls `visit` with the image or [`ImageEntryKind::Reduced`] entry that is nearest to `size` and greater or equal to it.
     ///
-    /// Does not call `visit` if none of the images are loaded, returns `None` in that case.
+    /// Does not call `visit` if none of the images are loaded.
+    ///
+    /// Does not call `visit` if the only loaded entry is more than twice the `size` and there is a better entry loading.
+    ///
+    /// Returns `None` if `visit` is not called.
     pub fn with_best_reduce<R>(&self, size: PxSize, visit: impl FnOnce(&ImageEntry) -> R) -> Option<R> {
         fn cmp(target_size: PxSize, a: PxSize, b: PxSize) -> std::cmp::Ordering {
             let target_ratio = target_size.width.0 as f32 / target_size.height.0 as f32;
@@ -398,11 +402,16 @@ impl ImageEntry {
             }
         }
 
+        let mut best_loading_i = usize::MAX;
+        let mut best_loading_size = PxSize::zero();
         let mut best_i = usize::MAX;
         let mut best_size = PxSize::zero();
 
         if self.is_loaded() {
             best_i = self.entries.len();
+            best_size = self.size();
+        } else if self.is_loading() {
+            best_loading_i = self.entries.len();
             best_size = self.size();
         }
 
@@ -414,18 +423,29 @@ impl ImageEntry {
                         best_i = i;
                         best_size = entry_size;
                     }
+                } else if e.is_loading() {
+                    let entry_size = e.size();
+                    if cmp(size, entry_size, best_loading_size).is_lt() {
+                        best_loading_i = i;
+                        best_loading_size = entry_size;
+                    }
                 }
             })
         }
 
-        if best_i == usize::MAX {
-            // image and all reduced are smaller than `size`, return the largest to reduce upscaling
-            None
-        } else if best_i == self.entries.len() {
-            Some(visit(self))
-        } else {
-            Some(self.entries[best_i].with(visit))
+        if best_i != usize::MAX {
+            // found loaded match
+            let best_area = best_size.area();
+            if best_area < size.area() * 2 || best_loading_i == usize::MAX || best_loading_size.area() > best_area {
+                // and is within twice the expected size or has no better loading entry
+                return if best_i == self.entries.len() {
+                    Some(visit(self))
+                } else {
+                    Some(self.entries[best_i].with(visit))
+                };
+            }
         }
+        None
     }
 
     /// Connection to the image resource in the view-process.

--- a/crates/zng-view-api/src/app_process.rs
+++ b/crates/zng-view-api/src/app_process.rs
@@ -511,6 +511,9 @@ impl Controller {
             }
         };
 
+        // cleanup any memmap from view-process
+        zng_task::channel::cleanup_memmap_storage();
+
         // try print stdout/err and exit code.
         if let Some(c) = exit_status {
             tracing::info!(target: "vp_respawn", "view-process killed");

--- a/crates/zng-wgt-image/src/mask.rs
+++ b/crates/zng-wgt-image/src/mask.rs
@@ -4,7 +4,8 @@
 //! [`mask_mode`]: fn@mask_mode
 
 use zng_ext_image::{
-    IMAGES, ImageCacheMode, ImageDownscaleMode, ImageEntriesMode, ImageLimits, ImageMaskMode, ImageOptions, ImageRenderArgs, ImageSource,
+    IMAGES, ImageCacheMode, ImageDownscaleMode, ImageEntriesMode, ImageEntryKind, ImageLimits, ImageMaskMode, ImageOptions,
+    ImageRenderArgs, ImageSource,
 };
 use zng_wgt::prelude::*;
 
@@ -23,6 +24,7 @@ pub fn mask_image(child: impl IntoUiNode, source: impl IntoVar<ImageSource>) -> 
     let mut img = None;
     let mut img_size = PxSize::zero();
     let mut rect = PxRect::zero();
+    let mut alternate_loading_handles = VarHandles::dummy();
 
     match_node(child, move |c, op| match op {
         UiNodeOp::Init => {
@@ -61,6 +63,7 @@ pub fn mask_image(child: impl IntoUiNode, source: impl IntoVar<ImageSource>) -> 
         UiNodeOp::Deinit => {
             c.deinit();
             img = None;
+            alternate_loading_handles = VarHandles::dummy();
         }
         UiNodeOp::Update { .. } => {
             // load
@@ -191,9 +194,33 @@ pub fn mask_image(child: impl IntoUiNode, source: impl IntoVar<ImageSource>) -> 
                 return;
             }
             img.as_ref().unwrap().0.with(|img| {
+                let mut ideal_match = false;
+
                 img.with_best_reduce(rect.size, |img| {
+                    let dist = img.size().width - rect.size.width;
+                    ideal_match = dist > Px(0) && dist < Px(400);
+
                     frame.push_mask(img, rect, |frame| c.render(frame));
                 });
+
+                if ideal_match {
+                    alternate_loading_handles = VarHandles::dummy();
+                } else if alternate_loading_handles.is_dummy() {
+                    let id = WIDGET.id();
+                    for entry in img.entries() {
+                        if entry.with(|e| matches!(e.entry_kind(), ImageEntryKind::Reduced { .. }) && e.is_loading()) {
+                            let handle = entry.hook(move |a| {
+                                if a.value().is_loaded() {
+                                    UPDATES.render(id);
+                                    true
+                                } else {
+                                    a.value().is_loading()
+                                }
+                            });
+                            alternate_loading_handles.push(handle);
+                        }
+                    }
+                }
             });
         }
         _ => {}

--- a/crates/zng-wgt-image/src/node.rs
+++ b/crates/zng-wgt-image/src/node.rs
@@ -1,6 +1,6 @@
 //! UI nodes used for building the image widget.
 
-use zng_ext_image::{IMAGES, ImageCacheMode, ImageOptions, ImageRenderArgs};
+use zng_ext_image::{IMAGES, ImageCacheMode, ImageEntryKind, ImageOptions, ImageRenderArgs};
 use zng_wgt_stack::stack_nodes;
 
 use super::image_properties::{
@@ -193,6 +193,7 @@ pub fn image_presenter() -> UiNode {
     let mut render_tile_spacing = PxSize::zero();
     let mut render_offset = PxVector::zero();
     let spatial_id = SpatialFrameId::new_unique();
+    let mut alternate_loading_handles = VarHandles::dummy();
 
     match_node_leaf(move |op| match op {
         UiNodeOp::Init => {
@@ -209,6 +210,9 @@ pub fn image_presenter() -> UiNode {
                 .sub_var_render(&IMAGE_RENDERING_VAR);
 
             img_size = CONTEXT_IMAGE_VAR.with(ImageEntry::size);
+        }
+        UiNodeOp::Deinit => {
+            alternate_loading_handles = VarHandles::dummy();
         }
         UiNodeOp::Update { .. } => {
             if let Some(img) = CONTEXT_IMAGE_VAR.get_new() {
@@ -403,7 +407,11 @@ pub fn image_presenter() -> UiNode {
                 return;
             }
             CONTEXT_IMAGE_VAR.with(|img| {
+                let mut ideal_match = false;
                 img.with_best_reduce(render_tile_size, |img| {
+                    let dist = img.size().width - render_tile_size.width;
+                    ideal_match = dist > Px(0) && dist < Px(400);
+
                     if render_offset != PxVector::zero() {
                         let transform = PxTransform::from(render_offset);
                         frame.push_reference_frame(spatial_id.into(), FrameValue::Value(transform), true, false, |frame| {
@@ -426,7 +434,29 @@ pub fn image_presenter() -> UiNode {
                             IMAGE_RENDERING_VAR.get(),
                         );
                     }
-                })
+                });
+
+                if ideal_match {
+                    alternate_loading_handles = VarHandles::dummy();
+                } else if alternate_loading_handles.is_dummy() {
+                    // can not match if only a very large alternate is loaded,
+                    // in that case we will try render again on any Reduced alternate loaded, and if
+                    // the primary image is the one loading the normal Update handler already requests render
+                    let id = WIDGET.id();
+                    for entry in img.entries() {
+                        if entry.with(|e| matches!(e.entry_kind(), ImageEntryKind::Reduced { .. }) && e.is_loading()) {
+                            let handle = entry.hook(move |a| {
+                                if a.value().is_loaded() {
+                                    UPDATES.render(id);
+                                    true
+                                } else {
+                                    a.value().is_loading()
+                                }
+                            });
+                            alternate_loading_handles.push(handle);
+                        }
+                    }
+                }
             });
         }
         _ => {}


### PR DESCRIPTION
Refactor ImageEntry::with_best_reduce

Does not render massive image when a better reduced alternate is loading. This fixes low framerate and crashes in machines with low VRAM as webrender struggles to tile and resize massive images to fit.