### PR TITLE
Change impl `Mul<i32>` and `Mul<f32>` for `Px` to be saturating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Change impl `Mul<i32>` and `Mul<f32>` for `Px` to be saturating to match other operations.
 * Image widget now does not render large images when a better reduced alternate is loading.
     - Fixes low framerate when presenting partially loaded gigapixel images.
     - Refactor `ImageEntry::with_best_reduce` to not select entries more than twice the requested size.

--- a/crates/zng-ext-image/src/types.rs
+++ b/crates/zng-ext-image/src/types.rs
@@ -435,8 +435,7 @@ impl ImageEntry {
 
         if best_i != usize::MAX {
             // found loaded match
-            let best_area = best_size.area();
-            if best_area < size.area() * 2 || best_loading_i == usize::MAX || best_loading_size.area() > best_area {
+            if best_size.height < size.height * 2 || best_loading_i == usize::MAX || best_loading_size.height > best_size.height {
                 // and is within twice the expected size or has no better loading entry
                 return if best_i == self.entries.len() {
                     Some(visit(self))

--- a/crates/zng-unit/src/px_dip.rs
+++ b/crates/zng-unit/src/px_dip.rs
@@ -170,7 +170,7 @@ impl ops::Mul<f32> for Px {
     type Output = Px;
 
     fn mul(self, rhs: f32) -> Self::Output {
-        Px((self.0 as f32 * rhs).round() as i32)
+        Px((self.0 as f32 * rhs).round().min(i32::MAX as _) as i32)
     }
 }
 impl ops::MulAssign<f32> for Px {
@@ -182,7 +182,7 @@ impl ops::Mul<i32> for Px {
     type Output = Px;
 
     fn mul(self, rhs: i32) -> Self::Output {
-        Px(self.0 * rhs)
+        Px(self.0.saturating_mul(rhs))
     }
 }
 impl ops::MulAssign<i32> for Px {


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->