### PR TITLE
Fix `IMAGES.limits` and `AUDIOS.limits` not filtering paths and uris

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `IMAGES.limits` and `AUDIOS.limits` not filtering paths and uris.
 * Image widget now does not render large images when a better reduced alternate is loading.
     - **Deprecated**`ImageEntry::with_best_reduce`.
     - Added `ImageEntry::best_reduce`.

--- a/crates/zng-ext-audio/src/lib.rs
+++ b/crates/zng-ext-audio/src/lib.rs
@@ -467,19 +467,24 @@ fn audio(mut source: AudioSource, mut options: AudioOptions, limits: Option<Audi
 
     match source {
         AudioSource::Read(path) => {
-            fn read(path: PathBuf, limit: ByteLength) -> std::io::Result<IpcBytes> {
+            fn read(path: &PathBuf, limit: (&AudioSourceFilter<PathBuf>, ByteLength)) -> std::io::Result<IpcBytes> {
+                if !limit.0.allows(path) {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "file path no allowed by limit",
+                    ));
+                }
                 let file = std::fs::File::open(path)?;
-                if file.metadata()?.len() > limit.bytes() as u64 {
+                if file.metadata()?.len() > limit.1.bytes() as u64 {
                     return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "file length exceeds limit"));
                 }
                 IpcBytes::from_file_blocking(file)
             }
-            let limit = limits.max_encoded_len;
             let data_format = match path.extension() {
                 Some(ext) => AudioDataFormat::FileExtension(ext.to_string_lossy().to_txt()),
                 None => AudioDataFormat::Unknown,
             };
-            zng_task::spawn_wait(move || match read(path, limit) {
+            zng_task::spawn_wait(move || match read(&path, (&limits.allow_path, limits.max_encoded_len)) {
                 Ok(data) => audio_data(false, Some(key), data_format, data, options, limits, r),
                 Err(e) => {
                     r.set(AudioTrack::new_error(e.to_txt()));
@@ -491,8 +496,18 @@ fn audio(mut source: AudioSource, mut options: AudioOptions, limits: Option<Audi
             let accept = accept.unwrap_or_else(|| AUDIOS.http_accept());
 
             use zng_task::http::*;
-            async fn download(uri: Uri, accept: zng_txt::Txt, limit: ByteLength) -> Result<(AudioDataFormat, IpcBytes), Error> {
-                let request = Request::get(uri)?.max_length(limit).header(header::ACCEPT, accept.as_str())?;
+            async fn download(
+                uri: Uri,
+                accept: zng_txt::Txt,
+                limit: (AudioSourceFilter<Uri>, ByteLength),
+            ) -> Result<(AudioDataFormat, IpcBytes), Error> {
+                if !limit.0.allows(&uri) {
+                    return Err(Box::new(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "uri no allowed by limit",
+                    )));
+                }
+                let request = Request::get(uri)?.max_length(limit.1).header(header::ACCEPT, accept.as_str())?;
                 let mut response = send(request).await?;
                 let data_format = match response.header().get(&header::CONTENT_TYPE).and_then(|m| m.to_str().ok()) {
                     Some(m) => AudioDataFormat::MimeType(m.to_txt()),
@@ -503,9 +518,8 @@ fn audio(mut source: AudioSource, mut options: AudioOptions, limits: Option<Audi
                 Ok((data_format, data))
             }
 
-            let limit = limits.max_encoded_len;
             zng_task::spawn(async move {
-                match download(uri, accept, limit).await {
+                match download(uri, accept, (limits.allow_uri.clone(), limits.max_encoded_len)).await {
                     Ok((fmt, data)) => {
                         audio_data(false, Some(key), fmt, data, options, limits, r);
                     }

--- a/crates/zng-ext-image/src/lib.rs
+++ b/crates/zng-ext-image/src/lib.rs
@@ -15,12 +15,7 @@
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 
-use std::{
-    any::Any,
-    mem,
-    path::{Path, PathBuf},
-    pin::Pin,
-};
+use std::{any::Any, mem, path::PathBuf, pin::Pin};
 
 use parking_lot::Mutex;
 use zng_app::{
@@ -476,19 +471,24 @@ fn image(mut source: ImageSource, mut options: ImageOptions, limits: Option<Imag
 
     match source {
         ImageSource::Read(path) => {
-            fn read(path: &Path, limit: ByteLength) -> std::io::Result<IpcBytes> {
+            fn read(path: &PathBuf, limit: (&ImageSourceFilter<PathBuf>, ByteLength)) -> std::io::Result<IpcBytes> {
+                if !limit.0.allows(path) {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "file path no allowed by limit",
+                    ));
+                }
                 let file = std::fs::File::open(path)?;
-                if file.metadata()?.len() > limit.bytes() as u64 {
+                if file.metadata()?.len() > limit.1.bytes() as u64 {
                     return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "file length exceeds limit"));
                 }
                 IpcBytes::from_file_blocking(file)
             }
-            let limit = limits.max_encoded_len;
             let data_format = match path.extension() {
                 Some(ext) => ImageDataFormat::FileExtension(ext.to_string_lossy().to_txt()),
                 None => ImageDataFormat::Unknown,
             };
-            zng_task::spawn_wait(move || match read(&path, limit) {
+            zng_task::spawn_wait(move || match read(&path, (&limits.allow_path, limits.max_encoded_len)) {
                 Ok(data) => {
                     tracing::trace!("read {path:?}, len: {:?}, fmt: {data_format:?}", data.len().bytes());
                     image_data(false, Some(key), data_format, data, options, limits, r)
@@ -504,8 +504,19 @@ fn image(mut source: ImageSource, mut options: ImageOptions, limits: Option<Imag
             let accept = accept.unwrap_or_else(|| IMAGES.http_accept());
 
             use zng_task::http::*;
-            async fn download(uri: Uri, accept: zng_txt::Txt, limit: ByteLength) -> Result<(ImageDataFormat, IpcBytes), Error> {
-                let request = Request::get(uri)?.max_length(limit).header(header::ACCEPT, accept.as_str())?;
+            async fn download(
+                uri: Uri,
+                accept: zng_txt::Txt,
+                limit: (ImageSourceFilter<Uri>, ByteLength),
+            ) -> Result<(ImageDataFormat, IpcBytes), Error> {
+                if !limit.0.allows(&uri) {
+                    return Err(Box::new(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "uri no allowed by limit",
+                    )));
+                }
+
+                let request = Request::get(uri)?.max_length(limit.1).header(header::ACCEPT, accept.as_str())?;
                 let mut response = send(request).await?;
                 let data_format = match response.header().get(&header::CONTENT_TYPE).and_then(|m| m.to_str().ok()) {
                     Some(m) => ImageDataFormat::MimeType(m.to_txt()),
@@ -516,9 +527,8 @@ fn image(mut source: ImageSource, mut options: ImageOptions, limits: Option<Imag
                 Ok((data_format, data))
             }
 
-            let limit = limits.max_encoded_len;
             zng_task::spawn(async move {
-                match download(uri.clone(), accept, limit).await {
+                match download(uri.clone(), accept, (limits.allow_uri.clone(), limits.max_encoded_len)).await {
                     Ok((fmt, data)) => {
                         tracing::trace!("download {uri:?}, len: {:?}, fmt: {fmt:?}", data.len().bytes());
                         image_data(false, Some(key), fmt, data, options, limits, r);


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->