### PR TITLE
Fix `IMAGES` and `AUDIOS` extensions not always applying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Unreleased
 
+* Fix `IMAGES` and `AUDIOS` extensions not always applying.
 * Fix `IMAGES.limits` and `AUDIOS.limits` not filtering paths and uris.
 * Image widget now does not render large images when a better reduced alternate is loading.
     - **Deprecated**`ImageEntry::with_best_reduce`.
     - Added `ImageEntry::best_reduce`.
-    - Image widget now tracks loading state of the best sized entry and only presents that entry. !!: TODO
+    - Image widget now tracks loading state of the best sized entry and only presents that entry.
 
 * Change impl `Mul<i32>` and `Mul<f32>` for `Px` to be saturating to match other operations.
 * Better cleanup of leftover memmap files after crash.

--- a/crates/zng-ext-audio/src/lib.rs
+++ b/crates/zng-ext-audio/src/lib.rs
@@ -15,7 +15,7 @@
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 
-use std::{mem, path::PathBuf, pin::Pin};
+use std::{path::PathBuf, pin::Pin};
 
 use zng_app::{
     update::UPDATES,
@@ -41,13 +41,12 @@ pub use output::*;
 
 app_local! {
     static AUDIOS_SV: AudiosService = AudiosService::new();
+    static AUDIOS_EXTENSIONS: Vec<Box<dyn AudiosExtension>> = vec![];
 }
 
 struct AudiosService {
     load_in_headless: Var<bool>,
     limits: Var<AudioLimits>,
-
-    extensions: Vec<Box<dyn AudiosExtension>>,
 
     cache: IdMap<AudioHash, AudioVar>,
     outputs: IdMap<AudioOutputId, WeakAudioOutput>,
@@ -58,8 +57,6 @@ impl AudiosService {
         Self {
             load_in_headless: var(false),
             limits: var(AudioLimits::default()),
-
-            extensions: vec![],
 
             cache: IdMap::new(),
             outputs: IdMap::new(),
@@ -290,7 +287,7 @@ impl AUDIOS {
     /// See [`AudiosExtension`] for extension capabilities.
     pub fn extend(&self, extension: Box<dyn AudiosExtension>) {
         UPDATES.once_update("AUDIOS.extend", move || {
-            AUDIOS_SV.write().extensions.push(extension);
+            AUDIOS_EXTENSIONS.write().push(extension);
         });
     }
 
@@ -298,13 +295,9 @@ impl AUDIOS {
     pub fn available_formats(&self) -> Vec<AudioFormat> {
         let mut formats = VIEW_PROCESS.info().audio.clone();
 
-        let mut exts = mem::take(&mut AUDIOS_SV.write().extensions);
-        for ext in exts.iter_mut() {
+        for ext in AUDIOS_EXTENSIONS.read().iter() {
             ext.available_formats(&mut formats);
         }
-        let mut s = AUDIOS_SV.write();
-        exts.append(&mut s.extensions);
-        s.extensions = exts;
 
         formats
     }
@@ -374,19 +367,21 @@ impl AUDIOS {
 }
 
 fn audio(mut source: AudioSource, mut options: AudioOptions, limits: Option<AudioLimits>, r: Var<AudioTrack>) {
-    let mut s = AUDIOS_SV.write();
-
-    let limits = limits.unwrap_or_else(|| s.limits.get());
+    let limits = limits.unwrap_or_else(|| AUDIOS_SV.read().limits.get());
 
     // apply extensions
-    let mut exts = mem::take(&mut s.extensions);
-    drop(s); // drop because extensions may use the service
-    for ext in &mut exts {
-        ext.audio(&limits, &mut source, &mut options);
+    {
+        let mut exts = AUDIOS_EXTENSIONS.write();
+        if !exts.is_empty() {
+            tracing::trace!("process audio with {} extensions", exts.len());
+        }
+        for ext in exts.iter_mut() {
+            ext.audio(&limits, &mut source, &mut options);
+        }
     }
+
+    // only lock service after extensions
     let mut s = AUDIOS_SV.write();
-    exts.append(&mut s.extensions);
-    s.extensions = exts;
 
     if let AudioSource::Audio(var) = source {
         // Audio is passthrough, cache config is ignored
@@ -543,24 +538,16 @@ fn audio_data(
     r: Var<AudioTrack>,
 ) {
     if !is_respawn && let Some(key) = cache_key {
-        let mut replaced = false;
-        let mut exts = mem::take(&mut AUDIOS_SV.write().extensions);
-        for ext in &mut exts {
+        let mut exts = AUDIOS_EXTENSIONS.write();
+        if !exts.is_empty() {
+            tracing::trace!("process audio_data with {} extensions", exts.len());
+        }
+        for ext in exts.iter_mut() {
             if let Some(replacement) = ext.audio_data(limits.max_decoded_len, &key, &data, &format, &options) {
                 replacement.set_bind(&r).perm();
                 r.hold(replacement).perm();
 
-                replaced = true;
-                break;
-            }
-        }
-
-        {
-            let mut s = AUDIOS_SV.write();
-            exts.append(&mut s.extensions);
-            s.extensions = exts;
-
-            if replaced {
+                tracing::trace!("extension replaced audio_data");
                 return;
             }
         }

--- a/crates/zng-ext-image/src/lib.rs
+++ b/crates/zng-ext-image/src/lib.rs
@@ -15,7 +15,7 @@
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 
-use std::{any::Any, mem, path::PathBuf, pin::Pin};
+use std::{any::Any, path::PathBuf, pin::Pin};
 
 use parking_lot::Mutex;
 use zng_app::{
@@ -52,13 +52,13 @@ pub use types::*;
 
 app_local! {
     static IMAGES_SV: ImagesService = ImagesService::new();
+    static IMAGES_EXTENSIONS: Vec<Box<dyn ImagesExtension>> = vec![];
 }
 
 struct ImagesService {
     load_in_headless: Var<bool>,
     limits: Var<ImageLimits>,
 
-    extensions: Vec<Box<dyn ImagesExtension>>,
     render_windows: Option<Box<dyn ImageRenderWindowsService>>,
 
     cache: IdMap<ImageHash, ImageVar>,
@@ -69,7 +69,6 @@ impl ImagesService {
             load_in_headless: var(false),
             limits: var(ImageLimits::default()),
 
-            extensions: vec![],
             render_windows: None,
 
             cache: IdMap::new(),
@@ -311,7 +310,7 @@ impl IMAGES {
     /// See [`ImagesExtension`] for extension capabilities.
     pub fn extend(&self, extension: Box<dyn ImagesExtension>) {
         UPDATES.once_update("IMAGES.extend", move || {
-            IMAGES_SV.write().extensions.push(extension);
+            IMAGES_EXTENSIONS.write().push(extension);
         });
     }
 
@@ -319,13 +318,9 @@ impl IMAGES {
     pub fn available_formats(&self) -> Vec<ImageFormat> {
         let mut formats = VIEW_PROCESS.info().image.clone();
 
-        let mut exts = mem::take(&mut IMAGES_SV.write().extensions);
-        for ext in exts.iter_mut() {
+        for ext in IMAGES_EXTENSIONS.read().iter() {
             ext.available_formats(&mut formats);
         }
-        let mut s = IMAGES_SV.write();
-        exts.append(&mut s.extensions);
-        s.extensions = exts;
 
         formats
     }
@@ -347,22 +342,21 @@ impl IMAGES {
 }
 
 fn image(mut source: ImageSource, mut options: ImageOptions, limits: Option<ImageLimits>, r: Var<ImageEntry>) {
-    let mut s = IMAGES_SV.write();
-
-    let limits = limits.unwrap_or_else(|| s.limits.get());
+    let limits = limits.unwrap_or_else(|| IMAGES_SV.read().limits.get());
 
     // apply extensions
-    let mut exts = mem::take(&mut s.extensions);
-    drop(s); // drop because extensions may use the service
-    if !exts.is_empty() {
-        tracing::trace!("process image with {} extensions", exts.len());
+    {
+        let mut exts = IMAGES_EXTENSIONS.write();
+        if !exts.is_empty() {
+            tracing::trace!("process image with {} extensions", exts.len());
+        }
+        for ext in exts.iter_mut() {
+            ext.image(&limits, &mut source, &mut options);
+        }
     }
-    for ext in &mut exts {
-        ext.image(&limits, &mut source, &mut options);
-    }
+
+    // only lock service after extensions
     let mut s = IMAGES_SV.write();
-    exts.append(&mut s.extensions);
-    s.extensions = exts;
 
     if let ImageSource::Image(var) = source {
         // Image is passthrough, cache config is ignored
@@ -557,26 +551,15 @@ fn image_data(
     r: Var<ImageEntry>,
 ) {
     if !is_respawn && let Some(key) = cache_key {
-        let mut replaced = false;
-        let mut exts = mem::take(&mut IMAGES_SV.write().extensions);
+        let mut exts = IMAGES_EXTENSIONS.write();
         if !exts.is_empty() {
             tracing::trace!("process image_data with {} extensions", exts.len());
         }
-        for ext in &mut exts {
+        for ext in exts.iter_mut() {
             if let Some(replacement) = ext.image_data(limits.max_decoded_len, &key, &data, &format, &options) {
                 replacement.set_bind(&r).perm();
                 r.hold(replacement).perm();
 
-                replaced = true;
-                break;
-            }
-        }
-        {
-            let mut s = IMAGES_SV.write();
-            exts.append(&mut s.extensions);
-            s.extensions = exts;
-
-            if replaced {
                 tracing::trace!("extension replaced image_data");
                 return;
             }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->