### PR TITLE
Mark memmap FILE_ATTRIBUTE_TEMPORARY on Windows

### DIFF
--- a/crates/zng-task/src/channel/ipc_bytes.rs
+++ b/crates/zng-task/src/channel/ipc_bytes.rs
@@ -560,13 +560,15 @@ impl IpcBytes {
             }
         };
 
-        // read(true) because some callers create a MmapMut
-        let file = fs::OpenOptions::new()
-            .create(true)
-            .read(true)
-            .write(true)
-            .truncate(true)
-            .open(&name)?;
+        let mut opt = fs::OpenOptions::new();
+        opt.create(true).read(true).write(true).truncate(true);
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::OpenOptionsExt as _;
+            const FILE_ATTRIBUTE_TEMPORARY: u32 = 0x00000100;
+            opt.attributes(FILE_ATTRIBUTE_TEMPORARY);
+        }
+        let file = opt.open(&name)?;
         Ok((name, file))
     }
 


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->